### PR TITLE
feat(core): Create Registry by Identifier Name and Retrieve All Regis…

### DIFF
--- a/src/core/agent/modules/signify/signifyApi.test.ts
+++ b/src/core/agent/modules/signify/signifyApi.test.ts
@@ -166,6 +166,35 @@ describe("Signify API", () => {
     });
   });
 
+  test("can create a registry", async () => {
+    const mockName = "keriuuid";
+    const mockRegistryName = "keriRegistry";
+    const mockCreateResult = {
+      registryName: mockRegistryName,
+      registryIdentifier: "registryIdentifier",
+    };
+    jest.spyOn(api, "createRegistry").mockResolvedValueOnce(mockCreateResult);
+    const result = await api.createRegistry(mockName);
+    expect(result).toEqual(mockCreateResult);
+  });
+
+  test("can get all registries by name", async () => {
+    const mockName = "keriuuid";
+    const mockRegistryName = "keriRegistry";
+    const mockRegistryData = [
+      {
+        name: mockRegistryName,
+        regk: "registryIdentifier",
+        pre: "pre",
+      },
+    ];
+    jest
+      .spyOn(api, "getAllRegistriesByName")
+      .mockResolvedValueOnce(mockRegistryData);
+    const result = await api.getAllRegistriesByName(mockName);
+    expect(result).toEqual(mockRegistryData);
+  });
+
   test("can get oobi by name", async () => {
     const mockName = "keriuuid";
     expect(await api.getOobi(mockName)).toEqual(oobiPrefix + mockName);

--- a/src/core/agent/modules/signify/signifyApi.ts
+++ b/src/core/agent/modules/signify/signifyApi.ts
@@ -10,6 +10,7 @@ import {
   CreateIdentifierResult,
   IdentifierResult,
   IdentifiersListResult,
+  CreateRegistryResult,
 } from "./signifyApi.types";
 import { KeyStoreKeys, SecureStorage } from "../../../storage";
 
@@ -21,6 +22,8 @@ export class SignifyApi {
   static readonly BACKER_AID = "BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP";
   static readonly FAILED_TO_CREATE_IDENTIFIER =
     "Failed to create new managed AID, operation not completing...";
+  static readonly FAILED_TO_CREATE_REGISTRY =
+    "Failed to create new registry, operation not completing...";
 
   // For now we connect to a single backer and hard-code the address - better solution should be provided in the future.
   static readonly BACKER_ADDRESS =
@@ -98,6 +101,26 @@ export class SignifyApi {
 
   async getIdentifierByName(name: string): Promise<any> {
     return this.signifyClient.identifiers().get(name);
+  }
+
+  async createRegistry(name: string): Promise<CreateRegistryResult> {
+    try {
+      const registryName = utils.uuid();
+      const resgistryResult = await this.signifyClient
+        .registries()
+        .create({ name, registryName });
+      await resgistryResult.op();
+      return {
+        registryName: registryName,
+        registryIdentifier: resgistryResult.regser.ked.i,
+      };
+    } catch {
+      throw new Error(SignifyApi.FAILED_TO_CREATE_REGISTRY);
+    }
+  }
+
+  async getAllRegistriesByName(name: string): Promise<any> {
+    return this.signifyClient.registries().list(name);
   }
 
   async getOobi(name: string): Promise<string> {

--- a/src/core/agent/modules/signify/signifyApi.types.ts
+++ b/src/core/agent/modules/signify/signifyApi.types.ts
@@ -3,6 +3,11 @@ export interface CreateIdentifierResult {
   identifier: string;
 }
 
+export interface CreateRegistryResult {
+  registryName: string;
+  registryIdentifier: string;
+}
+
 export interface KeriContact {
   alias: string;
   id: string;


### PR DESCRIPTION
## Description
### Registries Implementation 
- Implemented createRegistry function in signifyApi.ts for creating new registries.
- Added getAllRegistriesByName function in signifyApi.ts to retrieve registries by name.
- Created unit tests in signifyApi.test.ts for both functions.
- Defined CreateRegistryResult interface in signifyApi.types.ts.
## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---