### PR TITLE
build(gha): remove test:cardano from main branch build

### DIFF
--- a/.github/workflows/gh-vercel-main.yaml
+++ b/.github/workflows/gh-vercel-main.yaml
@@ -56,7 +56,6 @@ jobs:
       run: |
         npm ci
         npm run test
-        npm run test:cardano
 
     - name: 🔨 Build project
       run: npm run build


### PR DESCRIPTION
## Description

This was outdated since Jaime removed that script from the build and package.json.