### PR TITLE
fix(cred-serv): replace local ip with env endpoint on cli connectionless

### DIFF
--- a/credential-issuance-server/src/cli/invitationWithCredentialConnectionless.ts
+++ b/credential-issuance-server/src/cli/invitationWithCredentialConnectionless.ts
@@ -9,7 +9,7 @@ const main = async () => {
   const body = process.argv[2];
   let credentialJsonData: unknown;
   if (body) {
-    credentialJsonData = getCredentialJsonData(body);
+    credentialJsonData = JSON.parse(JSON.stringify(getCredentialJsonData(body)).replace("http://127.0.0.1:3001", config.endpoint));
     log("Credential: ", credentialJsonData);
   }
   await postRequestAndGenQR(`${config.endpoint}${API}`, credentialJsonData);


### PR DESCRIPTION
We must replace the local IP in the credential JSON files with the target server on the connectionless path too.