### PR TITLE
bugfix(ui): Breakpoints misalignment between layouts

### DIFF
--- a/src/ui/components/PageHeader/PageHeader.scss
+++ b/src/ui/components/PageHeader/PageHeader.scss
@@ -23,6 +23,10 @@
   }
 
   ion-toolbar {
+    ion-buttons.has-action.md {
+      min-width: 10%;
+    }
+
     ion-buttons ion-button {
       color: var(--ion-color-secondary);
 

--- a/src/ui/components/PageHeader/PageHeader.tsx
+++ b/src/ui/components/PageHeader/PageHeader.tsx
@@ -65,6 +65,8 @@ const PageHeader = ({
     }
   };
 
+  const hasAction = backButton || closeButton || actionButton;
+
   return (
     <IonHeader
       className={`ion-no-border page-header ${
@@ -72,7 +74,10 @@ const PageHeader = ({
       }`}
     >
       <IonToolbar>
-        <IonButtons slot="start">
+        <IonButtons
+          className={hasAction ? "has-action" : undefined}
+          slot="start"
+        >
           {backButton && (
             <IonButton
               slot="icon-only"
@@ -141,7 +146,10 @@ const PageHeader = ({
         )}
 
         {!progressBar && (
-          <IonButtons slot="end">
+          <IonButtons
+            className={hasAction ? "has-action" : undefined}
+            slot="end"
+          >
             {actionButton && !actionButtonLabel && (
               <IonButton
                 shape="round"

--- a/src/ui/components/Scanner/Scanner.scss
+++ b/src/ui/components/Scanner/Scanner.scss
@@ -25,6 +25,10 @@ ion-grid.qr-code-scanner {
       margin: 1.5rem 0;
       --ionicon-stroke-width: 0.938rem;
     }
+
+    &.no-footer {
+      margin-bottom: calc(var(--scale-scan) * 2rem);
+    }
   }
 
   .scanner-spinner-container {
@@ -48,5 +52,9 @@ ion-grid.qr-code-scanner {
   @media screen and (min-width: 250px) and (max-width: 370px) {
     --scale-scan: 0.7;
     padding-inline: 0.9rem;
+
+    ion-row.no-footer {
+      margin-bottom: calc(var(--scale-scan) * 5rem);
+    }
   }
 }

--- a/src/ui/components/VerifyPasscode/VerifyPasscode.scss
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.scss
@@ -10,6 +10,18 @@
   .responsive-page-content {
     justify-content: space-evenly;
 
+    & > .error-message {
+      margin: 0;
+    }
+
+    & > .error-message-placeholder {
+      margin: 0;
+    }
+
+    & > .passcode-module-container {
+      margin: 0;
+    }
+
     .verify-passcode-title,
     .verify-passcode-description {
       text-align: center;

--- a/src/ui/components/layout/ResponsivePageLayout/ResponsivePageLayout.scss
+++ b/src/ui/components/layout/ResponsivePageLayout/ResponsivePageLayout.scss
@@ -19,7 +19,7 @@
     }
   }
 
-  @media screen and (min-width: 250px) and (max-width: 425px) {
+  @media screen and (min-width: 250px) and (max-width: 370px) {
     padding: 0.9rem;
 
     .responsive-page-content {

--- a/src/ui/components/layout/TabLayout/TabLayout.scss
+++ b/src/ui/components/layout/TabLayout/TabLayout.scss
@@ -69,7 +69,7 @@
   }
 
   @media screen and (min-width: 250px) and (max-width: 370px) {
-    padding-inline: 1.063rem;
+    padding-inline: 0.9rem;
     font-size: 0.8rem;
 
     ion-header ion-toolbar {

--- a/src/ui/pages/LockPage/LockPage.scss
+++ b/src/ui/pages/LockPage/LockPage.scss
@@ -9,6 +9,14 @@
     }
   }
 
+  .lock-modal-title {
+    margin-top: 4rem;
+
+    @media screen and (min-height: 300px) and (max-height: 550px) {
+      margin-top: 2rem;
+    }
+  }
+
   .responsive-page-content {
     justify-content: space-around;
   }

--- a/src/ui/pages/SetPasscode/SetPasscode.scss
+++ b/src/ui/pages/SetPasscode/SetPasscode.scss
@@ -2,6 +2,28 @@
   .responsive-page-content {
     justify-content: space-evenly;
 
+    @media screen and (min-height: 581px) {
+      & > .passcode-module-circle-row {
+        margin: 0;
+      }
+    }
+
+    & > .set-passcode-title {
+      margin: 0;
+    }
+
+    & > .error-message {
+      margin: 0;
+    }
+
+    & > .error-message-placeholder {
+      margin: 0;
+    }
+
+    & > .passcode-module-container {
+      margin: 0;
+    }
+
     .set-passcode-title,
     .set-passcode-description {
       text-align: center;


### PR DESCRIPTION
## Description

This PR used to update layout breakpoint for `ResponsivePageLayout` component to make it same as other layouts.
`ResponsivePageLayout` now is using by:
- VerifyPasscode
- WalletConnect
- FullPageScanner
- CredentialRequest
- LockPage
- Onboarding
- SetPasscode
- VerifySeedPhrase


## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-884](https://cardanofoundation.atlassian.net/browse/DTIS-884)

### Testing & Validation

- [x This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS
![Screenshot 2024-05-14 at 15 22 38](https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/e16033d0-68c3-41d3-b534-a0f4ddd069e8)

#### Android
![Screenshot 2024-05-15 at 14 51 03](https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/b31240d6-0713-4ce7-8d94-70f51155e782)

#### Browser
![Screenshot 2024-05-14 at 14 22 39](https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/f42bb6d1-7f57-47f5-83d6-253756a9d091)


[DTIS-884]: https://cardanofoundation.atlassian.net/browse/DTIS-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ