### PR TITLE
feat(ui): Multi-sig feature - Sending the Multi-Sig Request

### DIFF
--- a/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
@@ -26,7 +26,6 @@ const CreateIdentifier = ({
     selectedAidType: 0,
     selectedTheme: 0,
     threshold: 1,
-    sortedConnections: [],
     selectedConnections: [],
   };
   const [state, setState] = useState(initialState);

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.types.ts
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.types.ts
@@ -30,8 +30,7 @@ interface IdentifierStageProps {
     selectedAidType: number;
     selectedTheme: number;
     threshold: number;
-    sortedConnections: ConnectionShortDetails[];
-    selectedConnections: string[];
+    selectedConnections: ConnectionShortDetails[];
   };
   setState: (value: any) => void;
   componentId: string;

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
@@ -107,6 +107,20 @@ const IdentifierStage0 = ({
     }
   };
 
+  const handleContinue = () => {
+    if (state.selectedIdentifierType === 1 && state.selectedAidType !== 0) {
+      setState((prevState: IdentifierStageProps) => ({
+        ...prevState,
+        identifierCreationStage: 1,
+      }));
+    } else {
+      setBlur && setBlur(true);
+      setTimeout(() => {
+        handleCreateIdentifier();
+      }, CREATE_IDENTIFIER_BLUR_TIMEOUT);
+    }
+  };
+
   return (
     <>
       <ScrollablePageLayout
@@ -243,22 +257,7 @@ const IdentifierStage0 = ({
         pageId={componentId}
         customClass={keyboardIsOpen ? "ion-hide" : ""}
         primaryButtonText={`${i18n.t("createidentifier.confirmbutton")}`}
-        primaryButtonAction={() => {
-          if (
-            state.selectedIdentifierType === 1 &&
-            state.selectedAidType !== 0
-          ) {
-            setState((prevState: IdentifierStageProps) => ({
-              ...prevState,
-              identifierCreationStage: 1,
-            }));
-          } else {
-            setBlur && setBlur(true);
-            setTimeout(() => {
-              handleCreateIdentifier();
-            }, CREATE_IDENTIFIER_BLUR_TIMEOUT);
-          }
-        }}
+        primaryButtonAction={() => handleContinue()}
         primaryButtonDisabled={
           !(displayNameValueIsValid && typeIsSelectedIsValid)
         }

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage1.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage1.tsx
@@ -23,9 +23,9 @@ const IdentifierStage1 = ({
   componentId,
 }: IdentifierStageProps) => {
   const connectionsCache = useAppSelector(getConnectionsCache);
-  const [selectedConnections, setSelectedConnections] = useState<string[]>(
-    state.selectedConnections
-  );
+  const [selectedConnections, setSelectedConnections] = useState<
+    ConnectionShortDetails[]
+  >(state.selectedConnections);
   const [sortedConnections, setSortedConnections] = useState<
     ConnectionShortDetails[]
   >([]);
@@ -41,19 +41,15 @@ const IdentifierStage1 = ({
         return textA < textB ? -1 : textA > textB ? 1 : 0;
       });
       setSortedConnections(sortedConnections);
-      setState((prevState: IdentifierStageProps) => ({
-        ...prevState,
-        sortedConnections: sortedConnections,
-      }));
     }
   }, [connectionsCache, setState]);
 
-  const handleSelectConnection = (id: string) => {
+  const handleSelectConnection = (connection: ConnectionShortDetails) => {
     let data = selectedConnections;
-    if (data.find((item) => item === id)) {
-      data = data.filter((item) => item !== id);
+    if (data.find((item) => item === connection)) {
+      data = data.filter((item) => item !== connection);
     } else {
-      data = [...selectedConnections, id];
+      data = [...selectedConnections, connection];
     }
     setSelectedConnections(data);
   };
@@ -95,9 +91,9 @@ const IdentifierStage1 = ({
             return (
               <IonItem
                 key={index}
-                onClick={() => handleSelectConnection(connection.id)}
+                onClick={() => handleSelectConnection(connection)}
                 className={`${
-                  selectedConnections.includes(connection.id) &&
+                  selectedConnections.includes(connection) &&
                   "selected-connection"
                 }`}
               >
@@ -109,10 +105,10 @@ const IdentifierStage1 = ({
                   />
                   <span className="connection-name">{connection.label}</span>
                   <IonCheckbox
-                    checked={selectedConnections.includes(connection.id)}
+                    checked={selectedConnections.includes(connection)}
                     data-testid={`connection-checkbox-${index}`}
                     onIonChange={() => {
-                      handleSelectConnection(connection.id);
+                      handleSelectConnection(connection);
                     }}
                     aria-label=""
                   />

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage1.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage1.tsx
@@ -54,12 +54,13 @@ const IdentifierStage1 = ({
     setSelectedConnections(data);
   };
 
-  useEffect(() => {
+  const handleContinue = () => {
     setState((prevState: IdentifierStageProps) => ({
       ...prevState,
+      identifierCreationStage: 2,
       selectedConnections: selectedConnections,
     }));
-  }, [selectedConnections, setState]);
+  };
 
   return (
     <>
@@ -121,12 +122,7 @@ const IdentifierStage1 = ({
       <PageFooter
         pageId={componentId}
         primaryButtonText={`${i18n.t("createidentifier.connections.continue")}`}
-        primaryButtonAction={() =>
-          setState((prevState: IdentifierStageProps) => ({
-            ...prevState,
-            identifierCreationStage: 2,
-          }))
-        }
+        primaryButtonAction={() => handleContinue()}
         primaryButtonDisabled={!selectedConnections.length}
       />
     </>

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage2.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage2.tsx
@@ -27,6 +27,13 @@ const IdentifierStage2 = ({
     }));
   };
 
+  const handleContinue = () => {
+    setState((prevState: IdentifierStageProps) => ({
+      ...prevState,
+      identifierCreationStage: 3,
+    }));
+  };
+
   return (
     <>
       <ScrollablePageLayout
@@ -87,12 +94,7 @@ const IdentifierStage2 = ({
       <PageFooter
         pageId={componentId}
         primaryButtonText={`${i18n.t("createidentifier.threshold.continue")}`}
-        primaryButtonAction={() =>
-          setState((prevState: IdentifierStageProps) => ({
-            ...prevState,
-            identifierCreationStage: 3,
-          }))
-        }
+        primaryButtonAction={() => handleContinue()}
       />
     </>
   );

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage2.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage2.tsx
@@ -11,6 +11,22 @@ const IdentifierStage2 = ({
   setState,
   componentId,
 }: IdentifierStageProps) => {
+  const updateThreshold = (amount: number) => {
+    const newThreshold = state.threshold + amount;
+
+    if (
+      newThreshold < 1 ||
+      newThreshold > state.selectedConnections.length + 1
+    ) {
+      return;
+    }
+
+    setState((prevState: IdentifierStageProps) => ({
+      ...prevState,
+      threshold: newThreshold,
+    }));
+  };
+
   return (
     <>
       <ScrollablePageLayout
@@ -44,16 +60,7 @@ const IdentifierStage2 = ({
                 shape="round"
                 className="decrease-threshold-button"
                 data-testid="decrease-threshold-button"
-                onClick={() => {
-                  if (state.threshold === 1) {
-                    return;
-                  } else {
-                    setState((prevState: IdentifierStageProps) => ({
-                      ...prevState,
-                      threshold: state.threshold - 1,
-                    }));
-                  }
-                }}
+                onClick={() => updateThreshold(-1)}
               >
                 <IonIcon
                   slot="icon-only"
@@ -65,19 +72,7 @@ const IdentifierStage2 = ({
                 shape="round"
                 className="increase-threshold-button"
                 data-testid="increase-threshold-button"
-                onClick={() => {
-                  if (
-                    state.threshold ===
-                    state.selectedConnections.length + 1
-                  ) {
-                    return;
-                  } else {
-                    setState((prevState: IdentifierStageProps) => ({
-                      ...prevState,
-                      threshold: state.threshold + 1,
-                    }));
-                  }
-                }}
+                onClick={() => updateThreshold(1)}
               >
                 <IonIcon
                   slot="icon-only"

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
@@ -8,11 +8,13 @@ import { ScrollablePageLayout } from "../../layout/ScrollablePageLayout";
 import { IdentifierStageProps } from "../CreateIdentifier.types";
 import CardanoLogo from "../../../assets/images/CardanoLogo.jpg";
 import { Alert } from "../../Alert";
-import { useAppDispatch } from "../../../../store/hooks";
+import { useAppDispatch, useAppSelector } from "../../../../store/hooks";
 import { setToastMsg } from "../../../../store/reducers/stateCache";
 import { ToastMsgType } from "../../../globals/types";
 import { AriesAgent } from "../../../../core/agent/agent";
 import { ConnectionShortDetails } from "../../../pages/Connections/Connections.types";
+import { getIdentifiersCache } from "../../../../store/reducers/identifiersCache";
+import { IdentifierType } from "../../../../core/agent/services/identifierService.types";
 
 const IdentifierStage3 = ({
   state,
@@ -22,7 +24,12 @@ const IdentifierStage3 = ({
 }: IdentifierStageProps) => {
   const dispatch = useAppDispatch();
   const [alertIsOpen, setAlertIsOpen] = useState(false);
-  const ourIdentifier = "";
+  // @TODO - sdisalvo: This is a temporary fix to get the identifier created.
+  // We'll need to work out a proper way to get 'ourIdentifier'.
+  const identifiersData = useAppSelector(getIdentifiersCache);
+  const ourIdentifier = identifiersData.filter(
+    (identifier) => identifier.method === IdentifierType.KERI
+  )[0].id;
   const otherIdentifierContacts: ConnectionShortDetails[] =
     state.sortedConnections.filter((connection) =>
       state.selectedConnections.includes(connection.id)

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
@@ -11,6 +11,8 @@ import { Alert } from "../../Alert";
 import { useAppDispatch } from "../../../../store/hooks";
 import { setToastMsg } from "../../../../store/reducers/stateCache";
 import { ToastMsgType } from "../../../globals/types";
+import { AriesAgent } from "../../../../core/agent/agent";
+import { ConnectionShortDetails } from "../../../pages/Connections/Connections.types";
 
 const IdentifierStage3 = ({
   state,
@@ -20,6 +22,24 @@ const IdentifierStage3 = ({
 }: IdentifierStageProps) => {
   const dispatch = useAppDispatch();
   const [alertIsOpen, setAlertIsOpen] = useState(false);
+  const ourIdentifier = "";
+  const otherIdentifierContacts: ConnectionShortDetails[] =
+    state.sortedConnections.filter((connection) =>
+      state.selectedConnections.includes(connection.id)
+    );
+
+  const createMultisigIdentifier = async () => {
+    await AriesAgent.agent.identifiers.createMultisig(
+      ourIdentifier,
+      otherIdentifierContacts,
+      {
+        theme: state.selectedTheme,
+        // @TODO - sdisalvo: Colors will need to be removed
+        colors: ["#000000", "#000000"],
+        displayName: state.displayNameValue,
+      }
+    );
+  };
   return (
     <>
       <ScrollablePageLayout
@@ -128,8 +148,7 @@ const IdentifierStage3 = ({
         customClass="identifier-stage-3"
         primaryButtonText={`${i18n.t("createidentifier.confirm.continue")}`}
         primaryButtonAction={() => {
-          // @TODO - sdisalvo: send the request
-          //  console.log(state);
+          createMultisigIdentifier();
           dispatch(setToastMsg(ToastMsgType.IDENTIFIER_REQUESTED));
           resetModal();
         }}

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
@@ -31,9 +31,11 @@ const IdentifierStage3 = ({
     (identifier) => identifier.method === IdentifierType.KERI
   )[0]?.id;
   const otherIdentifierContacts: ConnectionShortDetails[] =
-    state.sortedConnections.filter((connection) =>
-      state.selectedConnections.includes(connection.id)
-    );
+    state.selectedConnections.sort(function (a, b) {
+      const textA = a.label.toUpperCase();
+      const textB = b.label.toUpperCase();
+      return textA < textB ? -1 : textA > textB ? 1 : 0;
+    });
 
   const createMultisigIdentifier = async () => {
     await AriesAgent.agent.identifiers.createMultisig(
@@ -94,37 +96,33 @@ const IdentifierStage3 = ({
             {i18n.t("createidentifier.confirm.selectedmembers")}
           </div>
           <IonCard>
-            {state.sortedConnections.map((connection, index) => {
-              if (state.selectedConnections.includes(connection.id)) {
-                return (
-                  <IonItem
-                    key={index}
-                    className="identifier-list-item"
-                  >
-                    <IonLabel>
-                      <img
-                        src={connection?.logo ?? CardanoLogo}
-                        className="connection-logo"
-                        alt="connection-logo"
-                      />
-                      <span className="connection-name">
-                        {connection.label}
-                      </span>
-                      <IonIcon
-                        aria-hidden="true"
-                        icon={pencilOutline}
-                        slot="end"
-                        onClick={() =>
-                          setState((prevState: IdentifierStageProps) => ({
-                            ...prevState,
-                            identifierCreationStage: 1,
-                          }))
-                        }
-                      />
-                    </IonLabel>
-                  </IonItem>
-                );
-              }
+            {otherIdentifierContacts.map((connection, index) => {
+              return (
+                <IonItem
+                  key={index}
+                  className="identifier-list-item"
+                >
+                  <IonLabel>
+                    <img
+                      src={connection?.logo ?? CardanoLogo}
+                      className="connection-logo"
+                      alt="connection-logo"
+                    />
+                    <span className="connection-name">{connection.label}</span>
+                    <IonIcon
+                      aria-hidden="true"
+                      icon={pencilOutline}
+                      slot="end"
+                      onClick={() =>
+                        setState((prevState: IdentifierStageProps) => ({
+                          ...prevState,
+                          identifierCreationStage: 1,
+                        }))
+                      }
+                    />
+                  </IonLabel>
+                </IonItem>
+              );
             })}
           </IonCard>
         </div>
@@ -154,7 +152,7 @@ const IdentifierStage3 = ({
         pageId={componentId}
         customClass="identifier-stage-3"
         primaryButtonText={`${i18n.t("createidentifier.confirm.continue")}`}
-        primaryButtonAction={() => {
+        primaryButtonAction={async () => {
           createMultisigIdentifier();
           dispatch(setToastMsg(ToastMsgType.IDENTIFIER_REQUESTED));
           resetModal();

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
@@ -29,7 +29,7 @@ const IdentifierStage3 = ({
   const identifiersData = useAppSelector(getIdentifiersCache);
   const ourIdentifier = identifiersData.filter(
     (identifier) => identifier.method === IdentifierType.KERI
-  )[0].id;
+  )[0]?.id;
   const otherIdentifierContacts: ConnectionShortDetails[] =
     state.sortedConnections.filter((connection) =>
       state.selectedConnections.includes(connection.id)

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage3.tsx
@@ -1,6 +1,6 @@
 import { IonCard, IonItem, IonLabel, IonIcon } from "@ionic/react";
 import { pencilOutline } from "ionicons/icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { i18n } from "../../../../i18n";
 import { PageFooter } from "../../PageFooter";
 import { PageHeader } from "../../PageHeader";
@@ -27,15 +27,21 @@ const IdentifierStage3 = ({
   // @TODO - sdisalvo: This is a temporary fix to get the identifier created.
   // We'll need to work out a proper way to get 'ourIdentifier'.
   const identifiersData = useAppSelector(getIdentifiersCache);
-  const ourIdentifier = identifiersData.filter(
-    (identifier) => identifier.method === IdentifierType.KERI
-  )[0]?.id;
+  const [ourIdentifier, setOurIdentifier] = useState("");
   const otherIdentifierContacts: ConnectionShortDetails[] =
     state.selectedConnections.sort(function (a, b) {
       const textA = a.label.toUpperCase();
       const textB = b.label.toUpperCase();
       return textA < textB ? -1 : textA > textB ? 1 : 0;
     });
+
+  useEffect(() => {
+    setOurIdentifier(
+      identifiersData.filter(
+        (identifier) => identifier.method === IdentifierType.KERI
+      )[0]?.id
+    );
+  }, [identifiersData, state.selectedConnections]);
 
   const createMultisigIdentifier = async () => {
     await AriesAgent.agent.identifiers.createMultisig(
@@ -153,7 +159,7 @@ const IdentifierStage3 = ({
         customClass="identifier-stage-3"
         primaryButtonText={`${i18n.t("createidentifier.confirm.continue")}`}
         primaryButtonAction={async () => {
-          createMultisigIdentifier();
+          await createMultisigIdentifier();
           dispatch(setToastMsg(ToastMsgType.IDENTIFIER_REQUESTED));
           resetModal();
         }}


### PR DESCRIPTION
## Description

No changes to the UI, everything still looks the same all the way until the user will see the toast message confirming a request was sent. In this PR I am just hooking up the request for the Multi-Sig creation as described in the ticket linked below.

**NOTE:**

1- `colors`: we don't need this anymore and it will need a dedicated ticket for being removed from everywhere across the app.
2- As a temporary solution, I am getting `ourIdentifier` by returning the first Keri identifier available in our wallet. This will need to be refined further and a dedicated identifier will need to be created under the hood without showing up in the app with the other ones (Fergal will help finding a solution for this).

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-651**](https://cardanofoundation.atlassian.net/browse/DTIS-651)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences