### PR TITLE
refactor(core): avoid serialisation warning for getting multi-sig icp details

### DIFF
--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -977,14 +977,9 @@ describe("Multisig sig service of agent", () => {
       .fn()
       .mockResolvedValue(senderData);
     Agent.agent.connections.getConnections = jest.fn().mockResolvedValue([]);
-    const result = await multiSigService.getMultisigIcpDetails({
-      id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
-      createdAt: new Date("2024-03-08T08:52:10.801Z"),
-      a: {
-        r: "/multisig/icp",
-        d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
-      },
-    });
+    const result = await multiSigService.getMultisigIcpDetails(
+      "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW"
+    );
     expect(result.ourIdentifier.id).toBe(identifierMetadata.id);
     expect(result.sender.id).toBe(senderData.id);
     expect(result.otherConnections.length).toBe(0);
@@ -1040,14 +1035,9 @@ describe("Multisig sig service of agent", () => {
       },
     ]);
     await expect(
-      multiSigService.getMultisigIcpDetails({
-        id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
-        createdAt: new Date("2024-03-08T08:52:10.801Z"),
-        a: {
-          r: "/multisig/icp",
-          d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
-        },
-      })
+      multiSigService.getMultisigIcpDetails(
+        "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW"
+      )
     ).rejects.toThrowError(MultiSigService.UNKNOWN_AIDS_IN_MULTISIG_ICP);
   });
 
@@ -1097,14 +1087,9 @@ describe("Multisig sig service of agent", () => {
         status: ConnectionStatus.PENDING,
       },
     ]);
-    const result = await multiSigService.getMultisigIcpDetails({
-      id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
-      createdAt: new Date("2024-03-08T08:52:10.801Z"),
-      a: {
-        r: "/multisig/icp",
-        d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
-      },
-    });
+    const result = await multiSigService.getMultisigIcpDetails(
+      "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW"
+    );
     expect(result.ourIdentifier.id).toBe(identifierMetadata.id);
     expect(result.sender.id).toBe(senderData.id);
     expect(result.otherConnections.length).toBe(1);
@@ -1163,14 +1148,9 @@ describe("Multisig sig service of agent", () => {
       },
     ]);
     await expect(
-      multiSigService.getMultisigIcpDetails({
-        id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
-        createdAt: new Date("2024-03-08T08:52:10.801Z"),
-        a: {
-          r: "/multisig/icp",
-          d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
-        },
-      })
+      multiSigService.getMultisigIcpDetails(
+        "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW"
+      )
     ).rejects.toThrowError(MultiSigService.CANNOT_JOIN_MULTISIG_ICP);
   });
 
@@ -1197,28 +1177,18 @@ describe("Multisig sig service of agent", () => {
         throw new Error("Some error from connection service");
       });
     await expect(
-      multiSigService.getMultisigIcpDetails({
-        id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
-        createdAt: new Date("2024-03-08T08:52:10.801Z"),
-        a: {
-          r: "/multisig/icp",
-          d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
-        },
-      })
+      multiSigService.getMultisigIcpDetails(
+        "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW"
+      )
     ).rejects.toThrowError("Some error from connection service");
   });
 
   test("cannot get multi-sig details from a notification with no matching exn message", async () => {
     groupGetRequestMock = jest.fn().mockResolvedValue([]);
     await expect(
-      multiSigService.getMultisigIcpDetails({
-        id: "AIhrazlnKPLYOvqiNJrmG290VEcXsFnfTV2lSGOMiX88",
-        createdAt: new Date("2024-03-08T08:52:10.801Z"),
-        a: {
-          r: "/multisig/icp",
-          d: "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW",
-        },
-      })
+      multiSigService.getMultisigIcpDetails(
+        "EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW"
+      )
     ).rejects.toThrowError(
       `${MultiSigService.EXN_MESSAGE_NOT_FOUND} EHe8OnqWhR--r7zPJy97PS2B5rY7Zp4vnYQICs4gXodW`
     );

--- a/src/core/agent/services/multiSigService.ts
+++ b/src/core/agent/services/multiSigService.ts
@@ -307,15 +307,16 @@ class MultiSigService extends AgentService {
   }
 
   async getMultisigIcpDetails(
-    notification: KeriaNotification
+    notificationSaid: string
   ): Promise<MultiSigIcpRequestDetails> {
-    const msgSaid = notification.a.d as string;
     const icpMsg: MultiSigExnMessage[] = await this.signifyClient
       .groups()
-      .getRequest(msgSaid);
+      .getRequest(notificationSaid);
 
     if (!icpMsg.length) {
-      throw new Error(`${MultiSigService.EXN_MESSAGE_NOT_FOUND} ${msgSaid}`);
+      throw new Error(
+        `${MultiSigService.EXN_MESSAGE_NOT_FOUND} ${notificationSaid}`
+      );
     }
 
     const senderAid = icpMsg[0].exn.i;


### PR DESCRIPTION
## Description

To avoid the warning in the UI and to reduce payload, we change the parameter of `getMultisigIcpDetails` to `notificationsSaid`.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-866)

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)