### PR TITLE
build(core): working cardano-backer 2

### DIFF
--- a/configs/dev-comm.yaml
+++ b/configs/dev-comm.yaml
@@ -1,5 +1,5 @@
 keri:
   backerType: ledger
   ledger:
-    aid: BIbv75IB6gpkqEbWZdfVfDmP4Vbqo-BpHtOksYN3H34K
-    address: addr_test1vrvzszalceqqudxhs9cjmtjyf9klgaz2sepcs7zgnl8c6rq8n39qf
+    aid: BD39IWoiPYhhq5yn2l7FTQykcjhZma1KmfWrWr9ZYUFD
+    address: addr_test1vqefk7cyhcyet03humlzkyl2cj8jwezvr6gu8cg8jrkdq7cf30wpu

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -46,6 +46,13 @@ services:
     entrypoint: vLEI-server -s ./schema/acdc -c ./samples/acdc/ -o ./samples/oobis/
     ports:
       - 7723:7723
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.vlei.rule=Host(`${VLEI_HOST:-vlei-server}`)"
+      - "traefik.http.routers.keria.entrypoints=websecure"
+      - "traefik.http.routers.keria.tls.certresolver=myresolver"
+      - "traefik.http.routers.keria.service=keria"
+      - "traefik.http.services.keria.loadbalancer.server.port=7723"
 
   caddy:
     container_name: caddy
@@ -86,6 +93,8 @@ services:
       context: ../cf-identity-wallet/credential-issuance-server
       dockerfile: ./Dockerfile
     restart: unless-stopped
+    environment:
+      - PORT=3010
     ports:
       - 3010:3010
     labels:

--- a/services/external/keria-config/cf-backer-oobis.json
+++ b/services/external/keria-config/cf-backer-oobis.json
@@ -5,7 +5,7 @@
     "curls": ["http://dev.keria.cf-keripy.metadata.dev.cf-deployments.org:3902/"]
   },
   "iurls": [
-    "http://dev.backer.cf-keripy.metadata.dev.cf-deployments.org:5666/oobi/BIbv75IB6gpkqEbWZdfVfDmP4Vbqo-BpHtOksYN3H34K/controller",
+    "http://dev.backer.cf-keripy.metadata.dev.cf-deployments.org:5666/oobi/BD39IWoiPYhhq5yn2l7FTQykcjhZma1KmfWrWr9ZYUFD/controller",
     "http://dev.keria.cf-keripy.metadata.dev.cf-deployments.org:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller",
     "http://dev.keria.cf-keripy.metadata.dev.cf-deployments.org:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller",
     "http://dev.keria.cf-keripy.metadata.dev.cf-deployments.org:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller" 


### PR DESCRIPTION
One from previous PR had a misconfigured OOBI, and would not generate a new one without losing the AID. This should be improved in the cardano-backer repo.