### PR TITLE
feat(core): adjust the start method in peerConnection to accept an identifier

### DIFF
--- a/src/core/cardano/walletConnect/identityWalletConnect.ts
+++ b/src/core/cardano/walletConnect/identityWalletConnect.ts
@@ -11,9 +11,8 @@ import { Agent } from "../../agent/agent";
 class IdentityWalletConnect extends CardanoPeerConnect {
   static readonly IDENTIFIER_ID_NOT_LOCATED =
     "The id doesn't correspond with any stored identifier";
-  static readonly NO_IDENTIFIERS_STORED = "No stored identifiers";
   private selectedAid: string;
-  getIdentifierOobi: (selectedAid: string) => Promise<string>;
+  getIdentifierOobi: () => Promise<string>;
   sign: (identifier: string, payload: string) => Promise<string>;
 
   signerCache: Map<string, Signer>;
@@ -34,9 +33,9 @@ class IdentityWalletConnect extends CardanoPeerConnect {
     this.selectedAid = selectedAid;
     this.signerCache = new Map();
 
-    this.getIdentifierOobi = async (identifierAid: string): Promise<string> => {
+    this.getIdentifierOobi = async (): Promise<string> => {
       const identifier = await Agent.agent.identifiers.getIdentifier(
-        identifierAid
+        this.selectedAid
       );
       if (!identifier) {
         throw new Error(IdentityWalletConnect.IDENTIFIER_ID_NOT_LOCATED);

--- a/src/core/cardano/walletConnect/identityWalletConnect.ts
+++ b/src/core/cardano/walletConnect/identityWalletConnect.ts
@@ -12,8 +12,8 @@ class IdentityWalletConnect extends CardanoPeerConnect {
   static readonly IDENTIFIER_ID_NOT_LOCATED =
     "The id doesn't correspond with any stored identifier";
   static readonly NO_IDENTIFIERS_STORED = "No stored identifiers";
-
-  getIdentifierOobi: () => Promise<string>;
+  private selectedAid: string;
+  getIdentifierOobi: (selectedAid: string) => Promise<string>;
   sign: (identifier: string, payload: string) => Promise<string>;
 
   signerCache: Map<string, Signer>;
@@ -22,6 +22,7 @@ class IdentityWalletConnect extends CardanoPeerConnect {
     walletInfo: IWalletInfo,
     seed: string | null,
     announce: string[],
+    selectedAid: string,
     discoverySeed?: string | null
   ) {
     super(walletInfo, {
@@ -30,16 +31,17 @@ class IdentityWalletConnect extends CardanoPeerConnect {
       discoverySeed: discoverySeed,
       logLevel: "info",
     });
-
+    this.selectedAid = selectedAid;
     this.signerCache = new Map();
 
-    this.getIdentifierOobi = async (): Promise<string> => {
-      const identifiers = await Agent.agent.identifiers.getIdentifiers();
-      if (!(identifiers && identifiers.length > 0)) {
-        throw new Error(IdentityWalletConnect.NO_IDENTIFIERS_STORED);
+    this.getIdentifierOobi = async (identifierAid: string): Promise<string> => {
+      const identifier = await Agent.agent.identifiers.getIdentifier(
+        identifierAid
+      );
+      if (!identifier) {
+        throw new Error(IdentityWalletConnect.IDENTIFIER_ID_NOT_LOCATED);
       }
-
-      return Agent.agent.connections.getOobi(identifiers[0].signifyName);
+      return Agent.agent.connections.getOobi(identifier.signifyName);
     };
 
     this.sign = async (

--- a/src/core/cardano/walletConnect/peerConnection.ts
+++ b/src/core/cardano/walletConnect/peerConnection.ts
@@ -30,7 +30,7 @@ class PeerConnection {
   private identityWalletConnect: IdentityWalletConnect | undefined;
   private connected = false;
 
-  async start() {
+  async start(selectedAid: string) {
     let meerkatSeed = null;
 
     try {
@@ -44,7 +44,8 @@ class PeerConnection {
     this.identityWalletConnect = new IdentityWalletConnect(
       this.walletInfo,
       meerkatSeed,
-      this.announce
+      this.announce,
+      selectedAid
     );
     this.identityWalletConnect.setOnConnect(
       (connectMessage: IConnectMessage) => {
@@ -73,7 +74,6 @@ class PeerConnection {
 
     const seed = this.identityWalletConnect.connect(dAppIdentifier);
     SecureStorage.set(KeyStoreKeys.MEERKAT_SEED, seed);
-    this.connected = true;
   }
 
   disconnectDApp(dAppIdentifier: string) {

--- a/src/core/cardano/walletConnect/peerConnection.ts
+++ b/src/core/cardano/walletConnect/peerConnection.ts
@@ -29,6 +29,7 @@ class PeerConnection {
 
   private identityWalletConnect: IdentityWalletConnect | undefined;
   private connected = false;
+  private connectedDAppAdress = "";
 
   async start(selectedAid: string) {
     let meerkatSeed = null;
@@ -40,7 +41,12 @@ class PeerConnection {
     } catch {
       meerkatSeed = null;
     }
-
+    if (
+      this.identityWalletConnect &&
+      this.connectedDAppAdress.trim().length !== 0
+    ) {
+      this.disconnectDApp(this.connectedDAppAdress);
+    }
     this.identityWalletConnect = new IdentityWalletConnect(
       this.walletInfo,
       meerkatSeed,
@@ -49,12 +55,15 @@ class PeerConnection {
     );
     this.identityWalletConnect.setOnConnect(
       (connectMessage: IConnectMessage) => {
-        this.connected = true;
+        if (!connectMessage.error) {
+          this.connected = true;
+          this.connectedDAppAdress = connectMessage.dApp.address;
+        }
       }
     );
 
     this.identityWalletConnect.setOnDisconnect(
-      (connectMessage: IConnectMessage) => {
+      (disConnectMessage: IConnectMessage) => {
         this.connected = false;
       }
     );

--- a/src/core/cardano/walletConnect/peerConnection.types.ts
+++ b/src/core/cardano/walletConnect/peerConnection.types.ts
@@ -1,5 +1,5 @@
 interface ExperimentalAPIFunctions {
-  getIdentifierOobi: () => Promise<string>;
+  getIdentifierOobi: (selectedAid: string) => Promise<string>;
   sign: (identifier: string, payload: string) => Promise<string>;
 }
 

--- a/src/core/cardano/walletConnect/peerConnection.types.ts
+++ b/src/core/cardano/walletConnect/peerConnection.types.ts
@@ -1,5 +1,5 @@
 interface ExperimentalAPIFunctions {
-  getIdentifierOobi: (selectedAid: string) => Promise<string>;
+  getIdentifierOobi: () => Promise<string>;
   sign: (identifier: string, payload: string) => Promise<string>;
 }
 


### PR DESCRIPTION
## Description

Adjust the start method to accept an identifier (KERI AID) which will be the selected identifier in getIdentifierOobi of identityWalletConnect.ts (right now it selects the first one)

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-858)

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated