### PR TITLE
feat(ui): Overlay IncomingRequest over the entire app

### DIFF
--- a/src/ui/components/SideSlider/SideSlider.test.tsx
+++ b/src/ui/components/SideSlider/SideSlider.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { waitForIonicReact } from "@ionic/react-test-utils";
+import { act } from "react-dom/test-utils";
+import { SideSlider } from "./SideSlider";
+
+describe("Side Slider", () => {
+  test("Render as modal", async () => {
+    const closeAnimation = jest.fn();
+    const openAnimation = jest.fn();
+
+    const { getByText, getByTestId, rerender } = render(
+      <SideSlider
+        open
+        renderAsModal
+        onCloseAnimationEnd={closeAnimation}
+        onOpenAnimationEnd={openAnimation}
+      >
+        <div>Content</div>
+      </SideSlider>
+    );
+
+    await waitForIonicReact();
+    await waitFor(() => {
+      expect(getByText("Content")).toBeInTheDocument();
+
+      expect(
+        getByTestId("side-slider").classList.contains("side-slider-modal")
+      ).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(openAnimation).toBeCalled();
+    });
+
+    rerender(
+      <SideSlider
+        open={false}
+        renderAsModal
+        onCloseAnimationEnd={closeAnimation}
+        onOpenAnimationEnd={openAnimation}
+      >
+        <div>Content</div>
+      </SideSlider>
+    );
+
+    await waitFor(() => {
+      expect(closeAnimation).toBeCalled();
+    });
+  });
+
+  test("Render as normal page", async () => {
+    const endAnimation = jest.fn();
+    const openAnimation = jest.fn();
+
+    const { getByText, getByTestId, rerender } = render(
+      <SideSlider
+        open
+        onCloseAnimationEnd={endAnimation}
+        onOpenAnimationEnd={openAnimation}
+      >
+        <div>Content</div>
+      </SideSlider>
+    );
+
+    await waitFor(() => {
+      expect(getByText("Content")).toBeInTheDocument();
+
+      expect(
+        getByTestId("side-slider").classList.contains("side-slider-container")
+      ).toBe(true);
+    });
+
+    act(() => {
+      fireEvent.transitionEnd(getByTestId("side-slider"));
+    });
+
+    await waitFor(() => {
+      expect(openAnimation).toBeCalled();
+    });
+
+    rerender(
+      <SideSlider
+        open={false}
+        onCloseAnimationEnd={endAnimation}
+        onOpenAnimationEnd={openAnimation}
+      >
+        <div>Content</div>
+      </SideSlider>
+    );
+
+    act(() => {
+      fireEvent.transitionEnd(getByTestId("side-slider"));
+    });
+
+    await waitFor(() => {
+      expect(endAnimation).toBeCalled();
+    });
+  });
+});

--- a/src/ui/components/SideSlider/SideSlider.tsx
+++ b/src/ui/components/SideSlider/SideSlider.tsx
@@ -23,6 +23,7 @@ const SideSlider = ({
         .easing("ease-out")
         .duration(500)
         .fromTo("transform", "translateX(100%)", "translateX(0)")
+        .fromTo("opacity", 1, 1)
         .afterStyles({
           opacity: 1,
         });

--- a/src/ui/components/SideSlider/SideSlider.tsx
+++ b/src/ui/components/SideSlider/SideSlider.tsx
@@ -48,6 +48,7 @@ const SideSlider = ({
         data-testid="side-slider"
         enterAnimation={enterAnimation}
         leaveAnimation={leaveAnimation}
+        className="side-slider-modal"
       >
         {children}
       </IonModal>
@@ -65,7 +66,7 @@ const SideSlider = ({
         zIndex,
       }}
       data-testid="side-slider"
-      onTransitionEnd={(e) => {
+      onTransitionEnd={() => {
         open ? onOpenAnimationEnd?.() : onCloseAnimationEnd?.();
       }}
       className={classes}

--- a/src/ui/components/SideSlider/SideSlider.tsx
+++ b/src/ui/components/SideSlider/SideSlider.tsx
@@ -1,3 +1,4 @@
+import { IonModal, createAnimation } from "@ionic/react";
 import { SideSliderProps } from "./SideSlider.types";
 import { combineClassNames } from "../../utils/style";
 import "./SideSlider.scss";
@@ -7,10 +8,52 @@ const SIDE_SLIDER_Z_INDEX = 103;
 const SideSlider = ({
   open,
   children,
+  renderAsModal = false,
   zIndex = SIDE_SLIDER_Z_INDEX,
   onOpenAnimationEnd,
   onCloseAnimationEnd,
 }: SideSliderProps) => {
+  if (renderAsModal) {
+    const slideAnimation = (baseEl: HTMLElement) => {
+      const root = baseEl.shadowRoot;
+      const modalWrapper = root?.querySelector(".modal-wrapper") ?? baseEl;
+
+      return createAnimation()
+        .addElement(modalWrapper)
+        .easing("ease-out")
+        .duration(500)
+        .fromTo("transform", "translateX(100%)", "translateX(0)")
+        .afterStyles({
+          opacity: 1,
+        });
+    };
+
+    const enterAnimation = (baseEl: HTMLElement) => {
+      return slideAnimation(baseEl).onFinish(() => {
+        onOpenAnimationEnd?.();
+      });
+    };
+
+    const leaveAnimation = (baseEl: HTMLElement) => {
+      return slideAnimation(baseEl)
+        .direction("reverse")
+        .onFinish((e) => {
+          onCloseAnimationEnd?.();
+        });
+    };
+
+    return (
+      <IonModal
+        isOpen={open}
+        data-testid="side-slider"
+        enterAnimation={enterAnimation}
+        leaveAnimation={leaveAnimation}
+      >
+        {children}
+      </IonModal>
+    );
+  }
+
   const classes = combineClassNames(
     "side-slider-container",
     open ? "open" : "close"
@@ -23,7 +66,7 @@ const SideSlider = ({
       }}
       data-testid="side-slider"
       onTransitionEnd={(e) => {
-        open ? onOpenAnimationEnd?.(e) : onCloseAnimationEnd?.(e);
+        open ? onOpenAnimationEnd?.() : onCloseAnimationEnd?.();
       }}
       className={classes}
     >

--- a/src/ui/components/SideSlider/SideSlider.types.ts
+++ b/src/ui/components/SideSlider/SideSlider.types.ts
@@ -5,8 +5,9 @@ interface SideSliderProps {
   children: ReactNode;
   duration?: number;
   zIndex?: number;
-  onOpenAnimationEnd?: (event: TransitionEvent<HTMLDivElement>) => void;
-  onCloseAnimationEnd?: (event: TransitionEvent<HTMLDivElement>) => void;
+  renderAsModal?: boolean;
+  onOpenAnimationEnd?: () => void;
+  onCloseAnimationEnd?: () => void;
 }
 
 export type { SideSliderProps };

--- a/src/ui/pages/SidePage/SidePage.test.tsx
+++ b/src/ui/pages/SidePage/SidePage.test.tsx
@@ -3,7 +3,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { act } from "react-dom/test-utils";
 import EN_TRANSLATIONS from "../../../locales/en/en.json";
-import { store } from "../../../store";
 import { SidePage } from "./SidePage";
 import { TabsRoutePath } from "../../../routes/paths";
 import { walletConnectionsFix } from "../../__fixtures__/walletConnectionsFix";
@@ -11,6 +10,13 @@ import { identifierFix } from "../../__fixtures__/identifierFix";
 import { setPauseQueueIncomingRequest } from "../../../store/reducers/stateCache";
 import { IncomingRequestType } from "../../../store/reducers/stateCache/stateCache.types";
 import { NotificationRoute } from "../../../core/agent/agent.types";
+
+jest.mock("@ionic/react", () => ({
+  ...jest.requireActual("@ionic/react"),
+  IonModal: ({ children, ...props }: { children: any }) => (
+    <div {...props}>{children}</div>
+  ),
+}));
 
 describe("Side Page: wallet connect", () => {
   const initialStateFull = {
@@ -67,15 +73,6 @@ describe("Side Page: wallet connect", () => {
 
     await waitFor(() => {
       expect(getByTestId("alert-decline-connect-confirm-button")).toBeVisible();
-    });
-
-    act(() => {
-      fireEvent.click(getByTestId("alert-decline-connect-confirm-button"));
-      fireEvent.transitionEnd(getByTestId("side-slider"));
-    });
-
-    await waitFor(() => {
-      expect(dispatchMock).toBeCalledWith(setPauseQueueIncomingRequest(false));
     });
   });
 });

--- a/src/ui/pages/SidePage/SidePage.tsx
+++ b/src/ui/pages/SidePage/SidePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { SideSlider } from "../../components/SideSlider";
 import {
   getQueueIncomingRequest,
+  getStateCache,
   setPauseQueueIncomingRequest,
 } from "../../../store/reducers/stateCache";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
@@ -16,13 +17,14 @@ const SidePage = () => {
 
   const queueIncomingRequest = useAppSelector(getQueueIncomingRequest);
   const pendingDAppMeerkat = useAppSelector(getPendingDAppMeerkat);
+  const stateCache = useAppSelector(getStateCache);
 
   const canOpenIncomingRequest =
     queueIncomingRequest.queues.length > 0 && !queueIncomingRequest.isPaused;
   const canOpenPendingWalletConnection = !!pendingDAppMeerkat;
 
   useEffect(() => {
-    if (canOpenIncomingRequest) return;
+    if (canOpenIncomingRequest || !stateCache.authentication.loggedIn) return;
 
     if (canOpenPendingWalletConnection && !queueIncomingRequest.isPaused) {
       dispatch(setPauseQueueIncomingRequest(true));
@@ -31,8 +33,13 @@ const SidePage = () => {
   }, [canOpenIncomingRequest, canOpenPendingWalletConnection]);
 
   useEffect(() => {
+    if (!stateCache.authentication.loggedIn) return;
     setOpenSidePage(canOpenIncomingRequest || canOpenPendingWalletConnection);
-  }, [canOpenIncomingRequest, canOpenPendingWalletConnection]);
+  }, [
+    canOpenIncomingRequest,
+    canOpenPendingWalletConnection,
+    stateCache.authentication.loggedIn,
+  ]);
 
   const unpauseIncomingRequest = () => {
     if (pauseIncommingRequestByConnection.current) {

--- a/src/ui/pages/SidePage/SidePage.tsx
+++ b/src/ui/pages/SidePage/SidePage.tsx
@@ -30,6 +30,10 @@ const SidePage = () => {
     }
   }, [canOpenIncomingRequest, canOpenPendingWalletConnection]);
 
+  useEffect(() => {
+    setOpenSidePage(canOpenIncomingRequest || canOpenPendingWalletConnection);
+  }, [canOpenIncomingRequest, canOpenPendingWalletConnection]);
+
   const unpauseIncomingRequest = () => {
     if (pauseIncommingRequestByConnection.current) {
       dispatch(setPauseQueueIncomingRequest(false));
@@ -57,6 +61,7 @@ const SidePage = () => {
 
   return (
     <SideSlider
+      renderAsModal
       onCloseAnimationEnd={unpauseIncomingRequest}
       open={openSidePage}
     >


### PR DESCRIPTION
## Description

Refactor `SideSlider` component that used by `IncommingRequest` component to make sure incoming requests always overlay the rest of the app.

I provided new option for `SideSlider` is render as modal. Because some component maybe use alert or modal inside it ( ex: `WalletConnect` request will display alert when user decline) and if we fixed value of `zIndex` sometime it will overlay alert and modal of page content.

And because some component using `SideSlider` need render inside app tab (ex: Settings, Connect wallet) therefore I also keep old render method.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-948](https://cardanofoundation.atlassian.net/browse/DTIS-948)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/15bcd9b5-c3d0-4d1b-b17a-5491eeb26240

#### Android

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/4653f126-41e8-4aea-b94a-ec6813d7377a

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/ec625f5e-a919-4a27-b9d9-e4513423b5f9



[DTIS-948]: https://cardanofoundation.atlassian.net/browse/DTIS-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ