### PR TITLE
feat(core): interface to return multi-sig contact details for UI

### DIFF
--- a/services/credential-issuance-server/package-lock.json
+++ b/services/credential-issuance-server/package-lock.json
@@ -25,6 +25,7 @@
                 "ws": "^8.13.0"
             },
             "devDependencies": {
+                "@types/qrcode-terminal": "^0.12.2",
                 "nodemon": "^3.0.1",
                 "rimraf": "^5.0.1",
                 "ts-node": "^10.9.1"
@@ -6309,6 +6310,12 @@
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
+        },
+        "node_modules/@types/qrcode-terminal": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@types/qrcode-terminal/-/qrcode-terminal-0.12.2.tgz",
+            "integrity": "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==",
+            "dev": true
         },
         "node_modules/@types/qs": {
             "version": "6.9.10",

--- a/services/credential-issuance-server/package.json
+++ b/services/credential-issuance-server/package.json
@@ -11,6 +11,7 @@
         "cli:offer-credential": "npx ts-node src/cli/invitationWithCredential.ts",
         "cli:offer-credential-connection-less": "npx ts-node src/cli/invitationWithCredentialConnectionless.ts",
         "cli:keri-oobi": "npx ts-node ./src/cli/keriOobi.ts",
+        "cli:multi-sig-incept": "npx ts-node ./src/cli/multiSigIncept.ts",
         "build": "rimraf ./build && tsc"
     },
     "author": "",
@@ -27,11 +28,12 @@
         "net": "^1.0.2",
         "node-cache": "^5.1.2",
         "qrcode-terminal": "^0.12.0",
+        "signify-ts": "github:WebOfTrust/signify-ts#faeebad4bdb29832cb25b83e41db064ede07dd36",
         "uuid": "^9.0.1",
-        "ws": "^8.13.0",
-        "signify-ts": "github:WebOfTrust/signify-ts#faeebad4bdb29832cb25b83e41db064ede07dd36"
+        "ws": "^8.13.0"
     },
     "devDependencies": {
+        "@types/qrcode-terminal": "^0.12.2",
         "nodemon": "^3.0.1",
         "rimraf": "^5.0.1",
         "ts-node": "^10.9.1"

--- a/services/credential-issuance-server/src/cli/multiSigIncept.ts
+++ b/services/credential-issuance-server/src/cli/multiSigIncept.ts
@@ -1,0 +1,168 @@
+import { SignifyClient, randomPasscode, Tier, ready as signifyReady, Algos, Siger, d, messagize } from "signify-ts";
+import qrcode from "qrcode-terminal";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from 'node:process';
+import { SignifyApi } from "../modules/signify/signifyApi";
+import { waitAndGetDoneOp } from "../modules/signify/utils";
+
+async function getClient(): Promise<SignifyClient> {
+  const client = new SignifyClient(
+    SignifyApi.LOCAL_KERIA_ENDPOINT,
+    randomPasscode(),
+    Tier.low,
+    SignifyApi.LOCAL_KERIA_BOOT_ENDPOINT
+  );
+
+  await client.boot();
+  await client.connect();
+  return client;
+}
+
+// @TODO - foconnor: any.
+async function createIdentifier(client: SignifyClient, name: string): Promise<any> {
+  const createOp = await (await client.identifiers().create(name)).op();
+  await waitAndGetDoneOp(client, createOp);
+  await client.identifiers().addEndRole(
+    name,
+    SignifyApi.DEFAULT_ROLE,
+    client.agent!.pre
+  );
+  return client.identifiers().get(name);
+}
+
+async function waitForFirstNotification(client: SignifyClient, route: string, timeout = 5000, interval = 250) {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeout) {
+    const notes = (await client.notifications().list()).notes;
+    const note = notes.find((note) => note.a.r === route && note.r === false);
+    if (note) {
+      await client.notifications().mark(note.i);
+      return note.a.d;
+    }
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+  throw new Error(`Notification on route ${route} not appearing after ${timeout}ms`);
+}
+
+async function main() {
+  const idwOobi = process.argv[2];
+  if (!idwOobi?.includes("/oobi")) {
+    console.error(`Invalid OOBI argument: ${idwOobi}`);
+    process.exit(1);
+  }
+  
+  await signifyReady();
+  
+  const alice = await getClient();
+  const aliceAid = await createIdentifier(alice, "alice");
+  const oobiA = await alice.oobis().get("alice");
+  console.info(`Alice created: ${aliceAid.prefix}`);
+  
+  const bob = await getClient();
+  const bobAid = await createIdentifier(bob, "bob");
+  const oobiB = await bob.oobis().get("bob");
+  console.info(`Bob created: ${bobAid.prefix}`);
+
+  await waitAndGetDoneOp(alice, await alice.oobis().resolve(oobiB.oobis[0], "bob"));
+  await waitAndGetDoneOp(bob, await bob.oobis().resolve(oobiA.oobis[0], "alice"));
+
+  const resolveIdwOpA = await waitAndGetDoneOp(alice, await alice.oobis().resolve(idwOobi, "idw"));
+  await waitAndGetDoneOp(bob, await bob.oobis().resolve(idwOobi, "idw"));
+
+  console.info(`\nAlice OOBI: ${oobiA.oobis[0]}`);
+  qrcode.generate(oobiA.oobis[0], { small: true });
+  
+  console.info(`Bob OOBI: ${oobiB.oobis[0]}`);
+  qrcode.generate(oobiB.oobis[0], { small: true });
+
+  const rl = createInterface({ input: stdin, output: stdout });
+  await rl.question("After scanning the QR codes, press enter to trigger inception of the multi-sig...");
+
+  // --> Alice creates and sends to Bob and our IDW.
+  const states = [aliceAid["state"], bobAid["state"], resolveIdwOpA.response];
+  console.log(`it is here as ${JSON.stringify({
+    algo: Algos.group,
+    mhab: aliceAid,
+    isith: 3,
+    nsith: 3,
+    states,
+    rstates: states,
+  }, null, 2)}`);
+  const aliceIcp = await alice.identifiers().create("multisig", {
+    algo: Algos.group,
+    mhab: aliceAid,
+    isith: 3,
+    nsith: 3,
+    states,
+    rstates: states,
+  });
+  const aliceIcpOp = await aliceIcp.op();
+  const aliceSerder = aliceIcp.serder;
+  const aliceSigers = aliceIcp.sigs.map((sig: string) => new Siger({ qb64: sig }));
+
+  const aliceIms = d(messagize(aliceSerder, aliceSigers));
+  const aliceAtc = aliceIms.substring(aliceSerder.size);
+  const aliceEmbeds = { icp: [aliceSerder, aliceAtc] };
+
+  const smids = states.map((state) => state["i"]);
+  const recp = [bobAid["state"], resolveIdwOpA.response].map((state) => state["i"]);
+  await alice
+    .exchanges()
+    .send(
+      "alice",
+      "multisig",
+      aliceAid,
+      "/multisig/icp",
+      { gid: aliceSerder.pre, smids: smids, rmids: smids },
+      aliceEmbeds,
+      recp
+    );
+  
+  console.info("Alice has sent out the inception event!");
+   
+  // --> Bob wait and join.
+  const receviedMsgSaid = await waitForFirstNotification(bob, "/multisig/icp");
+  const receivedMsg = (await bob.groups().getRequest(receviedMsgSaid))[0].exn;
+  const receivedIcp = receivedMsg.e.icp;
+
+  const bobIcp = await bob.identifiers().create("multisig", {
+      algo: Algos.group,
+      mhab: bobAid,
+      isith: receivedIcp.kt,
+      nsith: receivedIcp.nt,
+      toad: parseInt(receivedIcp.bt),
+      wits: receivedIcp.b,
+      states,
+      rstates: states,
+  });
+  const bobIcpOp = await bobIcp.op();
+  const bobSerder = bobIcp.serder;
+  const bobSigers = bobIcp.sigs.map((sig) => new Siger({ qb64: sig }));
+
+  const bobIms = d(messagize(bobSerder, bobSigers));
+  const bobAtc = bobIms.substring(bobSerder.size);
+  const bobEmbeds = { icp: [bobSerder, bobAtc] };
+
+  const bobRecp = [aliceAid["state"], resolveIdwOpA.response].map((state) => state["i"]);
+  await bob.exchanges().send(
+    "bob",
+    "multisig",
+    bobAid,
+    "/multisig/icp",
+    { gid: bobSerder.pre, smids: smids, rmids: smids },
+    bobEmbeds,
+    bobRecp
+  );
+  
+  console.info("Bob has joined the multi-sig and sent his response!");
+
+  await rl.question("Accept the multi-sig in IDW, and press enter once done...");
+  rl.close();
+
+  await waitAndGetDoneOp(alice, aliceIcpOp);
+  await waitAndGetDoneOp(bob, bobIcpOp);
+
+  console.info("Multi-sig fully complete!")
+}
+
+void main();

--- a/services/credential-issuance-server/src/cli/multiSigIncept.ts
+++ b/services/credential-issuance-server/src/cli/multiSigIncept.ts
@@ -80,14 +80,6 @@ async function main() {
 
   // --> Alice creates and sends to Bob and our IDW.
   const states = [aliceAid["state"], bobAid["state"], resolveIdwOpA.response];
-  console.log(`it is here as ${JSON.stringify({
-    algo: Algos.group,
-    mhab: aliceAid,
-    isith: 3,
-    nsith: 3,
-    states,
-    rstates: states,
-  }, null, 2)}`);
   const aliceIcp = await aliceClient.identifiers().create("multisig", {
     algo: Algos.group,
     mhab: aliceAid,

--- a/services/credential-issuance-server/src/modules/signify/utils.ts
+++ b/services/credential-issuance-server/src/modules/signify/utils.ts
@@ -1,0 +1,20 @@
+import { Operation, SignifyClient } from "signify-ts";
+
+async function waitAndGetDoneOp(
+  client: SignifyClient,
+  op: Operation,
+  timeout = 10000,
+  interval = 250
+): Promise<Operation> {
+  const startTime = new Date().getTime();
+  while (!op.done && new Date().getTime() < startTime + timeout) {
+    op = await client.operations().get(op.name);
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  if (!op.done) {
+    throw new Error(`Operation not completing: ${JSON.stringify(op, null, 2)}`);
+  }
+  return op;
+}
+
+export { waitAndGetDoneOp }

--- a/services/credential-issuance-server/tsconfig.json
+++ b/services/credential-issuance-server/tsconfig.json
@@ -7,7 +7,6 @@
       "target": "es2018",
       "noImplicitReturns": true,
       "noFallthroughCasesInSwitch": true,
-      "noUnusedLocals": true,
       "pretty": true,
       "strict": true,
       "sourceMap": true,

--- a/src/core/agent/modules/signify/signifyApi.test.ts
+++ b/src/core/agent/modules/signify/signifyApi.test.ts
@@ -56,6 +56,12 @@ const membersMock = jest.fn();
 
 const exchangeSendMock = jest.fn();
 
+let getKeyStateMock = jest.fn().mockReturnValue([
+  {
+    i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+  },
+]);
+
 const contacts = [
   {
     id: "id",
@@ -72,7 +78,7 @@ jest.mock("signify-ts", () => ({
     return {
       connect: connectMock,
       boot: bootMock,
-      identifiers: jest.fn().mockReturnValue({
+      identifiers: () => ({
         list: jest.fn().mockResolvedValue({
           aids: [
             { name: firstAid, prefix: "1" },
@@ -108,7 +114,7 @@ jest.mock("signify-ts", () => ({
         rotate: rotateMock,
         members: membersMock,
       }),
-      operations: jest.fn().mockReturnValue({
+      operations: () => ({
         get: jest.fn().mockImplementation((name: string) => {
           if (
             name === `${witnessPrefix}${uuidToThrow}` ||
@@ -119,7 +125,7 @@ jest.mock("signify-ts", () => ({
           return { done: true, name };
         }),
       }),
-      oobis: jest.fn().mockReturnValue({
+      oobis: () => ({
         get: jest.fn().mockImplementation((name: string) => {
           return {
             oobis: [`${oobiPrefix}${name}`],
@@ -129,7 +135,7 @@ jest.mock("signify-ts", () => ({
           return { done: false, name, response: {} };
         }),
       }),
-      contacts: jest.fn().mockReturnValue({
+      contacts: () => ({
         list: jest
           .fn()
           .mockImplementation(
@@ -149,7 +155,7 @@ jest.mock("signify-ts", () => ({
           };
         }),
       }),
-      notifications: jest.fn().mockReturnValue({
+      notifications: () => ({
         list: jest.fn().mockImplementation((start?: number, end?: number) => {
           return notifications;
         }),
@@ -157,16 +163,16 @@ jest.mock("signify-ts", () => ({
           return "marked";
         }),
       }),
-      ipex: jest.fn().mockReturnValue({
+      ipex: () => ({
         admit: admitMock,
         submitAdmit: submitAdmitMock,
       }),
-      credentials: jest.fn().mockReturnValue({
+      credentials: () => ({
         list: jest.fn().mockImplementation((kargs?: CredentialFilter) => {
           return credentials;
         }),
       }),
-      exchanges: jest.fn().mockReturnValue({
+      exchanges: () => ({
         get: jest.fn().mockImplementation((name: string, said: string) => {
           return exchange;
         }),
@@ -175,11 +181,12 @@ jest.mock("signify-ts", () => ({
       agent: {
         pre: "pre",
       },
-      keyStates: jest.fn().mockReturnValue({
+      keyStates: () => ({
         query: jest.fn().mockReturnValue({
           name: "operation",
           done: true,
         }),
+        get: getKeyStateMock,
       }),
     };
   }),
@@ -194,6 +201,145 @@ jest.mock("signify-ts", () => ({
   d: jest.fn().mockReturnValue("string"),
   messagize: jest.fn(),
 }));
+
+const multisigIcpExn = {
+  v: "KERI10JSON0007bf_",
+  t: "exn",
+  d: "EPwR9xi7f8yMFYb31uRiPjwSWgzD40jLCUosxJe2k1aM",
+  i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+  p: "",
+  dt: "2023-12-25T07:57:40.307000+00:00",
+  r: "/multisig/icp",
+  q: {},
+  a: {
+    gid: "ENWBYC6g1-e3SyAB6PnjYwKMpQNw-jUwO_I9VUvYzM8_",
+    smids: [
+      "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+      "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+    ],
+    rmids: [
+      "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+      "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+    ],
+    rstates: [
+      {
+        vn: [1, 0],
+        i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+        s: "0",
+        p: "",
+        d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+        f: "0",
+        dt: "2023-12-25T07:37:32.006185+00:00",
+        et: "icp",
+        kt: "1",
+        k: ["DOBaDQOTbreUoqMzCzX0f2ywCB2Qbv17qeHMlm85QjZZ"],
+        nt: "1",
+        n: ["EJqXepNeybydv7fb0FdRsDhWxia6i_bDCv1LyucSegMj"],
+        bt: "1",
+        b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
+        c: [],
+        ee: {
+          s: "0",
+          d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+          br: [],
+          ba: [],
+        },
+        di: "",
+      },
+      {
+        vn: [1, 0],
+        i: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+        s: "0",
+        p: "",
+        d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+        f: "0",
+        dt: "2023-12-25T07:42:44.975239+00:00",
+        et: "icp",
+        kt: "1",
+        k: ["DIDpyM3TPrV5-ZwpiFDU9HtI9-zXpHtOGLNzfUrzLOs5"],
+        nt: "1",
+        n: ["EMnyXeI28CtemqNmxget-4Xn1DrKehDect1qHwfREo1u"],
+        bt: "1",
+        b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
+        c: [],
+        ee: {
+          s: "0",
+          d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+          br: [],
+          ba: [],
+        },
+        di: "",
+      },
+    ],
+    name: "6eaf3e83-eb11-4146-bfb3-17e67c38199a",
+  },
+  e: {
+    icp: {
+      v: "KERI10JSON0001b7_",
+      t: "icp",
+      d: "ENWBYC6g1-e3SyAB6PnjYwKMpQNw-jUwO_I9VUvYzM8_",
+      i: "ENWBYC6g1-e3SyAB6PnjYwKMpQNw-jUwO_I9VUvYzM8_",
+      s: "0",
+      kt: "2",
+      k: [
+        "DOBaDQOTbreUoqMzCzX0f2ywCB2Qbv17qeHMlm85QjZZ",
+        "DIDpyM3TPrV5-ZwpiFDU9HtI9-zXpHtOGLNzfUrzLOs5",
+      ],
+      nt: "2",
+      n: [
+        "EJqXepNeybydv7fb0FdRsDhWxia6i_bDCv1LyucSegMj",
+        "EMnyXeI28CtemqNmxget-4Xn1DrKehDect1qHwfREo1u",
+      ],
+      bt: "1",
+      b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
+      c: [],
+      a: [],
+    },
+    d: "EGG3Bma__y5CHGYDlGWKCcJNoO826bIXgrGwJBhz9OyV",
+  },
+};
+
+const multisigMember = {
+  name: "4130a76b-21d9-4a21-bdd4-40219b157be5",
+  prefix: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+  salty: {
+    sxlt: "1AAHhHKLzBwuO8s6Ntzb0OJ3vd8apYe5SsqAvaA_k3ac-Qu9Om-HHJCUac5Wh0EIuhySrrHYoiJV9KdJrEJiRjLULVdS0UR7T4cv",
+    pidx: 0,
+    kidx: 0,
+    stem: "signify:aid",
+    tier: "low",
+    dcode: "E",
+    icodes: ["A"],
+    ncodes: ["A"],
+    transferable: true,
+  },
+  transferable: true,
+  state: {
+    vn: [1, 0],
+    i: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+    s: "0",
+    p: "",
+    d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+    f: "0",
+    dt: "2023-12-25T07:36:32.350862+00:00",
+    et: "icp",
+    kt: "1",
+    k: ["DIDpyM3TPrV5-ZwpiFDU9HtI9-zXpHtOGLNzfUrzLOs5"],
+    nt: "1",
+    n: ["EMnyXeI28CtemqNmxget-4Xn1DrKehDect1qHwfREo1u"],
+    bt: "1",
+    b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
+    c: [],
+    ee: {
+      s: "0",
+      d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
+      br: [],
+      ba: [],
+    },
+    di: "",
+  },
+  windexes: [0],
+};
 
 // Set low timeout - fake timers would be better but having issues advancing timer at exact right time
 const api = new SignifyApi(5, 1);
@@ -491,147 +637,39 @@ describe("Signify API", () => {
   });
 
   test("Should able to join multisig", async () => {
-    const exn = {
-      v: "KERI10JSON0007bf_",
-      t: "exn",
-      d: "EPwR9xi7f8yMFYb31uRiPjwSWgzD40jLCUosxJe2k1aM",
-      i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-      p: "",
-      dt: "2023-12-25T07:57:40.307000+00:00",
-      r: "/multisig/icp",
-      q: {},
-      a: {
-        gid: "ENWBYC6g1-e3SyAB6PnjYwKMpQNw-jUwO_I9VUvYzM8_",
-        smids: [
-          "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-          "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-        ],
-        rmids: [
-          "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-          "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-        ],
-        rstates: [
-          {
-            vn: [1, 0],
-            i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-            s: "0",
-            p: "",
-            d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-            f: "0",
-            dt: "2023-12-25T07:37:32.006185+00:00",
-            et: "icp",
-            kt: "1",
-            k: ["DOBaDQOTbreUoqMzCzX0f2ywCB2Qbv17qeHMlm85QjZZ"],
-            nt: "1",
-            n: ["EJqXepNeybydv7fb0FdRsDhWxia6i_bDCv1LyucSegMj"],
-            bt: "1",
-            b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
-            c: [],
-            ee: {
-              s: "0",
-              d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-              br: [],
-              ba: [],
-            },
-            di: "",
-          },
-          {
-            vn: [1, 0],
-            i: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-            s: "0",
-            p: "",
-            d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-            f: "0",
-            dt: "2023-12-25T07:42:44.975239+00:00",
-            et: "icp",
-            kt: "1",
-            k: ["DIDpyM3TPrV5-ZwpiFDU9HtI9-zXpHtOGLNzfUrzLOs5"],
-            nt: "1",
-            n: ["EMnyXeI28CtemqNmxget-4Xn1DrKehDect1qHwfREo1u"],
-            bt: "1",
-            b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
-            c: [],
-            ee: {
-              s: "0",
-              d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-              br: [],
-              ba: [],
-            },
-            di: "",
-          },
-        ],
-        name: "6eaf3e83-eb11-4146-bfb3-17e67c38199a",
-      },
-      e: {
-        icp: {
-          v: "KERI10JSON0001b7_",
-          t: "icp",
-          d: "ENWBYC6g1-e3SyAB6PnjYwKMpQNw-jUwO_I9VUvYzM8_",
-          i: "ENWBYC6g1-e3SyAB6PnjYwKMpQNw-jUwO_I9VUvYzM8_",
-          s: "0",
-          kt: "2",
-          k: [
-            "DOBaDQOTbreUoqMzCzX0f2ywCB2Qbv17qeHMlm85QjZZ",
-            "DIDpyM3TPrV5-ZwpiFDU9HtI9-zXpHtOGLNzfUrzLOs5",
-          ],
-          nt: "2",
-          n: [
-            "EJqXepNeybydv7fb0FdRsDhWxia6i_bDCv1LyucSegMj",
-            "EMnyXeI28CtemqNmxget-4Xn1DrKehDect1qHwfREo1u",
-          ],
-          bt: "1",
-          b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
-          c: [],
-          a: [],
-        },
-        d: "EGG3Bma__y5CHGYDlGWKCcJNoO826bIXgrGwJBhz9OyV",
-      },
-    };
-    const aid = {
-      name: "4130a76b-21d9-4a21-bdd4-40219b157be5",
-      prefix: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-      salty: {
-        sxlt: "1AAHhHKLzBwuO8s6Ntzb0OJ3vd8apYe5SsqAvaA_k3ac-Qu9Om-HHJCUac5Wh0EIuhySrrHYoiJV9KdJrEJiRjLULVdS0UR7T4cv",
-        pidx: 0,
-        kidx: 0,
-        stem: "signify:aid",
-        tier: "low",
-        dcode: "E",
-        icodes: ["A"],
-        ncodes: ["A"],
-        transferable: true,
-      },
-      transferable: true,
-      state: {
-        vn: [1, 0],
-        i: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-        s: "0",
-        p: "",
-        d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-        f: "0",
-        dt: "2023-12-25T07:36:32.350862+00:00",
-        et: "icp",
-        kt: "1",
-        k: ["DIDpyM3TPrV5-ZwpiFDU9HtI9-zXpHtOGLNzfUrzLOs5"],
-        nt: "1",
-        n: ["EMnyXeI28CtemqNmxget-4Xn1DrKehDect1qHwfREo1u"],
-        bt: "1",
-        b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
-        c: [],
-        ee: {
-          s: "0",
-          d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-          br: [],
-          ba: [],
-        },
-        di: "",
-      },
-      windexes: [0],
-    };
-    const result = await api.joinMultisig(exn, aid, utils.uuid());
+    const result = await api.joinMultisig(
+      multisigIcpExn,
+      multisigMember,
+      utils.uuid()
+    );
     expect(result).toHaveProperty("op");
     expect(result).toHaveProperty("icpResult");
     expect(result).toHaveProperty("name");
+    expect(getKeyStateMock).toBeCalledTimes(4);
+  });
+
+  test("should throw if we cannot retrieve smid states joining multisig", async () => {
+    getKeyStateMock = jest.fn().mockResolvedValueOnce([]);
+    await expect(
+      api.joinMultisig(multisigIcpExn, multisigMember, utils.uuid())
+    ).rejects.toThrowError(SignifyApi.CANNOT_GET_KEYSTATES_FOR_MULTISIG_MEMBER);
+  });
+
+  test("should throw if we cannot retrieve rmid states joining multisig", async () => {
+    const getKeyStateRet = [
+      {
+        i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
+      },
+    ];
+    // 2 in multi-sig, so 2 for smids and then fail on rmids
+    getKeyStateMock = jest
+      .fn()
+      .mockResolvedValueOnce(getKeyStateRet)
+      .mockResolvedValueOnce(getKeyStateRet)
+      .mockResolvedValue([]);
+    await expect(
+      api.joinMultisig(multisigIcpExn, multisigMember, utils.uuid())
+    ).rejects.toThrowError(SignifyApi.CANNOT_GET_KEYSTATES_FOR_MULTISIG_MEMBER);
   });
 
   test("should create a new delegation identifier with a random UUID as the name", async () => {
@@ -671,37 +709,6 @@ describe("Signify API", () => {
   });
 
   test("can create Keri multisig rotation", async () => {
-    const aid = {
-      name: "0d5d804a-eb44-42e9-a67a-7e24ab4b7e42",
-      prefix: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-      salty: {},
-      transferable: true,
-      state: {
-        vn: [1, 0],
-        i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-        s: "0",
-        p: "",
-        d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-        f: "0",
-        dt: "2023-12-25T07:37:32.006185+00:00",
-        et: "icp",
-        kt: "1",
-        k: ["DOBaDQOTbreUoqMzCzX0f2ywCB2Qbv17qeHMlm85QjZZ"],
-        nt: "1",
-        n: ["EJqXepNeybydv7fb0FdRsDhWxia6i_bDCv1LyucSegMj"],
-        bt: "1",
-        b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
-        c: [],
-        ee: {
-          s: "0",
-          d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-          br: [],
-          ba: [],
-        },
-        di: "",
-      },
-      windexes: [0],
-    };
     const otherAids = [
       {
         state: {
@@ -730,7 +737,11 @@ describe("Signify API", () => {
         },
       },
     ];
-    const result = await api.rotateMultisigAid(aid, otherAids, utils.uuid());
+    const result = await api.rotateMultisigAid(
+      multisigMember,
+      otherAids,
+      utils.uuid()
+    );
     expect(result).toHaveProperty("op");
     expect(result).toHaveProperty("icpResult");
     expect(exchangeSendMock).toBeCalledWith(
@@ -745,6 +756,7 @@ describe("Signify API", () => {
       ["EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb"]
     );
   });
+
   test("can join Keri multisig rotation", async () => {
     const exn = {
       v: "KERI10JSON0007bf_",
@@ -842,48 +854,11 @@ describe("Signify API", () => {
         d: "EGG3Bma__y5CHGYDlGWKCcJNoO826bIXgrGwJBhz9OyV",
       },
     };
-    const aid = {
-      name: "4130a76b-21d9-4a21-bdd4-40219b157be5",
-      prefix: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-      salty: {
-        sxlt: "1AAHhHKLzBwuO8s6Ntzb0OJ3vd8apYe5SsqAvaA_k3ac-Qu9Om-HHJCUac5Wh0EIuhySrrHYoiJV9KdJrEJiRjLULVdS0UR7T4cv",
-        pidx: 0,
-        kidx: 0,
-        stem: "signify:aid",
-        tier: "low",
-        dcode: "E",
-        icodes: ["A"],
-        ncodes: ["A"],
-        transferable: true,
-      },
-      transferable: true,
-      state: {
-        vn: [1, 0],
-        i: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-        s: "0",
-        p: "",
-        d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-        f: "0",
-        dt: "2023-12-25T07:36:32.350862+00:00",
-        et: "icp",
-        kt: "1",
-        k: ["DIDpyM3TPrV5-ZwpiFDU9HtI9-zXpHtOGLNzfUrzLOs5"],
-        nt: "1",
-        n: ["EMnyXeI28CtemqNmxget-4Xn1DrKehDect1qHwfREo1u"],
-        bt: "1",
-        b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
-        c: [],
-        ee: {
-          s: "0",
-          d: "EJz3axjzmaJOracwpOXTyxtghohwAK7ly0qhCq9-5Bsb",
-          br: [],
-          ba: [],
-        },
-        di: "",
-      },
-      windexes: [0],
-    };
-    const result = await api.joinMultisigRotation(exn, aid, utils.uuid());
+    const result = await api.joinMultisigRotation(
+      exn,
+      multisigMember,
+      utils.uuid()
+    );
     expect(result).toHaveProperty("op");
     expect(result).toHaveProperty("icpResult");
     expect(result).toHaveProperty("name");
@@ -907,37 +882,6 @@ describe("Signify API", () => {
   });
 
   test("should throw error if the threshold is invalid", async () => {
-    const aid = {
-      name: "0d5d804a-eb44-42e9-a67a-7e24ab4b7e42",
-      prefix: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-      salty: {},
-      transferable: true,
-      state: {
-        vn: [1, 0],
-        i: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-        s: "0",
-        p: "",
-        d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-        f: "0",
-        dt: "2023-12-25T07:37:32.006185+00:00",
-        et: "icp",
-        kt: "1",
-        k: ["DOBaDQOTbreUoqMzCzX0f2ywCB2Qbv17qeHMlm85QjZZ"],
-        nt: "1",
-        n: ["EJqXepNeybydv7fb0FdRsDhWxia6i_bDCv1LyucSegMj"],
-        bt: "1",
-        b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"],
-        c: [],
-        ee: {
-          s: "0",
-          d: "EAEMpz0cdBEQN5GSr6NYRYV3PIeF-eBNn64kg4yLFu_7",
-          br: [],
-          ba: [],
-        },
-        di: "",
-      },
-      windexes: [0],
-    };
     const otherAids = [
       {
         state: {
@@ -967,10 +911,10 @@ describe("Signify API", () => {
       },
     ];
     await expect(
-      api.createMultisig(aid, otherAids, utils.uuid(), 5)
+      api.createMultisig(multisigMember, otherAids, utils.uuid(), 5)
     ).rejects.toThrowError(SignifyApi.INVALID_THRESHOLD);
     await expect(
-      api.createMultisig(aid, otherAids, utils.uuid(), 0)
+      api.createMultisig(multisigMember, otherAids, utils.uuid(), 0)
     ).rejects.toThrowError(SignifyApi.INVALID_THRESHOLD);
   });
 });

--- a/src/core/agent/modules/signify/signifyApi.ts
+++ b/src/core/agent/modules/signify/signifyApi.ts
@@ -473,11 +473,15 @@ export class SignifyApi {
     name: string;
   }> {
     const icp = exn.e.icp;
+
+    // @TODO - foconnor: We can skip our member and get state from aid param.
     const states = await Promise.all(
       exn.a.smids.map(
         async (member) => (await this.signifyClient.keyStates().get(member))[0]
       )
     );
+
+    // @TODO - foconnor: Check if smids === rmids, and if so, skip this.
     const rstates = await Promise.all(
       exn.a.rmids.map(
         async (member) => (await this.signifyClient.keyStates().get(member))[0]

--- a/src/core/agent/modules/signify/signifyApi.ts
+++ b/src/core/agent/modules/signify/signifyApi.ts
@@ -21,7 +21,7 @@ import {
   IdentifiersListResult,
   CreateMultisigExnPayload,
   Aid,
-  MultiSigIcpNotification,
+  MultiSigExnMessage,
   MultiSigRoute,
 } from "./signifyApi.types";
 import { KeyStoreKeys, SecureStorage } from "../../../storage";
@@ -394,7 +394,7 @@ export class SignifyApi {
   }
 
   async joinMultisigRotation(
-    exn: MultiSigIcpNotification["exn"],
+    exn: MultiSigExnMessage["exn"],
     aid: Aid,
     name: string
   ): Promise<{
@@ -458,14 +458,12 @@ export class SignifyApi {
       .send(name, "multisig", aid, route, payload, embeds, recp);
   }
 
-  async getNotificationsBySaid(
-    said: string
-  ): Promise<MultiSigIcpNotification[]> {
+  async getMultisigMessageBySaid(said: string): Promise<MultiSigExnMessage[]> {
     return this.signifyClient.groups().getRequest(said);
   }
 
   async joinMultisig(
-    exn: MultiSigIcpNotification["exn"],
+    exn: MultiSigExnMessage["exn"],
     aid: Aid,
     name: string
   ): Promise<{

--- a/src/core/agent/modules/signify/signifyApi.types.ts
+++ b/src/core/agent/modules/signify/signifyApi.types.ts
@@ -64,7 +64,7 @@ export interface Aid {
   windexes: number[];
 }
 
-export interface MultiSigIcpNotification {
+export interface MultiSigExnMessage {
   exn: {
     v: string;
     t: string;

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -31,7 +31,7 @@ const agent = jest.mocked({
       getAllIdentifiers: jest.fn(),
       resolveOobi: jest.fn(),
       createMultisig: jest.fn(),
-      getNotificationsBySaid: jest.fn(),
+      getMultisigMessageBySaid: jest.fn(),
       joinMultisig: jest.fn(),
       createDelegationIdentifier: jest.fn(),
       interactDelegation: jest.fn(),
@@ -841,23 +841,25 @@ describe("Identifier service of agent", () => {
     );
   });
 
-  test("can join the multisig", async () => {
+  test("can join the multisig inception", async () => {
     const multisigIdentifier = "newMultisigIdentifierAid";
     agent.genericRecords.findById = jest.fn().mockResolvedValue({
       content: {
         d: "d",
       },
     });
-    agent.modules.signify.getNotificationsBySaid = jest.fn().mockResolvedValue([
-      {
-        exn: {
-          a: {
-            name: "signifyName",
-            rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+    agent.modules.signify.getMultisigMessageBySaid = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          exn: {
+            a: {
+              name: "signifyName",
+              rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+            },
           },
         },
-      },
-    ]);
+      ]);
 
     agent.modules.signify.joinMultisig = jest.fn().mockResolvedValue({
       op: { name: `group.${multisigIdentifier}`, done: false },
@@ -889,8 +891,8 @@ describe("Identifier service of agent", () => {
     ).toBe(multisigIdentifier);
   });
 
-  test("should not join the multisig", async () => {
-    agent.modules.signify.getNotificationsBySaid = jest
+  test("cannot join multisig by notification if exn messages are missing", async () => {
+    agent.modules.signify.getMultisigMessageBySaid = jest
       .fn()
       .mockResolvedValue([]);
     await expect(
@@ -1330,7 +1332,7 @@ describe("Identifier service of agent", () => {
   });
 
   test("should can join the multisig rotation with no notification and throw error", async () => {
-    agent.modules.signify.getNotificationsBySaid = jest
+    agent.modules.signify.getMultisigMessageBySaid = jest
       .fn()
       .mockResolvedValue([]);
     expect(
@@ -1339,7 +1341,7 @@ describe("Identifier service of agent", () => {
         createdAt: new Date(),
         a: { d: "d" },
       })
-    ).rejects.toThrowError(IdentifierService.SAID_NOTIFICATIONS_NOT_FOUND);
+    ).rejects.toThrowError(IdentifierService.EXN_MESSAGE_NOT_FOUND);
   });
 
   test("should can join the multisig rotation with AID is not multisig and throw error", async () => {
@@ -1361,16 +1363,18 @@ describe("Identifier service of agent", () => {
         d: "d",
       },
     });
-    agent.modules.signify.getNotificationsBySaid = jest.fn().mockResolvedValue([
-      {
-        exn: {
-          a: {
-            name: "signifyName",
-            rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+    agent.modules.signify.getMultisigMessageBySaid = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          exn: {
+            a: {
+              name: "signifyName",
+              rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+            },
           },
         },
-      },
-    ]);
+      ]);
 
     agent.modules.signify.getIdentifierById = jest.fn().mockResolvedValue([
       {
@@ -1407,16 +1411,18 @@ describe("Identifier service of agent", () => {
         d: "d",
       },
     });
-    agent.modules.signify.getNotificationsBySaid = jest.fn().mockResolvedValue([
-      {
-        exn: {
-          a: {
-            name: "signifyName",
-            rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+    agent.modules.signify.getMultisigMessageBySaid = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          exn: {
+            a: {
+              name: "signifyName",
+              rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+            },
           },
         },
-      },
-    ]);
+      ]);
 
     agent.modules.signify.getIdentifierById = jest.fn().mockResolvedValue([
       {
@@ -1454,16 +1460,18 @@ describe("Identifier service of agent", () => {
         d: "d",
       },
     });
-    agent.modules.signify.getNotificationsBySaid = jest.fn().mockResolvedValue([
-      {
-        exn: {
-          a: {
-            name: "signifyName",
-            rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+    agent.modules.signify.getMultisigMessageBySaid = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          exn: {
+            a: {
+              name: "signifyName",
+              rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+            },
           },
         },
-      },
-    ]);
+      ]);
 
     agent.modules.signify.getIdentifierById = jest.fn().mockResolvedValue([
       {

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -57,6 +57,17 @@ const agent = jest.mocked({
 });
 const identifierService = new IdentifierService(agent as any as Agent);
 
+jest.mock("../../../core/agent/agent", () => ({
+  AriesAgent: {
+    agent: {
+      connections: {
+        getConnectionKeriShortDetailById: jest.fn(),
+        getConnections: jest.fn(),
+      },
+    },
+  },
+}));
+
 const now = new Date();
 const nowISO = now.toISOString();
 const colors: [string, string] = ["#fff", "#fff"];
@@ -856,7 +867,8 @@ describe("Identifier service of agent", () => {
           exn: {
             a: {
               name: "signifyName",
-              rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+              smids: ["id"],
+              rmids: ["id"],
             },
           },
         },
@@ -1517,7 +1529,8 @@ describe("Identifier service of agent", () => {
           exn: {
             a: {
               name: "signifyName",
-              rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+              smids: ["id"],
+              rmids: ["id"],
             },
           },
         },
@@ -1556,7 +1569,8 @@ describe("Identifier service of agent", () => {
           exn: {
             a: {
               name: "signifyName",
-              rstates: [{ i: "id", signifyName: "rstateSignifyName" }],
+              smids: ["id"],
+              rmids: ["id"],
             },
           },
         },
@@ -1614,6 +1628,11 @@ describe("Identifier service of agent", () => {
               name: "signifyName",
               smids: ["id", "EHxEwa9UAcThqxuxbq56BYMq7YPWYxA63A1nau2AZ-1A"],
             },
+            e: {
+              icp: {
+                kt: 2,
+              },
+            },
           },
         },
       ]);
@@ -1622,11 +1641,11 @@ describe("Identifier service of agent", () => {
       .fn()
       .mockResolvedValue([identifierMetadata]);
 
-    jest
-      .spyOn(AriesAgent.agent.connections, "getConnectionKeriShortDetailById")
+    AriesAgent.agent.connections.getConnectionKeriShortDetailById = jest
+      .fn()
       .mockResolvedValue(senderData);
-    jest
-      .spyOn(AriesAgent.agent.connections, "getConnections")
+    AriesAgent.agent.connections.getConnections = jest
+      .fn()
       .mockResolvedValue([]);
 
     const result = await identifierService.getMultisigIcpDetails({
@@ -1640,6 +1659,7 @@ describe("Identifier service of agent", () => {
     expect(result.ourIdentifier.id).toBe(identifierMetadata.id);
     expect(result.sender.id).toBe(senderData.id);
     expect(result.otherConnections.length).toBe(0);
+    expect(result.threshold).toBe(2);
   });
 
   test("Throw error if the Multi-sig join request contains unknown AIDs", async () => {
@@ -1681,29 +1701,27 @@ describe("Identifier service of agent", () => {
       .fn()
       .mockResolvedValue([identifierMetadata]);
 
-    jest
-      .spyOn(AriesAgent.agent.connections, "getConnectionKeriShortDetailById")
+    AriesAgent.agent.connections.getConnectionKeriShortDetailById = jest
+      .fn()
       .mockResolvedValue(senderData);
-    jest
-      .spyOn(AriesAgent.agent.connections, "getConnections")
-      .mockResolvedValue([
-        {
-          id: "EHxEwa9UAcThqxuxbq56BYMq7YPWYxA63A1nau2AZ-1A",
-          connectionDate: nowISO,
-          label: "",
-          logo: "logoUrl",
-          status: ConnectionStatus.PENDING,
-          type: ConnectionType.DIDCOMM,
-        },
-        {
-          id: "EDEp4MS9lFGBkV8sKFV0ldqcyiVd1iOEVZAhZnbqk6A3",
-          connectionDate: nowISO,
-          label: "",
-          logo: "logoUrl",
-          status: ConnectionStatus.CONFIRMED,
-          type: ConnectionType.DIDCOMM,
-        },
-      ]);
+    AriesAgent.agent.connections.getConnections = jest.fn().mockResolvedValue([
+      {
+        id: "EHxEwa9UAcThqxuxbq56BYMq7YPWYxA63A1nau2AZ-1A",
+        connectionDate: nowISO,
+        label: "",
+        logo: "logoUrl",
+        status: ConnectionStatus.PENDING,
+        type: ConnectionType.DIDCOMM,
+      },
+      {
+        id: "EDEp4MS9lFGBkV8sKFV0ldqcyiVd1iOEVZAhZnbqk6A3",
+        connectionDate: nowISO,
+        label: "",
+        logo: "logoUrl",
+        status: ConnectionStatus.CONFIRMED,
+        type: ConnectionType.DIDCOMM,
+      },
+    ]);
 
     await expect(
       identifierService.getMultisigIcpDetails({
@@ -1748,6 +1766,11 @@ describe("Identifier service of agent", () => {
                 "senderId",
               ],
             },
+            e: {
+              icp: {
+                kt: 3,
+              },
+            },
           },
         },
       ]);
@@ -1756,21 +1779,19 @@ describe("Identifier service of agent", () => {
       .fn()
       .mockResolvedValue([identifierMetadata]);
 
-    jest
-      .spyOn(AriesAgent.agent.connections, "getConnectionKeriShortDetailById")
+    AriesAgent.agent.connections.getConnectionKeriShortDetailById = jest
+      .fn()
       .mockResolvedValue(senderData);
-    jest
-      .spyOn(AriesAgent.agent.connections, "getConnections")
-      .mockResolvedValue([
-        {
-          id: "EHxEwa9UAcThqxuxbq56BYMq7YPWYxA63A1nau2AZ-1A",
-          connectionDate: nowISO,
-          label: "",
-          logo: "logoUrl",
-          status: ConnectionStatus.PENDING,
-          type: ConnectionType.DIDCOMM,
-        },
-      ]);
+    AriesAgent.agent.connections.getConnections = jest.fn().mockResolvedValue([
+      {
+        id: "EHxEwa9UAcThqxuxbq56BYMq7YPWYxA63A1nau2AZ-1A",
+        connectionDate: nowISO,
+        label: "",
+        logo: "logoUrl",
+        status: ConnectionStatus.PENDING,
+        type: ConnectionType.DIDCOMM,
+      },
+    ]);
     const result = await identifierService.getMultisigIcpDetails({
       id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
       createdAt: new Date("2024-03-08T08:52:10.801Z"),
@@ -1782,6 +1803,10 @@ describe("Identifier service of agent", () => {
     expect(result.ourIdentifier.id).toBe(identifierMetadata.id);
     expect(result.sender.id).toBe(senderData.id);
     expect(result.otherConnections.length).toBe(1);
+    expect(result.otherConnections[0].id).toBe(
+      "EHxEwa9UAcThqxuxbq56BYMq7YPWYxA63A1nau2AZ-1A"
+    );
+    expect(result.threshold).toBe(3);
   });
 
   test("Throw error if we do not control any member AID of the multi-sig", async () => {
@@ -1857,5 +1882,59 @@ describe("Identifier service of agent", () => {
         },
       })
     ).rejects.toThrowError(IdentifierService.CANNOT_JOIN_MULTISIG_ICP);
+  });
+
+  test("cannot get multi-sig details from an unknown sender (missing metadata)", async () => {
+    agent.modules.signify.getMultisigMessageBySaid = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          exn: {
+            a: {
+              name: "signifyName",
+              smids: [
+                "id1",
+                "EHxEwa9UAcThqxuxbq56BYMq7YPWYxA63A1nau2AZ-1A",
+                "senderId",
+              ],
+            },
+          },
+        },
+      ]);
+    // @TODO - foconnor: This is not ideal as our identifier service is getting tightly coupled with the connection service.
+    // Re-work this later.
+    AriesAgent.agent.connections.getConnectionKeriShortDetailById = jest
+      .fn()
+      .mockImplementation(() => {
+        throw new Error("Some error from connection service");
+      });
+    await expect(
+      identifierService.getMultisigIcpDetails({
+        id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
+        createdAt: new Date("2024-03-08T08:52:10.801Z"),
+        a: {
+          r: "/multisig/icp",
+          d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
+        },
+      })
+    ).rejects.toThrowError("Some error from connection service");
+  });
+
+  test("cannot get multi-sig details from a notification with no matching exn message", async () => {
+    agent.modules.signify.getMultisigMessageBySaid = jest
+      .fn()
+      .mockResolvedValue([]);
+    await expect(
+      identifierService.getMultisigIcpDetails({
+        id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
+        createdAt: new Date("2024-03-08T08:52:10.801Z"),
+        a: {
+          r: "/multisig/icp",
+          d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
+        },
+      })
+    ).rejects.toThrowError(
+      `${IdentifierService.EXN_MESSAGE_NOT_FOUND} EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW`
+    );
   });
 });

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -4,6 +4,7 @@ import {
   GetIdentifierResult,
   IdentifierShortDetails,
   IdentifierType,
+  MultiSigIcpRequestDetails,
 } from "./identifierService.types";
 import {
   IdentifierMetadataRecord,
@@ -529,7 +530,9 @@ class IdentifierService extends AgentService {
     return false;
   }
 
-  async getMultisigIcpDetails(notification: KeriNotification) {
+  async getMultisigIcpDetails(
+    notification: KeriNotification
+  ): Promise<MultiSigIcpRequestDetails> {
     const msgSaid = notification.a.d as string;
     const icpMsg: MultiSigExnMessage[] =
       await this.agent.modules.signify.getMultisigMessageBySaid(msgSaid);
@@ -589,6 +592,7 @@ class IdentifierService extends AgentService {
       ourIdentifier,
       sender: senderContact,
       otherConnections,
+      threshold: parseInt(icpMsg[0].exn.e.icp.kt),
     };
   }
 
@@ -613,10 +617,10 @@ class IdentifierService extends AgentService {
       throw new Error(`${IdentifierService.EXN_MESSAGE_NOT_FOUND} ${msgSaid}`);
     }
     const exn = icpMsg[0].exn;
-    const rstate = exn.a.rstates;
+    const smids = exn.a.smids;
     const identifiers = await this.getIdentifiers();
     const identifier = identifiers.find((identifier) => {
-      return rstate.find((item) => identifier.id === item.i);
+      return smids.find((member) => identifier.id === member);
     });
 
     if (!identifier) {

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -65,8 +65,6 @@ class IdentifierService extends AgentService {
     "Cannot find all members of multisig or one of the members does not rotate its AID";
   static readonly CANNOT_JOIN_MULTISIG_ICP =
     "Cannot join multi-sig inception as we do not control any member AID of the multi-sig";
-  static readonly MULTI_SIG_SENDER_AID_CONTACT_MISSING =
-    "Cannot find KERI contact for multi-sig inception event sender";
   static readonly UNKNOWN_AIDS_IN_MULTISIG_ICP =
     "Multi-sig join request contains unknown AIDs (not connected)";
 
@@ -542,13 +540,11 @@ class IdentifierService extends AgentService {
     }
 
     const senderAid = icpMsg[0].exn.i;
+    // @TODO - foconnor: This cross service call should be handled better.
     const senderContact =
       await AriesAgent.agent.connections.getConnectionKeriShortDetailById(
         icpMsg[0].exn.i
       );
-    if (!senderContact) {
-      throw new Error(IdentifierService.MULTI_SIG_SENDER_AID_CONTACT_MISSING);
-    }
 
     const smids = icpMsg[0].exn.a.smids;
     // @TODO - foconnor: These searches should be optimised, revisit.

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -599,6 +599,7 @@ class IdentifierService extends AgentService {
       "displayName" | "colors" | "theme"
     >
   ): Promise<string | undefined> {
+    // @TODO - foconnor: getMultisigDetails already has much of this done so this method signature could be adjusted.
     const msgSaid = notification.a.d as string;
     const hasJoined = await this.hasJoinedMultisig(msgSaid);
     if (hasJoined) {

--- a/src/core/agent/services/identifierService.types.ts
+++ b/src/core/agent/services/identifierService.types.ts
@@ -1,3 +1,5 @@
+import { ConnectionShortDetails } from "../agent.types";
+
 enum IdentifierType {
   KEY = "key",
   KERI = "keri",
@@ -37,6 +39,13 @@ interface KERIDetails extends IdentifierShortDetails {
   di: string;
 }
 
+interface MultiSigIcpRequestDetails {
+  ourIdentifier: IdentifierShortDetails;
+  sender: ConnectionShortDetails;
+  otherConnections: ConnectionShortDetails[];
+  threshold: number;
+}
+
 export { IdentifierType };
 
 export type {
@@ -44,4 +53,5 @@ export type {
   DIDDetails,
   KERIDetails,
   GetIdentifierResult,
+  MultiSigIcpRequestDetails,
 };

--- a/src/ui/components/IdentifierCardInfoKeri/IdentifierCardInfoKeri.tsx
+++ b/src/ui/components/IdentifierCardInfoKeri/IdentifierCardInfoKeri.tsx
@@ -122,7 +122,7 @@ const IdentifierCardInfoKeri = ({ cardData }: IdentifierCardInfoKeriProps) => {
           />
         </CardDetailsBlock>
       )}
-      {cardData.b.length && (
+      {cardData.b.length > 0 && (
         <CardDetailsBlock
           title={i18n.t("identifiers.card.details.backerslist.title")}
         >


### PR DESCRIPTION
## Description

This allows the UI to retrieve details about an incoming multi-sig inception notification event. It will return the connection short details for the other parties, separated by sender and "other" parties who are not you or the sender. It will also return the threshold and the identifier short details that we control (this will help organise the UI after accepting).

There are some comments on optimisations we can make once we have these features in and refactor.

I also added a cli command to the credential service package.json that will launch a CLI multi-sig inception with 2 other parties, Alice and Bob. This makes it a lot easier to test receiving an inception event. (this script can be improved for sure but is a decent first start)

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid GitHub issue or ticket number: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-707)]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
  - Does not have any elements that will affect iOS/Android and will be tested on those platforms with the UI stories that depend on this. 
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)