### PR TITLE
fix(core): always store multisig contact

### DIFF
--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -96,12 +96,12 @@ interface KeriNotification {
 
 enum KeriConnectionType {
   NORMAL = "NORMAL",
-  MULTI_SIG = "MULTI_SIG",
+  MULTI_SIG_INITIATOR = "MULTI_SIG_INITIATOR",
 }
 
 type OobiScan =
   | { type: KeriConnectionType.NORMAL }
-  | { type: KeriConnectionType.MULTI_SIG; groupId: string };
+  | { type: KeriConnectionType.MULTI_SIG_INITIATOR; groupId: string };
 
 interface BaseEventEmitter {
   type: string;

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -87,7 +87,9 @@ const Scanner = forwardRef(({ setIsValueCaptured }: ScannerProps, ref) => {
             );
           if (invitation.type === KeriConnectionType.NORMAL) {
             setIsValueCaptured && setIsValueCaptured(true);
-          } else if (invitation.type === KeriConnectionType.MULTI_SIG) {
+          } else if (
+            invitation.type === KeriConnectionType.MULTI_SIG_INITIATOR
+          ) {
             dispatch(
               setQueueIncomingRequest({
                 id: invitation.groupId,


### PR DESCRIPTION
## Description

There was some bugs related to when connections were stored or not stored if the OOBI contains the multisig `groupId` query param. Now, a new connection is always stored for simplicity and in case we need this info in the future for non-initiators of multisigs.

The get all connections interface filters these out now but this should be refactored by Bao once he's back to do this in the SQL - I wasn't sure if I'd cause a regression by altering to allow filtering by `undefined` in the tags.

Worth noting that the sync all connections function won't be context aware when syncing if it the connection is a multi-sig member or a normal connection - this is a todo and low priority.

Also re-adjusted the query params of OOBIs. The change from Patrick was inserting `+` instead of `%20` for spaces which seems to have worse compatibility.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-823)]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
