### PR TITLE
fix: ionic styles imports

### DIFF
--- a/src/ui/styles/ionic.scss
+++ b/src/ui/styles/ionic.scss
@@ -1,15 +1,14 @@
 /* Core CSS required for Ionic components to work properly */
-@use '@ionic/react/css/core';
+@import "@ionic/react/css/core.css";
 
 /* Basic CSS for apps built with Ionic */
-@use '@ionic/react/css/normalize';
-@use '@ionic/react/css/structure';
-@use '@ionic/react/css/typography';
+@import "@ionic/react/css/normalize.css";
+@import "@ionic/react/css/structure.css";
+@import "@ionic/react/css/typography.css";
 
-/* Optional CSS utils that can be commented out */
-@use '@ionic/react/css/padding';
-@use '@ionic/react/css/float-elements';
-@use '@ionic/react/css/text-alignment';
-@use '@ionic/react/css/text-transformation';
-@use '@ionic/react/css/flex-utils';
-@use '@ionic/react/css/display';
+@import "@ionic/react/css/padding.css";
+@import "@ionic/react/css/float-elements.css";
+@import "@ionic/react/css/text-alignment.css";
+@import "@ionic/react/css/text-transformation.css";
+@import "@ionic/react/css/flex-utils.css";
+@import "@ionic/react/css/display.css";


### PR DESCRIPTION

Ionic styles are not rendering correctly, resulting in even a blank page when using `IonContent`.

Replace `ionic.scss`:

```
/* Core CSS required for Ionic components to work properly */
@use '@ionic/react/css/core';

/* Basic CSS for apps built with Ionic */
@use '@ionic/react/css/normalize';
@use '@ionic/react/css/structure';
@use '@ionic/react/css/typography';

/* Optional CSS utils that can be commented out */
@use '@ionic/react/css/padding';
@use '@ionic/react/css/float-elements';
@use '@ionic/react/css/text-alignment';
@use '@ionic/react/css/text-transformation';
@use '@ionic/react/css/flex-utils';
@use '@ionic/react/css/display';
```

with:

```
/* Core CSS required for Ionic components to work properly */
@import "@ionic/react/css/core.css";

/* Basic CSS for apps built with Ionic */
@import "@ionic/react/css/normalize.css";
@import "@ionic/react/css/structure.css";
@import "@ionic/react/css/typography.css";

@import "@ionic/react/css/padding.css";
@import "@ionic/react/css/float-elements.css";
@import "@ionic/react/css/text-alignment.css";
@import "@ionic/react/css/text-transformation.css";
@import "@ionic/react/css/flex-utils.css";
@import "@ionic/react/css/display.css";
```