### PR TITLE
docs: replaced url of the overview video

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 <br>
 <p align="center">
   <kbd>
-    <a href="https://drive.google.com/file/d/1So8bW7dgprOFgKs8PQKQ7c8Sm1Kd8aWW/view?usp=sharing">
+    <a href="https://www.youtube.com/watch?v=YmEJHQksFyE">
     <img src="docs/images/readme/Introduction-Video-Thumbnail.jpg" alt="Identity Wallet Introduction Video Thumbnail">
     </a>
   </kbd>


### PR DESCRIPTION
## Description

Replaced the url of the overview video since we moved it from  Google Drive to Youtube.