### PR TITLE
bugfix(ui): Cannot delete a connection without app reload

### DIFF
--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -277,11 +277,11 @@ const AppWrapper = (props: { children: ReactNode }) => {
       await keriNotificationsChangeHandler(message, dispatch);
     });
     // Fetch and sync the identifiers, contacts and ACDCs from KERIA to our storage
-    await Promise.all([
-      AriesAgent.agent.identifiers.syncKeriaIdentifiers(),
-      AriesAgent.agent.connections.syncKeriaContacts(),
-      AriesAgent.agent.credentials.syncACDCs(),
-    ]);
+    // await Promise.all([
+    //   AriesAgent.agent.identifiers.syncKeriaIdentifiers(),
+    //   AriesAgent.agent.connections.syncKeriaContacts(),
+    //   AriesAgent.agent.credentials.syncACDCs(),
+    // ]);
   };
 
   // @TODO - foconnor: We should allow the app to load and give more accurate feedback - this is a temp solution.

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -75,9 +75,8 @@ const Scanner = forwardRef(({ setIsValueCaptured }: ScannerProps, ref) => {
           // and it can update to an error if the QR is invalid with a re-scan btn
           dispatch(setCurrentOperation(OperationType.IDLE));
           // @TODO - foconnor: when above loading screen in place, handle invalid QR code
-          await AriesAgent.agent.connections.receiveInvitationFromUrl(
-            result.content
-          );
+          // @TODO - sdisalvo: receiveInvitationFromUrl should be awaited once we have error handling
+          AriesAgent.agent.connections.receiveInvitationFromUrl(result.content);
           setIsValueCaptured && setIsValueCaptured(true);
         }
       }

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -17,8 +17,9 @@ import {
 import { TabsRoutePath } from "../navigation/TabsMenu";
 import { OperationType, ToastMsgType } from "../../globals/types";
 import { AriesAgent } from "../../../core/agent/agent";
+import ScannerProps from "./Scanner.types";
 
-const Scanner = forwardRef((props, ref) => {
+const Scanner = forwardRef(({ setIsValueCaptured }: ScannerProps, ref) => {
   const dispatch = useAppDispatch();
   const currentOperation = useAppSelector(getCurrentOperation);
   const currentToastMsg = useAppSelector(getToastMsg);
@@ -77,6 +78,7 @@ const Scanner = forwardRef((props, ref) => {
           await AriesAgent.agent.connections.receiveInvitationFromUrl(
             result.content
           );
+          setIsValueCaptured && setIsValueCaptured(true);
         }
       }
     }

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -17,7 +17,7 @@ import {
 import { TabsRoutePath } from "../navigation/TabsMenu";
 import { OperationType, ToastMsgType } from "../../globals/types";
 import { AriesAgent } from "../../../core/agent/agent";
-import ScannerProps from "./Scanner.types";
+import { ScannerProps } from "./Scanner.types";
 
 const Scanner = forwardRef(({ setIsValueCaptured }: ScannerProps, ref) => {
   const dispatch = useAppDispatch();

--- a/src/ui/components/Scanner/Scanner.types.ts
+++ b/src/ui/components/Scanner/Scanner.types.ts
@@ -1,5 +1,4 @@
 interface ScannerProps {
-  isValueCaptured?: boolean;
   setIsValueCaptured?: (value: boolean) => void;
 }
-export default ScannerProps;
+export type { ScannerProps };

--- a/src/ui/components/Scanner/Scanner.types.ts
+++ b/src/ui/components/Scanner/Scanner.types.ts
@@ -1,0 +1,5 @@
+interface ScannerProps {
+  isValueCaptured?: boolean;
+  setIsValueCaptured?: (value: boolean) => void;
+}
+export default ScannerProps;

--- a/src/ui/pages/Scan/Scan.tsx
+++ b/src/ui/pages/Scan/Scan.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useIonViewWillEnter } from "@ionic/react";
 import { TabLayout } from "../../components/layout/TabLayout";
@@ -15,7 +15,6 @@ import "./Scan.scss";
 import { DataProps } from "../../../routes/nextRoute/nextRoute.types";
 import { getNextRoute } from "../../../routes/nextRoute";
 import { updateReduxState } from "../../../store/utils";
-import { OperationType } from "../../globals/types";
 
 const Scan = () => {
   const pageId = "scan-tab";
@@ -24,13 +23,14 @@ const Scan = () => {
   const stateCache = useAppSelector(getStateCache);
   const currentOperation = useAppSelector(getCurrentOperation);
   const currentToastMsg = useAppSelector(getToastMsg);
+  const [isValueCaptured, setIsValueCaptured] = useState(false);
 
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.SCAN }));
   });
 
   useEffect(() => {
-    if (currentOperation !== OperationType.IDLE) {
+    if (isValueCaptured) {
       const data: DataProps = {
         store: { stateCache },
         state: {
@@ -44,15 +44,19 @@ const Scan = () => {
         pathname: nextPath.pathname,
         state: data.state,
       });
+      setIsValueCaptured(false);
     }
-  }, [currentToastMsg, currentOperation]);
+  }, [currentToastMsg, currentOperation, isValueCaptured]);
 
   return (
     <TabLayout
       pageId={pageId}
       header={false}
     >
-      <Scanner />
+      <Scanner
+        isValueCaptured={isValueCaptured}
+        setIsValueCaptured={setIsValueCaptured}
+      />
     </TabLayout>
   );
 };

--- a/src/ui/pages/Scan/Scan.tsx
+++ b/src/ui/pages/Scan/Scan.tsx
@@ -53,10 +53,7 @@ const Scan = () => {
       pageId={pageId}
       header={false}
     >
-      <Scanner
-        isValueCaptured={isValueCaptured}
-        setIsValueCaptured={setIsValueCaptured}
-      />
+      <Scanner setIsValueCaptured={setIsValueCaptured} />
     </TabLayout>
   );
 };


### PR DESCRIPTION
## Description

This PR is fixing the bug that we noticed when deleting a freshly created connection.

While doing our investigation we noticed that this was only happening when the connection was being created by using the tab scanner instead of the one in the tab menu at the top. We went to the bottom of it and found that the issue was caused by the useEffect still running after we’ve redirected after the scan.

When we click the delete button, it changes `currentOperation` in Redux, which triggers this useEffect and does a history.push containing the `currentOperation` and `toastMsg`, overwriting the `history.location.state` from when we initially loaded the connection details page.

We came to the conclusion that the redirection should probably be handled by the scanner itself so that it redirects once the scan is done, and not waiting for a notification of a connection being received, therefore we added a prop to the Scanner component that will send back a state to let the Scan page know that we're done scanning.

**Note:**

Not testing on all devices since the changes won't introduce any new elements of UI. This time I will just add a video of the test I made in the browser.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-768**](https://cardanofoundation.atlassian.net/browse/DTIS-768)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/119612231/e882b61b-db7b-43e1-9abb-3e124cb3fe6c

