### PR TITLE
fix(ui): Standardise Modals - Verify Passcode layout

### DIFF
--- a/src/ui/components/VerifyPasscode/VerifyPasscode.scss
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.scss
@@ -1,17 +1,18 @@
 .verify-passcode {
-  text-align: center;
-  --background: var(--ion-color-light);
-  &::part(backdrop) {
-    background-color: var(--ion-color-light);
-  }
+  .responsive-page-content {
+    justify-content: space-evenly;
 
-  .verify-passcode-title {
-    font-size: 24px;
-    font-weight: 700;
-  }
+    .verify-passcode-title,
+    .verify-passcode-description {
+      text-align: center;
+    }
 
-  .verify-passcode-description {
-    margin-top: 5px;
-    margin-bottom: 25px;
+    .verify-passcode-title {
+      margin-top: 4rem;
+
+      @media screen and (min-height: 300px) and (max-height: 550px) {
+        margin-top: 2rem;
+      }
+    }
   }
 }

--- a/src/ui/components/VerifyPasscode/VerifyPasscode.tsx
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.tsx
@@ -139,7 +139,7 @@ const VerifyPasscode = ({
       data-testid={componentId}
       onDidDismiss={() => handleClearState()}
     >
-      <ResponsivePageLayout pageId={componentId + "-content"}>
+      <ResponsivePageLayout pageId={`${componentId}-content`}>
         <h2
           className="verify-passcode-title"
           data-testid="verify-passcode-title"

--- a/src/ui/components/VerifyPasscode/VerifyPasscode.tsx
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
-import { IonButton, IonCol, IonGrid, IonModal, IonRow } from "@ionic/react";
+import { IonModal } from "@ionic/react";
 import { useHistory } from "react-router-dom";
 import { i18n } from "../../../i18n";
-import { PageLayout } from "../layout/PageLayout";
 import { ErrorMessage } from "../ErrorMessage";
 import { PasscodeModule } from "../PasscodeModule";
 import { Alert } from "../Alert";
@@ -21,12 +20,15 @@ import { VerifyPasscodeProps } from "./VerifyPasscode.types";
 import "./VerifyPasscode.scss";
 import { TabsRoutePath } from "../../../routes/paths";
 import { OperationType, ToastMsgType } from "../../globals/types";
+import { ResponsivePageLayout } from "../layout/ResponsivePageLayout";
+import { PageFooter } from "../PageFooter";
 
 const VerifyPasscode = ({
   isOpen,
   setIsOpen,
   onVerify,
 }: VerifyPasscodeProps) => {
+  const componentId = "verify-passcode";
   const history = useHistory();
   const dispatch = useAppDispatch();
   const currentOperation = useAppSelector(getCurrentOperation);
@@ -133,34 +135,23 @@ const VerifyPasscode = ({
   return (
     <IonModal
       isOpen={isOpen}
-      className="page-layout verify-passcode"
-      data-testid="verify-passcode"
+      className={componentId}
+      data-testid={componentId}
       onDidDismiss={() => handleClearState()}
     >
-      <PageLayout
-        header={true}
-        closeButton={true}
-        closeButtonLabel={`${i18n.t("verifypasscode.cancel")}`}
-        closeButtonAction={() => handleClearState()}
-      >
-        <IonGrid>
-          <IonRow>
-            <IonCol
-              className="verify-passcode-title"
-              data-testid="verify-passcode-title"
-            >
-              {i18n.t("verifypasscode.title")}
-            </IonCol>
-          </IonRow>
-          <IonRow>
-            <IonCol
-              className="verify-passcode-description"
-              data-testid="verify-passcode-description"
-            >
-              {i18n.t("verifypasscode.description")}
-            </IonCol>
-          </IonRow>
-        </IonGrid>
+      <ResponsivePageLayout pageId={componentId + "-content"}>
+        <h2
+          className="verify-passcode-title"
+          data-testid="verify-passcode-title"
+        >
+          {i18n.t("verifypasscode.title")}
+        </h2>
+        <p
+          className="verify-passcode-description small-hide"
+          data-testid="verify-passcode-description"
+        >
+          {i18n.t("verifypasscode.description")}
+        </p>
         <PasscodeModule
           error={
             <ErrorMessage
@@ -176,21 +167,11 @@ const VerifyPasscode = ({
           handlePinChange={handlePinChange}
           handleRemove={handleRemove}
         />
-        <IonGrid>
-          <IonRow>
-            <IonCol className="continue-col">
-              <IonButton
-                shape="round"
-                expand="block"
-                fill="outline"
-                className="secondary-button"
-                onClick={() => setAlertIsOpen(true)}
-              >
-                {i18n.t("verifypasscode.forgotten.button")}
-              </IonButton>
-            </IonCol>
-          </IonRow>
-        </IonGrid>
+        <PageFooter
+          pageId={componentId}
+          secondaryButtonText={`${i18n.t("verifypasscode.forgotten.button")}`}
+          secondaryButtonAction={() => setAlertIsOpen(true)}
+        />
         <Alert
           isOpen={alertIsOpen}
           setIsOpen={setAlertIsOpen}
@@ -200,7 +181,7 @@ const VerifyPasscode = ({
           cancelButtonText={cancelButtonText}
           actionConfirm={resetPasscode}
         />
-      </PageLayout>
+      </ResponsivePageLayout>
     </IonModal>
   );
 };


### PR DESCRIPTION
## Description

Part of the larger standardisation story for modals, in this PR I have refactored the layout of the Verify Passcode modal making use of some components recently created and used in other PRs such as the `ResponsivePageLayout`, the `PasscodeModule` and the `PageFooter` in order to responsively render the aforementioned modal in a way that takes advantage of what I did in my PR for the Passcode login and the one for the Terms and conditions modal.

**Note:**

1) In the screenshots below I am showing what the user will see when a wrong passcode is entered in order to show all of the components in a single shot.
2) As we already agreed some time ago with Robert, the reason why the subtitle isn't visible in smaller devices is to save space (same as what happens in the login screen).

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-398**](https://cardanofoundation.atlassian.net/jira/software/projects/DTIS/boards/36?selectedIssue=DTIS-398)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

![22012024154149](https://github.com/cardano-foundation/cf-identity-wallet/assets/119612231/849c0e16-e266-4d7e-b6f7-d2102dc28fd5)


#### Android

![22012024154235](https://github.com/cardano-foundation/cf-identity-wallet/assets/119612231/2f07ff37-0e45-4292-8a5a-aaa75038752e)
