### PR TITLE
fix(ui): fix connection note content not update after save

### DIFF
--- a/src/ui/components/layout/PageLayout/PageLayout.tsx
+++ b/src/ui/components/layout/PageLayout/PageLayout.tsx
@@ -34,29 +34,24 @@ const PageLayout = ({
   return (
     <>
       {header && (
-        <IonHeader
-          translucent={true}
-          className="ion-no-border page-header"
-        >
-          <PageHeader
-            backButton={backButton}
-            beforeBack={beforeBack}
-            onBack={onBack}
-            currentPath={currentPath}
-            closeButton={closeButton}
-            closeButtonAction={closeButtonAction}
-            closeButtonLabel={closeButtonLabel}
-            actionButton={actionButton}
-            actionButtonDisabled={actionButtonDisabled}
-            actionButtonAction={actionButtonAction}
-            actionButtonLabel={actionButtonLabel}
-            actionButtonIcon={actionButtonIcon}
-            progressBar={progressBar}
-            progressBarValue={progressBarValue}
-            progressBarBuffer={progressBarBuffer}
-            title={title}
-          />
-        </IonHeader>
+        <PageHeader
+          backButton={backButton}
+          beforeBack={beforeBack}
+          onBack={onBack}
+          currentPath={currentPath}
+          closeButton={closeButton}
+          closeButtonAction={closeButtonAction}
+          closeButtonLabel={closeButtonLabel}
+          actionButton={actionButton}
+          actionButtonDisabled={actionButtonDisabled}
+          actionButtonAction={actionButtonAction}
+          actionButtonLabel={actionButtonLabel}
+          actionButtonIcon={actionButtonIcon}
+          progressBar={progressBar}
+          progressBarValue={progressBarValue}
+          progressBarBuffer={progressBarBuffer}
+          title={title}
+        />
       )}
 
       <IonContent>{children}</IonContent>

--- a/src/ui/pages/ConnectionDetails/components/ConnectionDetailsHeader.tsx
+++ b/src/ui/pages/ConnectionDetails/components/ConnectionDetailsHeader.tsx
@@ -15,8 +15,8 @@ const ConnectionDetailsHeader = ({
           alt="connection-logo"
         />
       </div>
-      <h2>{label}</h2>
-      <p>{formatShortDate(`${date}`)}</p>
+      <h2 data-testid="connection-name">{label}</h2>
+      <p data-testid="data-connection-time">{formatShortDate(`${date}`)}</p>
     </div>
   );
 };

--- a/src/ui/pages/ConnectionDetails/components/ConnectionNote.test.tsx
+++ b/src/ui/pages/ConnectionDetails/components/ConnectionNote.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render } from "@testing-library/react";
+import { waitForIonicReact } from "@ionic/react-test-utils";
+import { ConnectionNote } from "./ConnectionNote";
+
+describe("Connection Note", () => {
+  test("Render connection note", async () => {
+    const handleUpdate = jest.fn();
+    const handleDelete = jest.fn();
+
+    const { getByTestId } = render(
+      <ConnectionNote
+        data={{
+          id: "1",
+          title: "note 1",
+          message: "note 2",
+        }}
+        onDeleteNote={handleDelete}
+        onNoteDataChange={handleUpdate}
+      />
+    );
+
+    await waitForIonicReact();
+
+    const titleInput = getByTestId("edit-connections-modal-note-title-1");
+    const messageInput = getByTestId("edit-connections-modal-note-message-1");
+
+    expect(titleInput.querySelector("input")?.value).toBe("note 1");
+    expect(messageInput.querySelector("textarea")?.value).toBe("note 2");
+  });
+
+  test("Fire delete action when click delete", async () => {
+    const handleUpdate = jest.fn();
+    const handleDelete = jest.fn();
+
+    const { getByTestId } = render(
+      <ConnectionNote
+        data={{
+          id: "1",
+          title: "note 1",
+          message: "note 2",
+        }}
+        onDeleteNote={handleDelete}
+        onNoteDataChange={handleUpdate}
+      />
+    );
+
+    await waitForIonicReact();
+
+    const deleteButton = getByTestId("note-delete-button-1");
+
+    fireEvent.click(deleteButton);
+
+    expect(handleDelete).toBeCalledTimes(1);
+  });
+});

--- a/src/ui/pages/ConnectionDetails/components/ConnectionNote.tsx
+++ b/src/ui/pages/ConnectionDetails/components/ConnectionNote.tsx
@@ -5,38 +5,41 @@ import { i18n } from "../../../../i18n";
 import { ConnectionNoteProps } from "./ConnectionNote.types";
 
 const ConnectionNote = ({
-  title,
-  message,
-  id,
-  notes,
-  currentNoteId,
-  setAlertDeleteNoteIsOpen,
-  setNotes,
+  data,
+  onNoteDataChange,
+  onDeleteNote,
 }: ConnectionNoteProps) => {
+  const { title, message, id } = data;
   const [newTitle, setNewTitle] = useState(title);
   const [newMessage, setNewMessage] = useState(message);
   const TITLE_MAX_LENGTH = 64;
   const MESSAGE_MAX_LENGTH = 576;
 
+  const submitNoteChange = () => {
+    onNoteDataChange({
+      id: id,
+      title: newTitle,
+      message: newMessage,
+    });
+  };
+
   return (
-    <div className="connection-details-info-block-inner">
+    <div
+      data-testid="connection-note"
+      className="connection-details-info-block-inner"
+    >
       <div className="connection-details-info-block-line">
         <div className="connection-details-info-block-data">
           <div className="connection-details-info-block-title">
             <span>{i18n.t("connections.details.title")}</span>
-            <span>
+            <span data-testid="title-length">
               {newTitle.length}/{TITLE_MAX_LENGTH}
             </span>
           </div>
           <IonInput
             data-testid={`edit-connections-modal-note-title-${id}`}
-            onIonChange={(e) => setNewTitle(`${e.target.value ?? ""}`)}
-            onIonBlur={(e) => {
-              const newNotes = [...notes];
-              const noteIndex = newNotes.map((el) => el.id).indexOf(id);
-              newNotes[noteIndex].title = e.target.value?.toString() ?? "";
-              setNotes(newNotes);
-            }}
+            onIonInput={(e) => setNewTitle(`${e.target.value ?? ""}`)}
+            onIonBlur={submitNoteChange}
             value={newTitle}
           />
         </div>
@@ -50,13 +53,8 @@ const ConnectionNote = ({
           <IonTextarea
             autoGrow={true}
             data-testid={`edit-connections-modal-note-message-${id}`}
-            onIonChange={(e) => setNewMessage(`${e.target.value ?? ""}`)}
-            onIonBlur={(e) => {
-              const newNotes = [...notes];
-              const noteIndex = newNotes.map((el) => el.id).indexOf(id);
-              newNotes[noteIndex].message = e.target.value?.toString() ?? "";
-              setNotes(newNotes);
-            }}
+            onIonInput={(e) => setNewMessage(`${e.target.value ?? ""}`)}
+            onIonBlur={submitNoteChange}
             value={newMessage}
           />
         </div>
@@ -65,9 +63,9 @@ const ConnectionNote = ({
         <IonButton
           shape="round"
           color={"danger"}
+          data-testid={`note-delete-button-${id}`}
           onClick={() => {
-            currentNoteId = id;
-            setAlertDeleteNoteIsOpen(true);
+            onDeleteNote(id);
           }}
         >
           <IonIcon

--- a/src/ui/pages/ConnectionDetails/components/ConnectionNote.types.ts
+++ b/src/ui/pages/ConnectionDetails/components/ConnectionNote.types.ts
@@ -1,13 +1,9 @@
 import { ConnectionNoteDetails } from "../../../../core/agent/agent.types";
 
 interface ConnectionNoteProps {
-  title: string;
-  message: string;
-  id: string;
-  notes: ConnectionNoteProps[];
-  currentNoteId: string;
-  setAlertDeleteNoteIsOpen: (isOpen: boolean) => void;
-  setNotes: (value: ConnectionNoteDetails[]) => void;
+  data: ConnectionNoteDetails;
+  onDeleteNote: (noteId: string) => void;
+  onNoteDataChange: (noteData: ConnectionNoteDetails) => void;
 }
 
 export type { ConnectionNoteProps };

--- a/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.scss
+++ b/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.scss
@@ -6,6 +6,12 @@
   .modal {
     border-radius: 0;
 
+    .page-header {
+      ion-toolbar {
+        --background: transparent;
+      }
+    }
+
     .close-button-label,
     .action-button-label {
       margin: 0;

--- a/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.scss
+++ b/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.scss
@@ -29,21 +29,30 @@
     }
 
     .action-button-label {
-      color: var(--ion-color-action-blue) !important;
+      & > p {
+        color: var(--ion-color-action-blue) !important;
+      }
     }
 
     .connection-details-info-block {
       margin-top: 1.5rem;
       padding-bottom: 10rem;
+      color: var(--ion-color-secondary);
 
       h3 {
         margin-bottom: 2.94rem;
+        margin-left: 1.25rem;
+        font-weight: 500;
+        color: var(--ion-color-secondary);
       }
     }
 
     .connection-details-info-block-inner {
       position: relative;
       margin-bottom: 2.94rem;
+      padding: 1.25rem;
+      border-radius: 1rem;
+      background-color: white;
 
       .connection-details-delete-note {
         position: absolute;
@@ -100,7 +109,7 @@
       }
 
       ion-input {
-        margin-bottom: 1.56rem;
+        margin-bottom: 1.5rem;
       }
     }
 
@@ -142,6 +151,31 @@
     .close-button-label,
     .close-button-label.md {
       font-size: 1rem;
+    }
+  }
+
+  @media screen and (min-width: 250px) and (max-width: 370px) {
+    .modal {
+      .connection-details-info-block {
+        h3 {
+          font-size: 0.8rem;
+          margin-bottom: 1.75rem;
+        }
+      }
+
+      .connection-details-info-block-title {
+        font-size: 0.8rem;
+
+        span:last-child {
+          font-size: 0.775rem;
+          font-weight: 400;
+        }
+      }
+
+      ion-input,
+      ion-textarea {
+        font-size: 0.8rem;
+      }
     }
   }
 }

--- a/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.test.tsx
+++ b/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.test.tsx
@@ -1,0 +1,270 @@
+import {
+  mockIonicReact,
+  ionFireEvent,
+  waitForIonicReact,
+} from "@ionic/react-test-utils";
+mockIonicReact();
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { act } from "react-dom/test-utils";
+import { TabsRoutePath } from "../../../../routes/paths";
+import { connectionsFix } from "../../../__fixtures__/connectionsFix";
+import { filteredCredsFix } from "../../../__fixtures__/filteredCredsFix";
+import {
+  EditConnectionsContainer,
+  EditConnectionsModal,
+} from "./EditConnectionsModal";
+import { formatShortDate } from "../../../utils/formatters";
+import EN_TRANSLATIONS from "../../../../locales/en/en.json";
+
+jest.mock("../../../../core/agent/agent", () => ({
+  Agent: {
+    agent: {
+      connections: {
+        createConnectionNote: jest.fn(),
+        deleteConnectionNoteById: jest.fn(),
+        updateConnectionNoteById: jest.fn(),
+      },
+    },
+  },
+}));
+
+const mockStore = configureStore();
+const dispatchMock = jest.fn();
+const initialStateFull = {
+  stateCache: {
+    routes: [TabsRoutePath.CREDENTIALS],
+    authentication: {
+      loggedIn: true,
+      time: Date.now(),
+      passcodeIsSet: true,
+    },
+  },
+  seedPhraseCache: {},
+  credsCache: {
+    creds: filteredCredsFix,
+  },
+  connectionsCache: {
+    connections: connectionsFix,
+  },
+};
+
+const mockNow = 1466424490000;
+let dateSpy: any;
+
+describe("Edit Connection Modal", () => {
+  beforeAll(() => {
+    dateSpy = jest.spyOn(Date, "now").mockReturnValue(mockNow);
+  });
+
+  afterAll(() => {
+    dateSpy.mockRestore();
+  });
+
+  test("Render edit connection modal: empty note", async () => {
+    const storeMocked = {
+      ...mockStore(initialStateFull),
+      dispatch: dispatchMock,
+    };
+    const { getByTestId, queryByTestId, getByText } = render(
+      <Provider store={storeMocked}>
+        <EditConnectionsModal
+          onConfirm={jest.fn()}
+          modalIsOpen={true}
+          setModalIsOpen={jest.fn()}
+          setNotes={jest.fn()}
+          notes={[]}
+          connectionDetails={connectionsFix[0]}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("connection-name").innerHTML).toBe(
+        connectionsFix[0].label
+      );
+    });
+    expect(getByTestId("data-connection-time").innerHTML).toBe(
+      formatShortDate(connectionsFix[0].connectionDate)
+    );
+    expect(getByTestId("action-button")).toBeVisible();
+    expect(getByTestId("close-button")).toBeVisible();
+    expect(getByTestId("add-note-button")).toBeVisible();
+    expect(
+      getByText(EN_TRANSLATIONS.connections.details.nocurrentnotes)
+    ).toBeVisible();
+  });
+
+  test("Render edit connection modal", async () => {
+    const storeMocked = {
+      ...mockStore(initialStateFull),
+      dispatch: dispatchMock,
+    };
+    const { getByTestId } = render(
+      <Provider store={storeMocked}>
+        <EditConnectionsContainer
+          onConfirm={jest.fn()}
+          modalIsOpen={true}
+          setModalIsOpen={jest.fn()}
+          setNotes={jest.fn()}
+          notes={[
+            {
+              id: "1",
+              title: "Mock Note",
+              message: "Mock Note",
+            },
+          ]}
+          connectionDetails={connectionsFix[0]}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("connection-name").innerHTML).toBe(
+        connectionsFix[0].label
+      );
+    });
+
+    await waitFor(() => {
+      const titleInput = getByTestId("edit-connections-modal-note-title-1");
+      const messageInput = getByTestId("edit-connections-modal-note-message-1");
+
+      expect(titleInput.querySelector("input")?.value).toBe("Mock Note");
+      expect(messageInput.querySelector("textarea")?.value).toBe("Mock Note");
+    });
+  });
+
+  test("Display delete note alert", async () => {
+    const storeMocked = {
+      ...mockStore(initialStateFull),
+      dispatch: dispatchMock,
+    };
+    const { getByTestId, getByText, getAllByTestId } = render(
+      <Provider store={storeMocked}>
+        <EditConnectionsContainer
+          onConfirm={jest.fn()}
+          modalIsOpen={true}
+          setModalIsOpen={jest.fn()}
+          setNotes={jest.fn()}
+          notes={[
+            {
+              id: "1",
+              title: "Mock Note",
+              message: "Mock Note",
+            },
+          ]}
+          connectionDetails={connectionsFix[0]}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("connection-name").innerHTML).toBe(
+        connectionsFix[0].label
+      );
+    });
+
+    await waitFor(() => {
+      const titleInput = getByTestId("edit-connections-modal-note-title-1");
+      expect(titleInput.querySelector("input")?.value).toBe("Mock Note");
+      expect(getByTestId("note-delete-button-1")).toBeVisible();
+    });
+
+    const deleteButton = getByTestId("note-delete-button-1");
+
+    act(() => {
+      ionFireEvent.click(deleteButton);
+    });
+
+    await waitFor(() => {
+      expect(getAllByTestId("alert-confirm-delete-note")[0]).toBeVisible();
+    });
+  });
+
+  test("Add note", async () => {
+    const storeMocked = {
+      ...mockStore(initialStateFull),
+      dispatch: dispatchMock,
+    };
+    const { getByTestId, getAllByTestId } = render(
+      <Provider store={storeMocked}>
+        <EditConnectionsContainer
+          onConfirm={jest.fn()}
+          modalIsOpen={true}
+          setModalIsOpen={jest.fn()}
+          setNotes={jest.fn()}
+          notes={[]}
+          connectionDetails={connectionsFix[0]}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("connection-name").innerHTML).toBe(
+        connectionsFix[0].label
+      );
+    });
+
+    act(() => {
+      fireEvent.click(getByTestId("add-note-button"));
+    });
+
+    await waitFor(() => {
+      expect(getAllByTestId("connection-note").length).toBeGreaterThan(0);
+    });
+  });
+
+  test("Save process not working when user confirm empty data", async () => {
+    const storeMocked = {
+      ...mockStore(initialStateFull),
+      dispatch: dispatchMock,
+    };
+
+    const confirmFn = jest.fn();
+
+    const { getByTestId, getAllByTestId, getByText } = render(
+      <Provider store={storeMocked}>
+        <EditConnectionsContainer
+          onConfirm={confirmFn}
+          modalIsOpen={true}
+          setModalIsOpen={jest.fn()}
+          setNotes={jest.fn()}
+          notes={[]}
+          connectionDetails={connectionsFix[0]}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("connection-name").innerHTML).toBe(
+        connectionsFix[0].label
+      );
+      expect(getByTestId("action-button")).toBeVisible();
+    });
+
+    act(() => {
+      fireEvent.click(getByTestId("add-note-button"));
+    });
+
+    await waitForIonicReact();
+
+    await waitFor(() => {
+      expect(
+        getByText(EN_TRANSLATIONS.connections.details.notes)
+      ).toBeVisible();
+      expect(getAllByTestId("connection-note").length).toBe(1);
+      expect(
+        getByText(EN_TRANSLATIONS.connections.details.title)
+      ).toBeVisible();
+    });
+
+    const actionBtn = getByTestId("action-button");
+
+    act(() => {
+      ionFireEvent.click(actionBtn);
+    });
+
+    expect(confirmFn).toBeCalledTimes(0);
+  });
+});

--- a/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.tsx
+++ b/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.tsx
@@ -155,7 +155,9 @@ export const EditConnectionsContainer = ({
             <div className="connection-details-info-block">
               {updatedNotes.length ? (
                 <>
-                  <h3>{i18n.t("connections.details.notes")}</h3>
+                  <h3 className="note-title">
+                    {i18n.t("connections.details.notes")}
+                  </h3>
                   {updatedNotes.map((note) => (
                     <ConnectionNote
                       data={note}

--- a/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.tsx
+++ b/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.tsx
@@ -1,5 +1,6 @@
 import { IonButton, IonIcon, IonModal } from "@ionic/react";
 import { createOutline } from "ionicons/icons";
+import { useEffect, useRef, useState } from "react";
 import { PageLayout } from "../../../components/layout/PageLayout";
 import { i18n } from "../../../../i18n";
 import { ConnectionNote } from "./ConnectionNote";
@@ -7,90 +8,142 @@ import ConnectionDetailsHeader from "./ConnectionDetailsHeader";
 import { Agent } from "../../../../core/agent/agent";
 import { setToastMsg } from "../../../../store/reducers/stateCache";
 import { ToastMsgType } from "../../../globals/types";
-import { ConnectionNoteProps } from "./ConnectionNote.types";
 import { useAppDispatch } from "../../../../store/hooks";
 import { EditConnectionsModalProps } from "./EditConnectionsModal.types";
 import KeriLogo from "../../../../ui/assets/images/KeriGeneric.jpg";
 import "./EditConnectionsModal.scss";
+import { ConnectionNoteDetails } from "../../../../core/agent/agent.types";
+import { Alert } from "../../../components/Alert";
 
-const EditConnectionsModal = ({
+export const EditConnectionsContainer = ({
   notes,
   setNotes,
-  coreNotes,
   modalIsOpen,
   setModalIsOpen,
-  currentNoteId,
   connectionDetails,
-  setAlertDeleteNoteIsOpen,
+  onConfirm,
 }: EditConnectionsModalProps) => {
   const TEMP_ID_PREFIX = "temp";
   const dispatch = useAppDispatch();
+  const [updatedNotes, setUpdatedNotes] = useState<ConnectionNoteDetails[]>([
+    ...notes,
+  ]);
+  const [alertDeleteNoteIsOpen, setAlertDeleteNoteIsOpen] = useState(false);
+  const deleteNoteId = useRef("");
+
+  useEffect(() => {
+    if (modalIsOpen) setUpdatedNotes([...notes]);
+  }, [modalIsOpen]);
+
+  const confirm = () => {
+    try {
+      const filteredNotes = updatedNotes.filter(
+        (note) => note.title !== "" && note.message !== ""
+      );
+
+      let update = false;
+      filteredNotes.forEach((note) => {
+        if (note.id.includes(TEMP_ID_PREFIX)) {
+          Agent.agent.connections.createConnectionNote(
+            connectionDetails.id,
+            note
+          );
+          update = true;
+        }
+      });
+
+      notes.forEach((note) => {
+        const noteFind = filteredNotes.find(
+          (noteFilter) => note.id === noteFilter.id
+        );
+
+        if (!noteFind) {
+          Agent.agent.connections.deleteConnectionNoteById(note.id);
+          update = true;
+          return;
+        }
+
+        if (
+          note.title !== noteFind.title ||
+          note.message !== noteFind.message
+        ) {
+          Agent.agent.connections.updateConnectionNoteById(note.id, noteFind);
+          update = true;
+        }
+      });
+
+      if (update) {
+        setNotes(filteredNotes);
+        dispatch(setToastMsg(ToastMsgType.NOTES_UPDATED));
+        onConfirm();
+        update = false;
+      }
+    } catch (e) {
+      // TODO: handle error
+    } finally {
+      setModalIsOpen(false);
+    }
+  };
+
+  const handleAddNewNote = () => {
+    setUpdatedNotes((currentNotes) => [
+      ...currentNotes,
+      {
+        title: "",
+        message: "",
+        id: TEMP_ID_PREFIX + Date.now(),
+      },
+    ]);
+  };
+
+  const handleUpdateNotes = (note: ConnectionNoteDetails) => {
+    const updateNoteIndex = updatedNotes.findIndex(
+      (currentNote) => currentNote.id === note.id
+    );
+
+    if (updateNoteIndex === -1) return;
+
+    const updateNote = updatedNotes[updateNoteIndex];
+    if (updateNote.message === note.message && updateNote.title === note.title)
+      return;
+
+    setUpdatedNotes((currentNotes) => {
+      currentNotes[updateNoteIndex] = {
+        ...note,
+      };
+
+      return [...currentNotes];
+    });
+  };
+
+  const openAlert = (id: string) => {
+    setAlertDeleteNoteIsOpen(true);
+    deleteNoteId.current = id;
+  };
+
+  const handleDeleteNote = () => {
+    if (!deleteNoteId.current) return;
+
+    const newNotes = updatedNotes.filter(
+      (note) => note.id !== deleteNoteId.current
+    );
+    setUpdatedNotes(newNotes);
+    deleteNoteId.current = "";
+    dispatch(setToastMsg(ToastMsgType.NOTE_REMOVED));
+  };
 
   return (
-    <IonModal
-      isOpen={modalIsOpen}
-      className="edit-connections-modal"
-      data-testid="edit-connections-modal"
-      onDidDismiss={() => {
-        if (modalIsOpen && notes !== coreNotes) {
-          setNotes(coreNotes);
-        }
-        setModalIsOpen(false);
-      }}
-    >
+    <>
       <div className="modal">
         <PageLayout
           header={true}
           closeButton={true}
           closeButtonLabel={`${i18n.t("connections.details.cancel")}`}
           closeButtonAction={() => {
-            if (notes !== coreNotes) {
-              setNotes(coreNotes);
-            }
             setModalIsOpen(false);
           }}
           actionButton={true}
-          actionButtonAction={() => {
-            const filteredNotes = notes.filter(
-              (note) => note.title !== "" && note.message !== ""
-            );
-            if (filteredNotes !== coreNotes) {
-              setNotes(filteredNotes);
-              let update = false;
-              filteredNotes.forEach((note) => {
-                if (note.id.includes(TEMP_ID_PREFIX)) {
-                  Agent.agent.connections.createConnectionNote(
-                    connectionDetails.id,
-                    note
-                  );
-                  update = true;
-                }
-              });
-              coreNotes.forEach((noteCore) => {
-                const noteFind = filteredNotes.find(
-                  (noteFilter) => noteCore.id === noteFilter.id
-                );
-                if (!noteFind) {
-                  Agent.agent.connections.deleteConnectionNoteById(noteCore.id);
-                  update = true;
-                } else if (
-                  noteCore.title !== noteFind.title ||
-                  noteCore.message !== noteFind.message
-                ) {
-                  Agent.agent.connections.updateConnectionNoteById(
-                    noteCore.id,
-                    noteFind
-                  );
-                  update = true;
-                }
-              });
-              if (update) {
-                dispatch(setToastMsg(ToastMsgType.NOTES_UPDATED));
-                update = false;
-              }
-            }
-            setModalIsOpen(false);
-          }}
+          actionButtonAction={confirm}
           actionButtonLabel={`${i18n.t("connections.details.confirm")}`}
         >
           <div className="connection-details-content">
@@ -100,19 +153,15 @@ const EditConnectionsModal = ({
               date={connectionDetails?.connectionDate}
             />
             <div className="connection-details-info-block">
-              {notes.length ? (
+              {updatedNotes.length ? (
                 <>
                   <h3>{i18n.t("connections.details.notes")}</h3>
-                  {notes.map((note, index) => (
+                  {updatedNotes.map((note) => (
                     <ConnectionNote
-                      title={note.title}
-                      message={note.message}
-                      id={note.id}
-                      notes={notes as ConnectionNoteProps[]}
-                      currentNoteId={currentNoteId}
-                      setAlertDeleteNoteIsOpen={setAlertDeleteNoteIsOpen}
-                      key={index}
-                      setNotes={setNotes}
+                      data={note}
+                      onNoteDataChange={handleUpdateNotes}
+                      onDeleteNote={openAlert}
+                      key={note.id}
                     />
                   ))}
                 </>
@@ -126,16 +175,8 @@ const EditConnectionsModal = ({
               <IonButton
                 shape="round"
                 className="primary-button"
-                onClick={() => {
-                  setNotes([
-                    ...notes,
-                    {
-                      title: "",
-                      message: "",
-                      id: TEMP_ID_PREFIX + notes.length,
-                    },
-                  ]);
-                }}
+                data-testid="add-note-button"
+                onClick={handleAddNewNote}
               >
                 <IonIcon
                   slot="icon-only"
@@ -146,6 +187,52 @@ const EditConnectionsModal = ({
           </div>
         </PageLayout>
       </div>
+      <Alert
+        isOpen={alertDeleteNoteIsOpen}
+        setIsOpen={setAlertDeleteNoteIsOpen}
+        dataTestId="alert-confirm-delete-note"
+        headerText={i18n.t(
+          "connections.details.options.alert.deletenote.title"
+        )}
+        confirmButtonText={`${i18n.t(
+          "connections.details.options.alert.deletenote.confirm"
+        )}`}
+        cancelButtonText={`${i18n.t(
+          "connections.details.options.alert.deletenote.cancel"
+        )}`}
+        actionConfirm={() => handleDeleteNote()}
+        actionCancel={() => setAlertDeleteNoteIsOpen(false)}
+        actionDismiss={() => setAlertDeleteNoteIsOpen(false)}
+      />
+    </>
+  );
+};
+
+const EditConnectionsModal = ({
+  notes,
+  setNotes,
+  modalIsOpen,
+  setModalIsOpen,
+  connectionDetails,
+  onConfirm,
+}: EditConnectionsModalProps) => {
+  return (
+    <IonModal
+      isOpen={modalIsOpen}
+      className="edit-connections-modal"
+      data-testid="edit-connections-modal"
+      onDidDismiss={() => {
+        setModalIsOpen(false);
+      }}
+    >
+      <EditConnectionsContainer
+        notes={notes}
+        setNotes={setNotes}
+        connectionDetails={connectionDetails}
+        onConfirm={onConfirm}
+        modalIsOpen={modalIsOpen}
+        setModalIsOpen={setModalIsOpen}
+      />
     </IonModal>
   );
 };

--- a/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.types.ts
+++ b/src/ui/pages/ConnectionDetails/components/EditConnectionsModal.types.ts
@@ -4,12 +4,10 @@ import { ConnectionNoteDetails } from "../../../../core/agent/agent.types";
 interface EditConnectionsModalProps {
   notes: ConnectionNoteDetails[];
   setNotes: (value: ConnectionNoteDetails[]) => void;
-  coreNotes: ConnectionNoteDetails[];
   modalIsOpen: boolean;
   setModalIsOpen: (value: boolean) => void;
-  currentNoteId: string;
   connectionDetails: ConnectionDetails;
-  setAlertDeleteNoteIsOpen: (value: boolean) => void;
+  onConfirm: () => void;
 }
 
 export type { EditConnectionsModalProps };


### PR DESCRIPTION
## Description

Fix connection note content not update after save. It seem the issue occur because object reference. 

After we get data from core API, we push it in 2 states: `notes` and `coreNotes`. 
And when update note we only update note object (`title`, `message`) properties and not create new note object to break reference to old object => it also update object store in `coreNotes` (because they are same reference).  

And when we save change, We are comparing object in updated note list and `coreNotes` to find note need update. But because above issue => data in update note list is equal `coreNotes` => cannot find updated item => no change update to core by API.

Beside that, I found some bugs are note title length not update when we change note title, delete new note, open 2 edit note modal,... => Then I think I will refactor edit note modal. Evidence capture video is present test for all case: create, edit, delete.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-654](https://cardanofoundation.atlassian.net/browse/DTIS-654)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/0aa925c2-fd92-48c9-95ed-f69a721803c5

#### Android

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/b71fd072-7070-41a4-8a2a-e69a8b81c09d

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/1552babf-9b89-4d2e-b16a-80ffc445eafd

[DTIS-654]: https://cardanofoundation.atlassian.net/browse/DTIS-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
