### PR TITLE
feat(core): set name/alias when resolving via test credential server

### DIFF
--- a/services/credential-issuance-server/src/modules/signify/signifyApi.ts
+++ b/services/credential-issuance-server/src/modules/signify/signifyApi.ts
@@ -74,11 +74,10 @@ export class SignifyApi {
   }
 
   async resolveOobi(url: string): Promise<any> {
-    const alias = uuidv4();
-    let operation = await this.signifyClient.oobis().resolve(url, alias);
-    operation = await waitAndGetDoneOp(
+    const alias = new URL(url).searchParams.get("name") ?? uuidv4();
+    const operation = await waitAndGetDoneOp(
       this.signifyClient,
-      operation,
+      await this.signifyClient.oobis().resolve(url, alias),
       this.opTimeout,
       this.opRetryInterval
     );

--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -17,6 +17,7 @@ import { IdentifierType } from "./identifierService.types";
 import { KeriContact } from "../modules/signify/signifyApi.types";
 import { BasicRecord } from "../records";
 import { RecordType } from "../../storage/storage.types";
+import { PreferencesKeys, PreferencesStorage } from "../../storage";
 
 class ConnectionService extends AgentService {
   // static readonly NOT_FOUND_DOMAIN_CONFIG_ERROR_MSG =
@@ -65,9 +66,24 @@ class ConnectionService extends AgentService {
           (identifier) => identifier.method === IdentifierType.KERI
         );
         if (aid && aid.signifyName) {
+          let userName;
+          try {
+            userName = (
+              await PreferencesStorage.get(PreferencesKeys.APP_USER_NAME)
+            ).userName as string;
+          } catch (error) {
+            if (
+              (error as Error).message !==
+              `${PreferencesStorage.KEY_NOT_FOUND} ${PreferencesKeys.APP_USER_NAME}`
+            ) {
+              throw error;
+            }
+          }
+
           // signifyName should always be set
           const oobi = await AriesAgent.agent.connections.getKeriOobi(
-            aid.signifyName
+            aid.signifyName,
+            userName
           );
           await (
             await fetch(


### PR DESCRIPTION
We still have this "hack" in our wallet where we use a resolve OOBI endpoint on our test credential server to allow the server to find our wallet. Since we now have a name we can pass to this, this PR passes that through too.

It also updates the cred server to recognise the name/alias query parameter rather than defaulting to a UUID.