### PR TITLE
feat(core): support for OOBI aliases

### DIFF
--- a/services/credential-issuance-server/src/ariesAgent.ts
+++ b/services/credential-issuance-server/src/ariesAgent.ts
@@ -229,7 +229,7 @@ class AriesAgent {
   }
 
   async createKeriOobi() {
-    return this.agent.modules.signify.getOobi(AriesAgent.ISSUER_AID_NAME);
+    return `${await this.agent.modules.signify.getOobi(AriesAgent.ISSUER_AID_NAME)}?name=CF%20Credential%20Issuance`;
   }
 
   async resolveOobi(url: string) {

--- a/src/core/agent/modules/signify/signifyApi.test.ts
+++ b/src/core/agent/modules/signify/signifyApi.test.ts
@@ -9,7 +9,7 @@ const secondAid = "aid2";
 const aidPrefix = "keri-";
 const witnessPrefix = "witness.";
 const uuidToThrow = "throwMe";
-const oobiPrefix = "oobi.";
+const oobiPrefix = "http://server.com/oobi/";
 
 let connectMock = jest.fn();
 const bootMock = jest.fn();
@@ -384,9 +384,8 @@ describe("Signify API", () => {
     expect(await api.getOobi(mockName)).toEqual(oobiPrefix + mockName);
   });
 
-  test("can resolve oobi", async () => {
-    const aid = "keriuuid";
-    const url = oobiPrefix + aid;
+  test("can resolve oobi with no name parameter", async () => {
+    const url = `${oobiPrefix}keriuuid`;
     const op = await api.resolveOobi(url);
     expect(op).toEqual({
       name: url,
@@ -395,11 +394,20 @@ describe("Signify API", () => {
     });
   });
 
+  test("can resolve oobi with a name parameter (URL decoded)", async () => {
+    const url = `${oobiPrefix}keriuuid?name=alias%20with%20spaces`;
+    const op = await api.resolveOobi(url);
+    expect(op).toEqual({
+      name: url,
+      alias: "alias with spaces",
+      done: true,
+    });
+  });
+
   test("should timeout if oobi resolving is not completing", async () => {
-    const url = oobiPrefix + uuidToThrow;
-    await expect(api.resolveOobi(url)).rejects.toThrowError(
-      SignifyApi.FAILED_TO_RESOLVE_OOBI
-    );
+    await expect(
+      api.resolveOobi(`${oobiPrefix}${uuidToThrow}`)
+    ).rejects.toThrowError(SignifyApi.FAILED_TO_RESOLVE_OOBI);
   });
 
   test("should get contacts successfully", async () => {

--- a/src/core/agent/modules/signify/signifyApi.ts
+++ b/src/core/agent/modules/signify/signifyApi.ts
@@ -173,11 +173,11 @@ export class SignifyApi {
     return this.signifyClient.contacts().delete(id);
   }
 
-  async resolveOobi(url: string, alias?: string): Promise<any> {
+  async resolveOobi(url: string): Promise<any> {
     if (SignifyApi.resolvedOobi[url]) {
       return SignifyApi.resolvedOobi[url];
     }
-    alias = alias ?? utils.uuid();
+    const alias = new URL(url).searchParams.get("name") ?? utils.uuid();
     const operation = await this.waitAndGetDoneOp(
       await this.signifyClient.oobis().resolve(url, alias),
       this.opTimeout,

--- a/src/core/agent/modules/signify/signifyApi.ts
+++ b/src/core/agent/modules/signify/signifyApi.ts
@@ -173,14 +173,13 @@ export class SignifyApi {
     return this.signifyClient.contacts().delete(id);
   }
 
-  async resolveOobi(url: string): Promise<any> {
+  async resolveOobi(url: string, alias?: string): Promise<any> {
     if (SignifyApi.resolvedOobi[url]) {
       return SignifyApi.resolvedOobi[url];
     }
-    const alias = utils.uuid();
-    let operation = await this.signifyClient.oobis().resolve(url, alias);
-    operation = await this.waitAndGetDoneOp(
-      operation,
+    alias = alias ?? utils.uuid();
+    const operation = await this.waitAndGetDoneOp(
+      await this.signifyClient.oobis().resolve(url, alias),
       this.opTimeout,
       this.opRetryInterval
     );

--- a/src/core/agent/services/connectionService.test.ts
+++ b/src/core/agent/services/connectionService.test.ts
@@ -625,7 +625,7 @@ describe("Connection service of agent", () => {
       ConnectionType.KERI
     );
     expect(basicStorage.deleteById).toBeCalledWith(connectionId);
-    expect(signifyApi.deleteContactById).toBeCalledWith(connectionId);
+    // expect(signifyApi.deleteContactById).toBeCalledWith(connectionId);  // @TODO - foconnor: Re-enable once KERIA fixed.
     await connectionService.deleteConnectionById(
       connectionId,
       ConnectionType.DIDCOMM
@@ -694,6 +694,20 @@ describe("Connection service of agent", () => {
     const signifyName = "keriuuid";
     const KeriOobi = await connectionService.getKeriOobi(signifyName);
     expect(KeriOobi).toEqual(oobiPrefix + signifyName);
+  });
+
+  test("can get a KERI OOBI with an alias (URL encoded)", async () => {
+    signifyApi.getOobi = jest.fn().mockImplementation((name: string) => {
+      return `${oobiPrefix}${name}`;
+    });
+    const signifyName = "keriuuid";
+    const KeriOobi = await connectionService.getKeriOobi(
+      signifyName,
+      "alias with spaces"
+    );
+    expect(KeriOobi).toEqual(
+      `${oobiPrefix}${signifyName}?name=alias%20with%20spaces`
+    );
   });
 
   test("Should call createIdentifierMetadataRecord when there are un-synced KERI contacts", async () => {

--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -135,11 +135,10 @@ class ConnectionService extends AgentService {
         }
       );
 
-      const alias = new URL(url).searchParams.get("name") ?? undefined;
-      const operation = await this.signifyApi.resolveOobi(url, alias);
+      const operation = await this.signifyApi.resolveOobi(url);
       const connectionId = operation.response.i;
       await this.createConnectionKeriMetadata(connectionId, {
-        alias: alias ?? operation.alias,
+        alias: operation.alias,
         oobi: url,
       });
 


### PR DESCRIPTION
## Description

If an OOBI we are resolving contains the `name` query parameter as in the [OOBI](https://github.com/WebOfTrust/ietf-oobi) spec, this will be used as the alias for that new KERI contact.

Likewise, we can also assign a name to OOBIs we generate for a KERI AID.

Finally, I also disabled deleting a contact from KERIA - I have a task on Jira to uncomment this, but this behaviour is broken in KERIA as far as I can tell and so lets just remove it for now.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[supporting this UI ticket](https://cardanofoundation.atlassian.net/browse/DTIS-760)]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser. - n/a
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
