### PR TITLE
fix(ui): Credential Page: Blank Credentials Page on Archiving a Single Credential

### DIFF
--- a/src/ui/pages/CredCardDetails/CredCardDetails.tsx
+++ b/src/ui/pages/CredCardDetails/CredCardDetails.tsx
@@ -117,13 +117,10 @@ const CredCardDetails = () => {
   };
 
   const handleArchiveCredential = async () => {
-    setVerifyPasswordIsOpen(false);
-    setVerifyPasscodeIsOpen(false);
     await AriesAgent.agent.credentials.archiveCredential(params.id);
     const creds = credsCache.filter((item) => item.id !== params.id);
     dispatch(setCredsCache(creds));
     dispatch(setToastMsg(ToastMsgType.CREDENTIAL_ARCHIVED));
-    handleDone();
   };
 
   const handleDeleteCredential = async () => {
@@ -151,11 +148,11 @@ const CredCardDetails = () => {
     handleDone();
   };
 
-  const onVerify = () => {
+  const onVerify = async () => {
     if (isArchived) {
-      handleDeleteCredential();
+      await handleDeleteCredential();
     } else {
-      handleArchiveCredential();
+      await handleArchiveCredential();
     }
     setVerifyPasswordIsOpen(false);
     setVerifyPasscodeIsOpen(false);

--- a/src/ui/pages/Creds/Creds.tsx
+++ b/src/ui/pages/Creds/Creds.tsx
@@ -74,9 +74,6 @@ const Creds = () => {
   const credsCache = useAppSelector(getCredsCache);
   const favCredsCache = useAppSelector(getFavouritesCredsCache);
   const currentOperation = useAppSelector(getCurrentOperation);
-  const [currentCreds, setCurrentCreds] = useState<CredentialShortDetails[]>([
-    ...credsCache,
-  ]);
   const [archivedCreds, setArchivedCreds] = useState<CredentialShortDetails[]>(
     []
   );
@@ -88,7 +85,6 @@ const Creds = () => {
   const fetchCurrentCreds = async () => {
     try {
       const creds = await AriesAgent.agent.credentials.getCredentials();
-      setCurrentCreds(creds);
       dispatch(setCredsCache(creds));
     } catch (e) {
       // @TODO - sdisalvo: handle error
@@ -168,7 +164,7 @@ const Creds = () => {
             />
           }
         >
-          {currentCreds.length ? (
+          {credsCache.length ? (
             <>
               {favCreds.length ? (
                 <>


### PR DESCRIPTION
## Description

Credential Page: Blank Credentials Page on Archiving a Single Credential. When archiving the credential, UI must show correctly content.
![image](https://github.com/cardano-foundation/cf-identity-wallet/assets/142210850/14fd0210-8a76-417d-98ff-ed23293ac6d4)


## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-470)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated