### PR TITLE
fix(ui): Credential Page: Incorrect Count Display in Archived Credentials List

### DIFF
--- a/src/ui/components/ArchivedCredentials/ArchivedCredentials.tsx
+++ b/src/ui/components/ArchivedCredentials/ArchivedCredentials.tsx
@@ -151,12 +151,13 @@ const ArchivedCredentials = ({
     setSelectedCredentials(data);
   };
 
-  const handleDeleteCredential = async (id: string) => {
+  const handleDeleteCredentialBatches = async (ids: string[]) => {
     setVerifyPasswordIsOpen(false);
     setVerifyPasscodeIsOpen(false);
     try {
-      await AriesAgent.agent.credentials.deleteCredential(id);
-      setArchivedCreds(credsCache.filter((item) => item.id !== id));
+      await Promise.all(
+        ids.map((id) => AriesAgent.agent.credentials.deleteCredential(id))
+      );
     } catch (e) {
       // @TODO - sdisalvo: handle error
     }
@@ -325,8 +326,8 @@ const ArchivedCredentials = ({
       <VerifyPassword
         isOpen={verifyPasswordIsOpen}
         setIsOpen={setVerifyPasswordIsOpen}
-        onVerify={() => {
-          selectedCredentials.forEach((id) => handleDeleteCredential(id));
+        onVerify={async () => {
+          await handleDeleteCredentialBatches(selectedCredentials);
           dispatch(
             setToastMsg(
               selectedCredentials.length === 1
@@ -340,8 +341,8 @@ const ArchivedCredentials = ({
       <VerifyPasscode
         isOpen={verifyPasscodeIsOpen}
         setIsOpen={setVerifyPasscodeIsOpen}
-        onVerify={() => {
-          selectedCredentials.forEach((id) => handleDeleteCredential(id));
+        onVerify={async () => {
+          await handleDeleteCredentialBatches(selectedCredentials);
           dispatch(
             setToastMsg(
               selectedCredentials.length === 1


### PR DESCRIPTION
## Description

Credential Page: Incorrect Count Display in Archived Credentials List. After deleting one of the two archived credentials, the archived list should accurately display one remaining credential.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-471)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
