### PR TITLE
feat(core): retry mechanism for multisig missing contacts

### DIFF
--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -76,6 +76,18 @@ const keriNotificationsChangeHandler = async (
       })
     );
   } else if (event?.a?.r === NotificationRoute.MultiSigIcp) {
+    retryHandleMultisigEvent(event, dispatch);
+  } else if (event?.a?.r === NotificationRoute.MultiSigRot) {
+    //TODO: Use dispatch here, handle logic for the multisig rotation notification
+  }
+};
+
+const retryHandleMultisigEvent = async (
+  event: KeriNotification,
+  dispatch: ReturnType<typeof useAppDispatch>,
+  retryInterval = 3000
+) => {
+  try {
     const multisigIcpDetails =
       await Agent.agent.identifiers.getMultisigIcpDetails(event);
     dispatch(
@@ -86,8 +98,9 @@ const keriNotificationsChangeHandler = async (
         multisigIcpDetails: multisigIcpDetails,
       })
     );
-  } else if (event?.a?.r === NotificationRoute.MultiSigRot) {
-    //TODO: Use dispatch here, handle logic for the multisig rotation notification
+  } catch (error) {
+    await new Promise((resolve) => setTimeout(resolve, retryInterval));
+    await retryHandleMultisigEvent(event, dispatch, retryInterval);
   }
 };
 

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -43,6 +43,7 @@ import { NotificationRoute } from "../../../core/agent/modules/signify/signifyAp
 import "./AppWrapper.scss";
 import { ConfigurationService } from "../../../core/configuration";
 import { PreferencesStorageItem } from "../../../core/storage/preferences/preferencesStorage.type";
+import { IdentifierService } from "../../../core/agent/services";
 
 const connectionKeriStateChangedHandler = async (
   event: ConnectionKeriStateChangedEvent,
@@ -76,13 +77,13 @@ const keriNotificationsChangeHandler = async (
       })
     );
   } else if (event?.a?.r === NotificationRoute.MultiSigIcp) {
-    retryHandleMultisigEvent(event, dispatch);
+    processMultiSigIcpNotification(event, dispatch);
   } else if (event?.a?.r === NotificationRoute.MultiSigRot) {
     //TODO: Use dispatch here, handle logic for the multisig rotation notification
   }
 };
 
-const retryHandleMultisigEvent = async (
+const processMultiSigIcpNotification = async (
   event: KeriNotification,
   dispatch: ReturnType<typeof useAppDispatch>,
   retryInterval = 3000
@@ -99,8 +100,14 @@ const retryHandleMultisigEvent = async (
       })
     );
   } catch (error) {
-    await new Promise((resolve) => setTimeout(resolve, retryInterval));
-    await retryHandleMultisigEvent(event, dispatch, retryInterval);
+    if (
+      (error as Error).message == IdentifierService.UNKNOWN_AIDS_IN_MULTISIG_ICP
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, retryInterval));
+      await processMultiSigIcpNotification(event, dispatch, retryInterval);
+    } else {
+      throw error;
+    }
   }
 };
 


### PR DESCRIPTION
## Description

In case we receive a multi-sig inception event, but don’t know all of the contacts yet - we should have a way of pushing a retrying.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [DTIS-740](https://cardanofoundation.atlassian.net/browse/DTIS-740)

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated


[DTIS-740]: https://cardanofoundation.atlassian.net/browse/DTIS-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ