### PR TITLE
fix(ui): Get the latest credential details to prevent incorrect rendering credential

### DIFF
--- a/src/ui/components/CredCardTemplate/CardBodySummit.tsx
+++ b/src/ui/components/CredCardTemplate/CardBodySummit.tsx
@@ -15,12 +15,7 @@ const CardBodySummit = ({ cardData }: any) => {
               {i18n.t("creds.card.layout.type")}
             </span>
             <span className="card-body-info-value">
-              {credentialSubject.type
-                ? `${credentialSubject.type}`.replace(
-                  /([a-z])([A-Z])/g,
-                  "$1 $2"
-                )
-                : ""}
+              {credentialSubject.type.replace(/([a-z])([A-Z])/g, "$1 $2")}
             </span>
           </div>
           <div className="card-body-info">

--- a/src/ui/components/CredCardTemplate/CredCardTemplate.tsx
+++ b/src/ui/components/CredCardTemplate/CredCardTemplate.tsx
@@ -27,11 +27,11 @@ const CredCardTemplate = ({
   const [alertIsOpen, setAlertIsOpen] = useState(false);
   const [cardData, setCardData] = useState<CredentialDetails>();
   const isUniversity =
-    shortData.credentialType === CredentialType.UNIVERSITY_DEGREE_CREDENTIAL;
+    cardData?.credentialType === CredentialType.UNIVERSITY_DEGREE_CREDENTIAL;
   const isResidency =
-    shortData.credentialType === CredentialType.PERMANENT_RESIDENT_CARD;
+    cardData?.credentialType === CredentialType.PERMANENT_RESIDENT_CARD;
   const isAccessPass =
-    shortData.credentialType === CredentialType.ACCESS_PASS_CREDENTIAL;
+    cardData?.credentialType === CredentialType.ACCESS_PASS_CREDENTIAL;
   const isW3CTemplate = isUniversity || (!isResidency && !isAccessPass);
   const isKnownTemplate = isUniversity || isResidency || isAccessPass;
 


### PR DESCRIPTION
## Description

Change the credentialType check to use the most recent data from the database instead of using cached data.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-358)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated