### PR TITLE
feat(core): reset signify-bran on re-install (dev)

### DIFF
--- a/src/core/storage/secureStorage/secureStorage.test.ts
+++ b/src/core/storage/secureStorage/secureStorage.test.ts
@@ -16,7 +16,7 @@ jest.mock("@aparajita/capacitor-secure-storage", () => ({
   },
 }));
 
-describe("Secure Storage Facade", () => {
+describe("Secure storage service (secure enclave/TEE)", () => {
   test("will throw if an item is missing from the secure storage or return the value if not", async () => {
     expect(await SecureStorage.get(EXISTING_KEY)).toEqual(EXISTING_VALUE);
     expect(SecureStorage.get(NON_EXISTING_KEY)).rejects.toThrow(

--- a/src/core/storage/secureStorage/secureStorage.ts
+++ b/src/core/storage/secureStorage/secureStorage.ts
@@ -8,10 +8,7 @@ enum KeyStoreKeys {
   IDENTITY_ENTROPY = "identity-entropy",
   IDENTITY_ROOT_XPRV_KEY = "identity-root-xprv-key",
   APP_OP_PASSWORD = "app-operations-password",
-  CRYPTO_ENTROPY_PREFIX = "crypto-entropy-",
-  CRYPTO_ROOT_XPRV_KEY_PREFIX = "crypto-root-xprv-key-",
   SIGNIFY_BRAN = "signify-bran",
-  KERI_OOBI = "keri-oobi",
 }
 
 class SecureStorage {

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -74,6 +74,7 @@ jest.mock("@aparajita/capacitor-secure-storage", () => ({
   SecureStorage: {
     set: jest.fn(),
     get: jest.fn(),
+    remove: jest.fn(),
   },
 }));
 

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -241,16 +241,19 @@ const AppWrapper = (props: { children: ReactNode }) => {
   };
 
   const initApp = async () => {
+    // @TODO - foconnor: This is a temp hack for development to be removed pre-release.
+    // These items are removed from the secure storage on re-install to re-test the on-boarding for iOS devices.
     try {
       const isInitialized = await PreferencesStorage.get(
         PreferencesKeys.APP_ALREADY_INIT
       );
       dispatch(setInitialized(isInitialized?.initialized as boolean));
     } catch (e) {
-      // TODO
-      await SecureStorage.set(KeyStoreKeys.IDENTITY_ENTROPY, "");
-      await SecureStorage.set(KeyStoreKeys.IDENTITY_ROOT_XPRV_KEY, "");
-      await SecureStorage.set(KeyStoreKeys.APP_PASSCODE, "");
+      await SecureStorage.delete(KeyStoreKeys.APP_PASSCODE);
+      await SecureStorage.delete(KeyStoreKeys.IDENTITY_ENTROPY);
+      await SecureStorage.delete(KeyStoreKeys.IDENTITY_ROOT_XPRV_KEY);
+      await SecureStorage.delete(KeyStoreKeys.APP_OP_PASSWORD);
+      await SecureStorage.delete(KeyStoreKeys.SIGNIFY_BRAN);
     }
 
     await new ConfigurationService().start();


### PR DESCRIPTION
Secure storage items (at least on on iOS) are persisted across installs (as they should be). But for dev purposes until we have a proper release we clear this so we can re-show onboarding and also reset the Signify bran in case there is a cloud tenant issue. So signify bran is also reset now.