### PR TITLE
fix(docker): WebRTC relay build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,4 +17,9 @@ services:
     tty: true
     ports:
       - "3001:3001"
+    volumes:
+      - issuer-server-data:/root/.afj
     restart: always
+
+volumes:
+  issuer-server-data:

--- a/webrtc-relay/package-lock.json
+++ b/webrtc-relay/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@chainsafe/libp2p-noise": "^13.0.0",
         "@libp2p/mplex": "^8.0.1",
-        "@libp2p/webrtc": "^3.1.10",
+        "@libp2p/webrtc": "^3.2.1",
         "@libp2p/websockets": "^6.0.1",
         "@multiformats/multiaddr": "^12.0.0",
         "libp2p": "^0.46.0",
@@ -173,13 +173,12 @@
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-0.1.4.tgz",
-      "integrity": "sha512-fRa8AUeCVOqfjgJgpIWupOsc7nAnJuI/VjWL2ZfRqbz7CPLD9c/ZAKXC140THSxlNdNQ9kGpo/C2z/yCGLy4ig==",
-      "license": "Apache-2.0 OR MIT",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-0.1.5.tgz",
+      "integrity": "sha512-h6f1fk2M6BhqjooE4I1iODmY/jorCvJ1bX1IOMHOMNkrbwsMS2BOpDkBJD+u+QlKMoRIA2zEfWezXB4Pa8GASw==",
       "dependencies": {
         "@libp2p/interface": "^0.1.2",
-        "@libp2p/peer-collections": "^4.0.3",
+        "@libp2p/peer-collections": "^4.0.4",
         "@multiformats/multiaddr": "^12.1.5",
         "uint8arraylist": "^2.4.3"
       }
@@ -388,10 +387,9 @@
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-4.0.3.tgz",
-      "integrity": "sha512-ahfZFdRhApN4dulnzAvkzQsPVJVX7UID3QMKC/cduK5FYWqm7zbtW6bpwDilhZY3wvjvaQYs4R0KKSysvTPiQQ==",
-      "license": "Apache-2.0 OR MIT",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-4.0.4.tgz",
+      "integrity": "sha512-MGuTtt6a2TLUlr4b1dUAOd43SAe/lxLZX3E9iYeRqI9IWzw6cwvvOzGNTYwAlkBpASCmm0aJpGXDA/r6lpIzMQ==",
       "dependencies": {
         "@libp2p/interface": "^0.1.2",
         "@libp2p/peer-id": "^3.0.2"
@@ -491,17 +489,18 @@
       }
     },
     "node_modules/@libp2p/webrtc": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-3.1.10.tgz",
-      "integrity": "sha512-H0JWCX2N6L3VBzKDQ+inS/x17FVG17TBnCe/thZc2b+j5kl9DH2hVNdTxhjpqPo7NQHBtkPHOk2+mw893/VmQw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-3.2.1.tgz",
+      "integrity": "sha512-HtvbUQwngCBrY9ZwDEHpafyO2UHl8z7F6W2LMBXjnErMfFls4nvL/VtuPd7KLAvySw7ajY57AcdHZkHhzjb73A==",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^13.0.0",
         "@libp2p/interface": "^0.1.2",
-        "@libp2p/interface-internal": "^0.1.4",
+        "@libp2p/interface-internal": "^0.1.5",
         "@libp2p/logger": "^3.0.2",
         "@libp2p/peer-id": "^3.0.2",
         "@multiformats/mafmt": "^12.1.2",
         "@multiformats/multiaddr": "^12.1.5",
+        "@multiformats/multiaddr-matcher": "^1.0.1",
         "abortable-iterator": "^5.0.1",
         "detect-browser": "^5.3.0",
         "it-length-prefixed": "^9.0.1",

--- a/webrtc-relay/package.json
+++ b/webrtc-relay/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^13.0.0",
     "@libp2p/mplex": "^8.0.1",
-    "@libp2p/webrtc": "^3.1.10",
+    "@libp2p/webrtc": "^3.2.1",
     "@libp2p/websockets": "^6.0.1",
     "@multiformats/multiaddr": "^12.0.0",
     "libp2p": "^0.46.0",


### PR DESCRIPTION
`3.1.11` version of `@libp2p/webrtc` wasn't building in Docker but latest version does. Also mounted issuance server agent data so connections aren't lost when pulled down.