### PR TITLE
feat(ui): Enable Biometrics with Password/Passcode Confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@ionic/storage": "^3.0.6",
         "@reduxjs/toolkit": "^1.9.5",
         "bip39": "^3.0.4",
+        "capacitor-native-settings": "^5.0.1",
         "dotenv": "^16.4.5",
         "i18next": "^22.4.14",
         "i18next-browser-languagedetector": "^7.0.1",
@@ -22589,6 +22590,14 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/capacitor-native-settings": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/capacitor-native-settings/-/capacitor-native-settings-5.0.1.tgz",
+      "integrity": "sha512-HH7GCyaVLwWP4FEVqvOQM+cHWveQUjsA2128wfZ5yr9eOQrECVWzO5UXH9ZlikpWi1C7exnovcyEr3TlYO6l8w==",
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
     },
     "node_modules/capital-case": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@ionic/storage": "^3.0.6",
     "@reduxjs/toolkit": "^1.9.5",
     "bip39": "^3.0.4",
+    "capacitor-native-settings": "^5.0.1",
     "dotenv": "^16.4.5",
     "i18next": "^22.4.14",
     "i18next-browser-languagedetector": "^7.0.1",

--- a/src/ui/hooks/useBiometricsHook.ts
+++ b/src/ui/hooks/useBiometricsHook.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import {
   BiometricAuth,
   BiometryError,
@@ -8,11 +7,10 @@ import {
   AndroidBiometryStrength,
   CheckBiometryResult,
 } from "@aparajita/capacitor-biometric-auth/dist/esm/definitions";
-import i18n from "i18next";
 import { PluginListenerHandle } from "@capacitor/core";
-import { useSelector } from "react-redux";
+import i18n from "i18next";
+import { useEffect, useState } from "react";
 import { useActivityTimer } from "../components/AppWrapper/hooks/useActivityTimer";
-import { getBiometryCacheCache } from "../../store/reducers/biometryCache";
 
 const useBiometricAuth = () => {
   const [biometricInfo, setBiometricInfo] = useState<CheckBiometryResult>();

--- a/src/ui/pages/Menu/components/Settings/Settings.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.test.tsx
@@ -1,12 +1,63 @@
+import {
+  BiometryErrorType,
+  BiometryType,
+} from "@aparajita/capacitor-biometric-auth/dist/esm/definitions";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { BiometryType } from "@aparajita/capacitor-biometric-auth/dist/esm/definitions";
+import configureStore from "redux-mock-store";
 import { useState } from "react";
-import { Settings } from "./Settings";
-import { store } from "../../../../../store";
-import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
-import { MiscRecordId } from "../../../../../core/agent/agent.types";
 import { Agent } from "../../../../../core/agent/agent";
+import { MiscRecordId } from "../../../../../core/agent/agent.types";
+import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
+import { TabsRoutePath } from "../../../../../routes/paths";
+import { store } from "../../../../../store";
+import { Settings } from "./Settings";
+
+jest.mock("@ionic/react", () => ({
+  ...jest.requireActual("@ionic/react"),
+  IonModal: ({ children, isOpen }: any) => (
+    <div style={{ display: isOpen ? "block" : "none" }}>{children}</div>
+  ),
+}));
+
+jest.mock("@aparajita/capacitor-secure-storage", () => ({
+  SecureStorage: {
+    get: (key: string) => {
+      return "111111";
+    },
+  },
+}));
+
+let useBiometricAuthMock = jest.fn(() => {
+  const [biometricsIsEnabled, setBiometricsIsEnabled] = useState(true);
+
+  return {
+    biometricsIsEnabled,
+    biometricInfo: {
+      isAvailable: true,
+      hasCredentials: false,
+      biometryType: BiometryType.fingerprintAuthentication,
+      strongBiometryIsAvailable: true,
+    },
+    handleBiometricAuth: jest.fn(() => Promise.resolve(true)),
+    setBiometricsIsEnabled,
+  };
+});
+
+jest.mock("../../../../hooks/useBiometricsHook", () => {
+  return {
+    useBiometricAuth: () => useBiometricAuthMock(),
+  };
+});
+
+const openSettingMock = jest.fn(() => Promise.resolve(true));
+
+jest.mock("capacitor-native-settings", () => ({
+  ...jest.requireActual("capacitor-native-settings"),
+  NativeSettings: {
+    open: () => openSettingMock(),
+  },
+}));
 
 jest.mock("../../../../../core/agent/agent", () => ({
   Agent: {
@@ -20,26 +71,6 @@ jest.mock("../../../../../core/agent/agent", () => ({
     },
   },
 }));
-
-jest.mock("../../../../hooks/useBiometricsHook", () => {
-  return {
-    useBiometricAuth: () => {
-      const [biometricsIsEnabled, setBiometricsIsEnabled] = useState(true);
-
-      return {
-        biometricsIsEnabled,
-        biometricInfo: {
-          isAvailable: true,
-          hasCredentials: false,
-          biometryType: BiometryType.fingerprintAuthentication,
-          strongBiometryIsAvailable: true,
-        },
-        handleBiometricAuth: jest.fn(() => Promise.resolve(true)),
-        setBiometricsIsEnabled,
-      };
-    },
-  };
-});
 
 describe("Settings page", () => {
   beforeEach(() => {
@@ -90,9 +121,31 @@ describe("Settings page", () => {
     ).toBeInTheDocument();
   });
 
-  test("Disable/enable biometrics toggle", async () => {
+  test("Enable biometrics toggle", async () => {
+    const mockStore = configureStore();
+    const dispatchMock = jest.fn();
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.IDENTIFIERS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: false,
+        },
+      },
+      biometryCache: {
+        enabled: false,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
     const { getByText, getByTestId } = render(
-      <Provider store={store}>
+      <Provider store={storeMocked}>
         <Settings />
       </Provider>
     );
@@ -104,6 +157,96 @@ describe("Settings page", () => {
     act(() => {
       fireEvent.click(getByTestId("security-item-0"));
     });
+
+    await waitFor(() => {
+      expect(getByTestId("verify-passcode-content-page")).toBeVisible();
+    });
+
+    fireEvent.click(getByTestId("passcode-button-1"));
+
+    await waitFor(() => {
+      expect(getByTestId("circle-0")).toBeVisible();
+    });
+
+    fireEvent.click(getByTestId("passcode-button-1"));
+
+    await waitFor(() => {
+      expect(getByTestId("circle-1")).toBeVisible();
+    });
+
+    fireEvent.click(getByTestId("passcode-button-1"));
+
+    await waitFor(() => {
+      expect(getByTestId("circle-2")).toBeVisible();
+    });
+
+    fireEvent.click(getByTestId("passcode-button-1"));
+
+    await waitFor(() => {
+      expect(getByTestId("circle-3")).toBeVisible();
+    });
+
+    fireEvent.click(getByTestId("passcode-button-1"));
+
+    await waitFor(() => {
+      expect(getByTestId("circle-4")).toBeVisible();
+    });
+
+    fireEvent.click(getByTestId("passcode-button-1"));
+
+    await waitFor(() => {
+      expect(getByTestId("circle-5")).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(Agent.agent.basicStorage.createOrUpdateBasicRecord).toBeCalledWith(
+        expect.objectContaining({
+          id: MiscRecordId.APP_BIOMETRY,
+          content: {
+            enabled: true,
+          },
+        })
+      );
+    });
+  });
+
+  test("Disable biometrics toggle", async () => {
+    const mockStore = configureStore();
+    const dispatchMock = jest.fn();
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.IDENTIFIERS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: false,
+        },
+      },
+      biometryCache: {
+        enabled: true,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <Settings />
+      </Provider>
+    );
+
+    expect(
+      getByText(EN_TRANSLATIONS.settings.sections.security.biometry)
+    ).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId("security-item-0"));
+    });
+
     await waitFor(() => {
       expect(
         Agent.agent.basicStorage.createOrUpdateBasicRecord
@@ -115,30 +258,69 @@ describe("Settings page", () => {
         expect.objectContaining({
           id: MiscRecordId.APP_BIOMETRY,
           content: {
-            enabled: true,
+            enabled: false,
           },
         })
       );
     });
+  });
+
+  test("Open setting page when biometrics not enroll", async () => {
+    const mockStore = configureStore();
+    const dispatchMock = jest.fn();
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.IDENTIFIERS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: false,
+        },
+      },
+      biometryCache: {
+        enabled: false,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    useBiometricAuthMock = jest.fn(() => {
+      const [biometricsIsEnabled, setBiometricsIsEnabled] = useState(true);
+
+      return {
+        biometricsIsEnabled,
+        biometricInfo: {
+          isAvailable: true,
+          hasCredentials: false,
+          biometryType: BiometryType.fingerprintAuthentication,
+          strongBiometryIsAvailable: false,
+          code: BiometryErrorType.biometryNotEnrolled,
+        },
+        handleBiometricAuth: jest.fn(() => Promise.resolve(true)),
+        setBiometricsIsEnabled,
+      };
+    });
+
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <Settings />
+      </Provider>
+    );
+
+    expect(
+      getByText(EN_TRANSLATIONS.settings.sections.security.biometry)
+    ).toBeInTheDocument();
 
     act(() => {
       fireEvent.click(getByTestId("security-item-0"));
     });
-    await waitFor(() => {
-      expect(
-        Agent.agent.basicStorage.createOrUpdateBasicRecord
-      ).toBeCalledTimes(2);
-    });
 
     await waitFor(() => {
-      expect(Agent.agent.basicStorage.createOrUpdateBasicRecord).toBeCalledWith(
-        expect.objectContaining({
-          id: MiscRecordId.APP_BIOMETRY,
-          content: {
-            enabled: true,
-          },
-        })
-      );
+      expect(openSettingMock).toBeCalledTimes(1);
     });
   });
 });

--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -21,6 +21,13 @@ import {
 } from "ionicons/icons";
 import "./Settings.scss";
 import { useSelector } from "react-redux";
+import { useEffect, useRef, useState } from "react";
+import {
+  NativeSettings,
+  AndroidSettings,
+  IOSSettings,
+} from "capacitor-native-settings";
+import { BiometryErrorType } from "@aparajita/capacitor-biometric-auth";
 import { i18n } from "../../../../../i18n";
 import pJson from "../../../../../../package.json";
 import { OptionProps } from "./Settings.types";
@@ -32,10 +39,21 @@ import {
   setEnableBiometryCache,
 } from "../../../../../store/reducers/biometryCache";
 import { Agent } from "../../../../../core/agent/agent";
+import { VerifyPassword } from "../../../../components/VerifyPassword";
+import { VerifyPasscode } from "../../../../components/VerifyPasscode";
+import { getStateCache } from "../../../../../store/reducers/stateCache";
+import { useBiometricAuth } from "../../../../hooks/useBiometricsHook";
 
 const Settings = () => {
+  const [verifyPasswordIsOpen, setVerifyPasswordIsOpen] = useState(false);
+  const [verifyPasscodeIsOpen, setVerifyPasscodeIsOpen] = useState(false);
+
+  const stateCache = useSelector(getStateCache);
   const biometryCache = useSelector(getBiometryCacheCache);
   const dispatch = useAppDispatch();
+  const { biometricInfo, handleBiometricAuth } = useBiometricAuth();
+  const inBiometricSetup = useRef(false);
+
   const securityItems: OptionProps[] = [
     {
       icon: lockClosedOutline,
@@ -78,16 +96,63 @@ const Settings = () => {
     },
   ];
 
+  const handleToggleBiometricAuth = async () => {
+    await Agent.agent.basicStorage.createOrUpdateBasicRecord(
+      new BasicRecord({
+        id: MiscRecordId.APP_BIOMETRY,
+        content: { enabled: !biometryCache.enabled },
+      })
+    );
+    dispatch(setEnableBiometryCache(!biometryCache.enabled));
+  };
+
+  const handleBiometricUpdate = () => {
+    inBiometricSetup.current = false;
+
+    if (biometryCache.enabled) {
+      handleToggleBiometricAuth();
+      return;
+    }
+
+    if (
+      !biometricInfo?.strongBiometryIsAvailable &&
+      biometricInfo?.code === BiometryErrorType.biometryNotEnrolled
+    ) {
+      NativeSettings.open({
+        optionAndroid: AndroidSettings.Security,
+        optionIOS: IOSSettings.TouchIdPasscode,
+      }).then((result) => {
+        inBiometricSetup.current = result.status;
+      });
+
+      return;
+    }
+
+    if (
+      !stateCache?.authentication.passwordIsSkipped &&
+      stateCache?.authentication.passwordIsSet
+    ) {
+      setVerifyPasswordIsOpen(true);
+    } else {
+      setVerifyPasscodeIsOpen(true);
+    }
+  };
+
+  const biometricAuth = async () => {
+    const result = await handleBiometricAuth();
+    if (result) handleToggleBiometricAuth();
+  };
+
+  useEffect(() => {
+    if (biometricInfo?.strongBiometryIsAvailable && inBiometricSetup.current) {
+      handleBiometricUpdate();
+    }
+  }, [biometricInfo]);
+
   const handleOptionClick = async (item: OptionProps) => {
     switch (item.label) {
     case i18n.t("settings.sections.security.biometry"): {
-      await Agent.agent.basicStorage.createOrUpdateBasicRecord(
-        new BasicRecord({
-          id: MiscRecordId.APP_BIOMETRY,
-          content: { enabled: !biometryCache.enabled },
-        })
-      );
-      dispatch(setEnableBiometryCache(!biometryCache.enabled));
+      handleBiometricUpdate();
       break;
     }
     default:
@@ -174,6 +239,16 @@ const Settings = () => {
           </IonItem>
         </IonList>
       </IonCard>
+      <VerifyPassword
+        isOpen={verifyPasswordIsOpen}
+        setIsOpen={setVerifyPasswordIsOpen}
+        onVerify={biometricAuth}
+      />
+      <VerifyPasscode
+        isOpen={verifyPasscodeIsOpen}
+        setIsOpen={setVerifyPasscodeIsOpen}
+        onVerify={biometricAuth}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Description

This PR use to update missing logic of enable biometrics on setting page:

1. Add verify password/passcode, verify biometry when user enable biometric auth
2. Nav to setting page when biometry not enrolled

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-914](https://cardanofoundation.atlassian.net/browse/DTIS-914)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/19c23ac4-9a42-47fc-8fc0-65b72a3b7b14


#### Android

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/5ba75fad-a2c3-429e-a76c-359ee8157e45


#### Browser

[DTIS-914]: https://cardanofoundation.atlassian.net/browse/DTIS-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ