### PR TITLE
feat(ui): Auto-open the modal for the connection

### DIFF
--- a/src/core/cardano/walletConnect/peerConnection.ts
+++ b/src/core/cardano/walletConnect/peerConnection.ts
@@ -119,7 +119,7 @@ class PeerConnection {
         if (!connectMessage.error) {
           const { name, url, address, icon } = connectMessage.dApp;
           this.connectedDAppAdress = address;
-          let iconB64 = ICON_BASE64;
+          let iconB64;
           // Check if the icon is base64
           if (
             icon &&
@@ -192,7 +192,6 @@ class PeerConnection {
         {
           id: dAppIdentifier,
           selectedAid: this.identityWalletConnect.getConnectingAid(),
-          iconB64: ICON_BASE64,
         }
       );
     }

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -898,16 +898,10 @@
           "cip": "CIP-45",
           "tabheader": "Cardano Connect",
           "connectbtn": "Connect with Cardano",
-          "connectwalletmodal": {
-            "header": "New connection",
-            "cancel": "Cancel",
-            "scanqr": "Scan QR code",
-            "pastePID": "Paste Peer ID",
-            "disconnectbeforecreatealert": {
-              "message": "You are currently connected. To connect with a new wallet, you will be disconnected from your current selection. Would you like to disconnect and continue?",
-              "confirm": "Continue",
-              "cancel": "Cancel"
-            }
+          "disconnectbeforecreatealert": {
+            "message": "You are currently connected. To connect with a new wallet, you will be disconnected from your current selection. Would you like to disconnect and continue?",
+            "confirm": "Continue",
+            "cancel": "Cancel"
           },
           "connectionbrokenalert": {
             "message": "Your connection has been disconnected as you have deleted the chosen identifier paired with this connection. Please choose a new identifier to re-establish this connection.",

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -937,7 +937,9 @@
             "confirmconnect": {
               "done": "Done",
               "connectbtn": "Connect",
-              "disconnectbtn": "Disconnect"
+              "disconnectbtn": "Disconnect",
+              "connectingbtn": "Connecting...",
+              "pending": "Pending"
             }
           },
           "request": {

--- a/src/routes/backRoute/backRoute.test.ts
+++ b/src/routes/backRoute/backRoute.test.ts
@@ -62,7 +62,7 @@ describe("getBackRoute", () => {
       walletConnectionsCache: {
         walletConnections: [],
         connectedWallet: null,
-        pendingDAppMeerKat: null,
+        pendingConnection: null,
       },
       identifierViewTypeCacheCache: {
         viewType: null,
@@ -189,7 +189,7 @@ describe("getPreviousRoute", () => {
       walletConnectionsCache: {
         walletConnections: [],
         connectedWallet: null,
-        pendingDAppMeerKat: null,
+        pendingConnection: null,
       },
       identifierViewTypeCacheCache: {
         viewType: null,

--- a/src/routes/nextRoute/nextRoute.test.ts
+++ b/src/routes/nextRoute/nextRoute.test.ts
@@ -61,7 +61,7 @@ describe("NextRoute", () => {
       walletConnectionsCache: {
         walletConnections: [],
         connectedWallet: null,
-        pendingDAppMeerKat: null,
+        pendingConnection: null,
       },
       identifierViewTypeCacheCache: {
         viewType: null,
@@ -194,7 +194,7 @@ describe("getNextRoute", () => {
     walletConnectionsCache: {
       walletConnections: [],
       connectedWallet: null,
-      pendingDAppMeerKat: null,
+      pendingConnection: null,
     },
     identifierViewTypeCacheCache: {
       viewType: null,

--- a/src/store/reducers/walletConnectionsCache/walletConnectionsCache.test.ts
+++ b/src/store/reducers/walletConnectionsCache/walletConnectionsCache.test.ts
@@ -2,10 +2,10 @@ import { PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "../../index";
 import {
   getConnectedWallet,
-  getPendingDAppMeerkat,
+  getPendingConnection,
   getWalletConnectionsCache,
   setConnectedWallet,
-  setPendingDAppMeerKat,
+  setPendingConnection,
   setWalletConnectionsCache,
   walletConnectionsCacheSlice,
 } from "./walletConnectionsCache";
@@ -18,7 +18,7 @@ describe("walletConnectionsCacheSlice", () => {
   const initialState: WalletConnectState = {
     walletConnections: [],
     connectedWallet: null,
-    pendingDAppMeerKat: null,
+    pendingConnection: null,
   };
 
   it("should return the initial state", () => {
@@ -51,16 +51,18 @@ describe("walletConnectionsCacheSlice", () => {
     };
     const newState = walletConnectionsCacheSlice.reducer(
       initialState,
-      setConnectedWallet(connection.id)
+      setConnectedWallet(connection)
     );
-    expect(newState.connectedWallet).toEqual(connection.id);
+    expect(newState.connectedWallet).toEqual(connection);
   });
-  it("should handle setPendingDAppMeerKat", () => {
+  it("should handle setPendingConnection", () => {
     const newState = walletConnectionsCacheSlice.reducer(
       initialState,
-      setPendingDAppMeerKat("pending-meerkat")
+      setPendingConnection({
+        id: "pending-meerkat",
+      })
     );
-    expect(newState.pendingDAppMeerKat).toEqual("pending-meerkat");
+    expect(newState.pendingConnection?.id).toEqual("pending-meerkat");
   });
 });
 
@@ -94,7 +96,9 @@ describe("Get wallet connections cache", () => {
   it("should return connected wallet from RootState", () => {
     const state = {
       walletConnectionsCache: {
-        connectedWallet: "1",
+        connectedWallet: {
+          id: "1",
+        },
       },
     } as RootState;
     const connectionCache = getConnectedWallet(state);
@@ -105,12 +109,14 @@ describe("Get wallet connections cache", () => {
   it("should return pending DApp MeerKat from RootState", () => {
     const state = {
       walletConnectionsCache: {
-        pendingDAppMeerKat: "pending-meerkat",
+        pendingConnection: {
+          id: "pending-meerkat",
+        },
       },
     } as RootState;
-    const pendingMeerKatCache = getPendingDAppMeerkat(state);
+    const pendingMeerKatCache = getPendingConnection(state);
     expect(pendingMeerKatCache).toEqual(
-      state.walletConnectionsCache.pendingDAppMeerKat
+      state.walletConnectionsCache.pendingConnection
     );
   });
 });

--- a/src/store/reducers/walletConnectionsCache/walletConnectionsCache.ts
+++ b/src/store/reducers/walletConnectionsCache/walletConnectionsCache.ts
@@ -8,7 +8,7 @@ import {
 const initialState: WalletConnectState = {
   walletConnections: [],
   connectedWallet: null,
-  pendingDAppMeerKat: null,
+  pendingConnection: null,
 };
 const walletConnectionsCacheSlice = createSlice({
   name: "walletConnectionsCache",
@@ -20,11 +20,17 @@ const walletConnectionsCacheSlice = createSlice({
     ) => {
       state.walletConnections = action.payload;
     },
-    setConnectedWallet: (state, action: PayloadAction<string | null>) => {
+    setConnectedWallet: (
+      state,
+      action: PayloadAction<ConnectionData | null>
+    ) => {
       state.connectedWallet = action.payload;
     },
-    setPendingDAppMeerKat: (state, action: PayloadAction<string | null>) => {
-      state.pendingDAppMeerKat = action.payload;
+    setPendingConnection: (
+      state,
+      action: PayloadAction<ConnectionData | null>
+    ) => {
+      state.pendingConnection = action.payload;
     },
   },
 });
@@ -34,7 +40,7 @@ export { initialState, walletConnectionsCacheSlice };
 export const {
   setWalletConnectionsCache,
   setConnectedWallet,
-  setPendingDAppMeerKat,
+  setPendingConnection,
 } = walletConnectionsCacheSlice.actions;
 
 const getWalletConnectionsCache = (state: RootState) =>
@@ -43,7 +49,7 @@ const getWalletConnectionsCache = (state: RootState) =>
 const getConnectedWallet = (state: RootState) =>
   state.walletConnectionsCache.connectedWallet;
 
-const getPendingDAppMeerkat = (state: RootState) =>
-  state.walletConnectionsCache.pendingDAppMeerKat;
+const getPendingConnection = (state: RootState) =>
+  state.walletConnectionsCache.pendingConnection;
 
-export { getWalletConnectionsCache, getConnectedWallet, getPendingDAppMeerkat };
+export { getWalletConnectionsCache, getConnectedWallet, getPendingConnection };

--- a/src/store/reducers/walletConnectionsCache/walletConnectionsCache.types.ts
+++ b/src/store/reducers/walletConnectionsCache/walletConnectionsCache.types.ts
@@ -9,8 +9,8 @@ interface ConnectionData {
 
 interface WalletConnectState {
   walletConnections: ConnectionData[];
-  connectedWallet: string | null;
-  pendingDAppMeerKat: string | null;
+  connectedWallet: ConnectionData | null;
+  pendingConnection: ConnectionData | null;
 }
 
 export type { ConnectionData, WalletConnectState };

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -322,9 +322,9 @@ describe("AppWrapper handler", () => {
       Agent.agent.peerConnectionMetadataStorage.getAllPeerConnectionMetadata =
         jest.fn().mockResolvedValue([peerConnectionMock]);
       await peerConnectedChangeHandler(peerConnectedEventMock, dispatch);
-      expect(dispatch).toBeCalledWith(
-        setConnectedWallet(peerConnectionMock.id)
-      );
+      await waitFor(() => {
+        expect(dispatch).toBeCalledWith(setConnectedWallet(peerConnectionMock));
+      });
       expect(dispatch).toBeCalledWith(
         setWalletConnectionsCache([peerConnectionMock])
       );

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -45,6 +45,7 @@ import { useActivityTimer } from "./hooks/useActivityTimer";
 import {
   getConnectedWallet,
   setConnectedWallet,
+  setPendingDAppMeerKat,
   setWalletConnectionsCache,
 } from "../../../store/reducers/walletConnectionsCache";
 import { PeerConnection } from "../../../core/cardano/walletConnect/peerConnection";
@@ -176,6 +177,7 @@ const peerConnectedChangeHandler = async (
     await Agent.agent.peerConnectionMetadataStorage.getAllPeerConnectionMetadata();
   dispatch(setWalletConnectionsCache(existingConnections));
   dispatch(setConnectedWallet(event.payload.dAppAddress));
+  dispatch(setPendingDAppMeerKat(null));
   dispatch(setToastMsg(ToastMsgType.CONNECT_WALLET_SUCCESS));
 };
 

--- a/src/ui/components/CardList/CardList.scss
+++ b/src/ui/components/CardList/CardList.scss
@@ -8,6 +8,7 @@
   ion-item.card-item {
     --inner-padding-top: 1rem;
     --inner-padding-bottom: 1rem;
+    --inner-padding-end: 0;
     --padding-start: 0;
     --background: var(--ion-color-light);
     --title-font-size: 1rem;
@@ -43,6 +44,7 @@
 
     .card-info {
       flex: 1;
+      overflow: hidden;
 
       .card-title {
         font-size: var(--title-font-size);
@@ -51,6 +53,9 @@
         font-weight: 500;
         color: var(--ion-color-primary);
         margin-top: 0;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
 
         &.no-margin {
           --title-margin-bottom: 0;

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -35,7 +35,7 @@ import { MultiSigGroup } from "../../../store/reducers/identifiersCache/identifi
 import { PageFooter } from "../PageFooter";
 import { CustomInput } from "../CustomInput";
 import { OptionModal } from "../OptionsModal";
-import { setPendingDAppMeerKat } from "../../../store/reducers/walletConnectionsCache";
+import { setPendingConnection } from "../../../store/reducers/walletConnectionsCache";
 import { CreateIdentifier } from "../CreateIdentifier";
 import { setBootUrl, setConnectUrl } from "../../../store/reducers/ssiAgent";
 
@@ -96,7 +96,11 @@ const Scanner = forwardRef(
     const handleConnectWallet = (id: string) => {
       handleReset && handleReset();
       dispatch(setToastMsg(ToastMsgType.PEER_ID_SUCCESS));
-      dispatch(setPendingDAppMeerKat(id));
+      dispatch(
+        setPendingConnection({
+          id,
+        })
+      );
     };
 
     const updateConnections = async (groupId: string) => {

--- a/src/ui/components/SideSlider/SideSlider.tsx
+++ b/src/ui/components/SideSlider/SideSlider.tsx
@@ -1,5 +1,5 @@
 import { IonModal, createAnimation } from "@ionic/react";
-import { SideSliderProps } from "./SideSlider.types";
+import { ANIMATION_DURATION, SideSliderProps } from "./SideSlider.types";
 import { combineClassNames } from "../../utils/style";
 import "./SideSlider.scss";
 
@@ -21,7 +21,7 @@ const SideSlider = ({
       return createAnimation()
         .addElement(modalWrapper)
         .easing("ease-out")
-        .duration(500)
+        .duration(ANIMATION_DURATION)
         .fromTo("transform", "translateX(100%)", "translateX(0)")
         .fromTo("opacity", 1, 1)
         .afterStyles({

--- a/src/ui/components/SideSlider/SideSlider.types.ts
+++ b/src/ui/components/SideSlider/SideSlider.types.ts
@@ -10,4 +10,6 @@ interface SideSliderProps {
   onCloseAnimationEnd?: () => void;
 }
 
+export const ANIMATION_DURATION = 500;
+
 export type { SideSliderProps };

--- a/src/ui/globals/types.ts
+++ b/src/ui/globals/types.ts
@@ -29,6 +29,7 @@ enum OperationType {
   SCAN_WALLET_CONNECTION = "scanWalletConnection",
   SCAN_SSI_BOOT_URL = "scanSSIBootUrl",
   SCAN_SSI_CONNECT_URL = "scanSSIConnectUrl",
+  OPEN_WALLET_CONNECTION_DETAIL = "openWalletConnection",
 }
 
 enum ToastMsgType {

--- a/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.scss
+++ b/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.scss
@@ -108,6 +108,12 @@
       }
     }
 
+    & .page-header.md {
+      ion-toolbar {
+        max-height: none !important;
+      }
+    }
+
     &.responsive-modal .responsive-modal-content {
       .confirm-modal-id {
         padding: 0.875rem 1.5rem;
@@ -115,6 +121,15 @@
         & > span {
           font-size: 0.875rem;
         }
+      }
+
+      .wallet-connect-fallback-logo {
+        width: 2.5rem;
+        height: 2.5rem;
+      }
+
+      .confirm-modal-name-title {
+        font-size: 0.875rem;
       }
 
       .confirm-connect-submit {

--- a/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.scss
+++ b/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.scss
@@ -34,13 +34,14 @@
     }
 
     .confirm-modal-name {
-      margin: 0;
+      margin: 0 0 1.25rem;
       font-size: 0.875rem;
       line-height: 1rem;
+      font-weight: 400;
     }
 
     .confirm-modal-id {
-      margin: 1.25rem 0 1.5rem;
+      margin: 0 0 1.5rem;
       padding: 1rem 1.5rem;
       background-color: #fff;
       border-radius: 1.875rem;
@@ -57,6 +58,18 @@
         margin-left: 0.625rem;
         width: 1.375rem;
         height: 1.375rem;
+      }
+    }
+
+    .pending-chip {
+      margin: 1.25rem 0 1.5rem;
+      border-radius: 0.25rem;
+      color: var(--ion-color-secondary);
+      background: rgba(187, 187, 187, 0.5);
+
+      & > span {
+        font-size: 0.75rem;
+        font-weight: 400;
       }
     }
 

--- a/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.test.tsx
+++ b/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.test.tsx
@@ -37,7 +37,7 @@ const initialState = {
     identifiers: [...identifierFix],
   },
   walletConnectionsCache: {
-    pendingDAppMeerKat: undefined,
+    pendingConnection: null,
   },
 };
 
@@ -181,7 +181,7 @@ describe("Confirm connect modal", () => {
         identifiers: [...identifierFix],
       },
       walletConnectionsCache: {
-        pendingDAppMeerKat: walletConnectionsFix[0].id,
+        pendingConnection: walletConnectionsFix[0],
       },
     };
 

--- a/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.tsx
+++ b/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.tsx
@@ -8,7 +8,7 @@ import {
 import { i18n } from "../../../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
 import { setToastMsg } from "../../../../../store/reducers/stateCache";
-import { getPendingDAppMeerkat } from "../../../../../store/reducers/walletConnectionsCache";
+import { getPendingConnection } from "../../../../../store/reducers/walletConnectionsCache";
 import { OptionModal } from "../../../../components/OptionsModal";
 import { ToastMsgType } from "../../../../globals/types";
 import { writeToClipboard } from "../../../../utils/clipboard";
@@ -26,7 +26,7 @@ const ConfirmConnectModal = ({
   onDeleteConnection,
 }: ConfirmConnectModalProps) => {
   const dispatch = useAppDispatch();
-  const pendingMeerkatId = useAppSelector(getPendingDAppMeerkat);
+  const pendingConnection = useAppSelector(getPendingConnection);
 
   const cardImg = connectionData?.iconB64 ? (
     <img
@@ -48,7 +48,7 @@ const ConfirmConnectModal = ({
   );
 
   const isConnecting =
-    !!pendingMeerkatId && pendingMeerkatId === connectionData?.id;
+    !!pendingConnection && pendingConnection.id === connectionData?.id;
   const dAppName = !connectionData?.name
     ? ellipsisText(connectionData?.id || "", 25)
     : connectionData?.name;
@@ -61,9 +61,9 @@ const ConfirmConnectModal = ({
         : "menu.tab.items.connectwallet.connectionhistory.confirmconnect.disconnectbtn"
   );
 
-  const meerkatId =
-    (connectionData?.id as string).substring(0, 5) +
-    (connectionData?.id as string).slice(-5);
+  const meerkatId = connectionData?.id
+    ? connectionData.id.substring(0, 5) + "..." + connectionData.id.slice(-5)
+    : "";
 
   const deleteConnection = () => {
     if (!connectionData) return;

--- a/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.tsx
+++ b/src/ui/pages/Menu/components/ConfirmConnectModal/ConfirmConnectModal.tsx
@@ -61,12 +61,9 @@ const ConfirmConnectModal = ({
         : "menu.tab.items.connectwallet.connectionhistory.confirmconnect.disconnectbtn"
   );
 
-  const displayMeerkatId =
-    connectionData && connectionData.id && connectionData.name
-      ? (connectionData.id as string).substring(0, 5) +
-        "..." +
-        (connectionData.id as string).slice(-5)
-      : null;
+  const meerkatId =
+    (connectionData?.id as string).substring(0, 5) +
+    (connectionData?.id as string).slice(-5);
 
   const deleteConnection = () => {
     if (!connectionData) return;
@@ -117,7 +114,7 @@ const ConfirmConnectModal = ({
           {connectionData?.url}
         </p>
       )}
-      {!isConnecting && displayMeerkatId && (
+      {!isConnecting && connectionData?.name && (
         <div
           onClick={() => {
             if (!connectionData?.id) return;
@@ -127,7 +124,7 @@ const ConfirmConnectModal = ({
           className="confirm-modal-id"
           data-testid="connection-id"
         >
-          <span>{displayMeerkatId}</span>
+          <span>{meerkatId}</span>
           <IonIcon icon={copyOutline} />
         </div>
       )}

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.scss
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.scss
@@ -10,6 +10,16 @@
     height: calc(100vh - 8rem);
   }
 
+  .connection-pending {
+    width: 2rem;
+    height: 2rem;
+    padding: 0.5rem;
+
+    & > ion-icon {
+      margin: 0;
+    }
+  }
+
   @media screen and (min-width: 250px) and (max-width: 370px) {
     .connect-wallet-title {
       font-size: 1rem;

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -14,6 +14,7 @@ import { OperationType, ToastMsgType } from "../../../../globals/types";
 import { identifierFix } from "../../../../__fixtures__/identifierFix";
 import { PeerConnection } from "../../../../../core/cardano/walletConnect/peerConnection";
 import { setPendingDAppMeerKat } from "../../../../../store/reducers/walletConnectionsCache";
+import { ellipsisText } from "../../../../utils/formatters";
 
 jest.mock("../../../../../core/agent/agent", () => ({
   Agent: {
@@ -480,6 +481,154 @@ describe("Wallet connect", () => {
       expect(dispatchMock).toBeCalledWith(
         setCurrentOperation(OperationType.CREATE_IDENTIFIER_CONNECT_WALLET)
       );
+    });
+  });
+
+  test("Show connection modal after create connect to wallet", async () => {
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.IDENTIFIERS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: true,
+        },
+        currentOperation: OperationType.OPEN_WALLET_CONNECTION_DETAIL,
+      },
+      walletConnectionsCache: {
+        walletConnections: [
+          ...walletConnectionsFix,
+          {
+            ...walletConnectionsFix[0],
+            name: undefined,
+            url: undefined,
+          },
+        ],
+        connectedWallet: null,
+        pendingDAppMeerKat: walletConnectionsFix[0].id,
+      },
+      identifiersCache: {
+        identifiers: [
+          {
+            signifyName: "Test",
+            id: "EN5dwY0N7RKn6OcVrK7ksIniSgPcItCuBRax2JFUpuRd",
+            displayName: "Professional ID",
+            createdAtUTC: "2023-01-01T19:23:24Z",
+            isPending: false,
+            theme: 0,
+            s: 4, // Sequence number, only show if s > 0
+            dt: "2023-06-12T14:07:53.224866+00:00", // Last key rotation timestamp, if s > 0
+            kt: 2, // Keys signing threshold (only show if kt > 1)
+            k: [
+              // List of signing keys - array
+              "DCF6b0c5aVm_26_sCTgLB4An6oUxEM5pVDDLqxxXDxH-",
+            ],
+            nt: 3, // Next keys signing threshold, only show if nt > 1
+            n: [
+              // Next keys digests - array
+              "EIZ-n_hHHY5ERGTzvpXYBkB6_yBAM4RXcjQG3-JykFvF",
+            ],
+            bt: 1, // Backer threshold and backer keys below
+            b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"], // List of backers
+            di: "test", // Delegated identifier prefix, don't show if ""
+          },
+        ],
+      },
+      biometryCache: {
+        enabled: false,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const { getByTestId, getByText, rerender } = render(
+      <MemoryRouter>
+        <Provider store={storeMocked}>
+          <ConnectWallet />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    const updatedStore = {
+      stateCache: {
+        routes: [TabsRoutePath.IDENTIFIERS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: true,
+        },
+        currentOperation: OperationType.IDLE,
+        toastMsg: ToastMsgType.CONNECT_WALLET_SUCCESS,
+      },
+      walletConnectionsCache: {
+        walletConnections: [
+          ...walletConnectionsFix,
+          {
+            ...walletConnectionsFix[0],
+          },
+        ],
+        connectedWallet: null,
+        pendingDAppMeerKat: null,
+      },
+      identifiersCache: {
+        identifiers: [
+          {
+            signifyName: "Test",
+            id: "EN5dwY0N7RKn6OcVrK7ksIniSgPcItCuBRax2JFUpuRd",
+            displayName: "Professional ID",
+            createdAtUTC: "2023-01-01T19:23:24Z",
+            isPending: false,
+            theme: 0,
+            s: 4, // Sequence number, only show if s > 0
+            dt: "2023-06-12T14:07:53.224866+00:00", // Last key rotation timestamp, if s > 0
+            kt: 2, // Keys signing threshold (only show if kt > 1)
+            k: [
+              // List of signing keys - array
+              "DCF6b0c5aVm_26_sCTgLB4An6oUxEM5pVDDLqxxXDxH-",
+            ],
+            nt: 3, // Next keys signing threshold, only show if nt > 1
+            n: [
+              // Next keys digests - array
+              "EIZ-n_hHHY5ERGTzvpXYBkB6_yBAM4RXcjQG3-JykFvF",
+            ],
+            bt: 1, // Backer threshold and backer keys below
+            b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"], // List of backers
+            di: "test", // Delegated identifier prefix, don't show if ""
+          },
+        ],
+      },
+      biometryCache: {
+        enabled: false,
+      },
+    };
+
+    const updateStoreMocked = {
+      ...mockStore(updatedStore),
+      dispatch: dispatchMock,
+    };
+
+    await waitFor(() => {
+      expect(getByTestId("connect-wallet-title")).toBeVisible();
+      expect(
+        getByText(ellipsisText(walletConnectionsFix[0].id, 25))
+      ).toBeVisible();
+    });
+
+    rerender(
+      <MemoryRouter>
+        <Provider store={updateStoreMocked}>
+          <ConnectWallet />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("connection-id")).toBeVisible();
     });
   });
 });

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -614,9 +614,6 @@ describe("Wallet connect", () => {
 
     await waitFor(() => {
       expect(getByTestId("connect-wallet-title")).toBeVisible();
-      expect(
-        getByText(ellipsisText(walletConnectionsFix[0].id, 25))
-      ).toBeVisible();
     });
 
     rerender(

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -13,8 +13,7 @@ import {
 import { OperationType, ToastMsgType } from "../../../../globals/types";
 import { identifierFix } from "../../../../__fixtures__/identifierFix";
 import { PeerConnection } from "../../../../../core/cardano/walletConnect/peerConnection";
-import { setPendingDAppMeerKat } from "../../../../../store/reducers/walletConnectionsCache";
-import { ellipsisText } from "../../../../utils/formatters";
+import { setPendingConnection } from "../../../../../store/reducers/walletConnectionsCache";
 
 jest.mock("../../../../../core/agent/agent", () => ({
   Agent: {
@@ -69,7 +68,7 @@ const initialState = {
   },
   walletConnectionsCache: {
     walletConnections: [...walletConnectionsFix],
-    connectedWallet: walletConnectionsFix[1].id,
+    connectedWallet: walletConnectionsFix[1],
   },
   identifiersCache: {
     identifiers: [...identifierFix],
@@ -388,8 +387,26 @@ describe("Wallet connect", () => {
     });
 
     await waitFor(() => {
+      expect(
+        getByText(
+          EN_TRANSLATIONS.menu.tab.items.connectwallet
+            .disconnectbeforecreatealert.message
+        )
+      ).toBeVisible();
+    });
+
+    act(() => {
+      fireEvent.click(
+        getByText(
+          EN_TRANSLATIONS.menu.tab.items.connectwallet
+            .disconnectbeforecreatealert.confirm
+        )
+      );
+    });
+
+    await waitFor(() => {
       expect(dispatchMock).toBeCalledWith(
-        setPendingDAppMeerKat(walletConnectionsFix[0].id)
+        setPendingConnection(walletConnectionsFix[0])
       );
     });
 
@@ -506,7 +523,7 @@ describe("Wallet connect", () => {
           },
         ],
         connectedWallet: null,
-        pendingDAppMeerKat: walletConnectionsFix[0].id,
+        pendingConnection: walletConnectionsFix[0],
       },
       identifiersCache: {
         identifiers: [
@@ -573,7 +590,7 @@ describe("Wallet connect", () => {
           },
         ],
         connectedWallet: null,
-        pendingDAppMeerKat: null,
+        pendingConnection: null,
       },
       identifiersCache: {
         identifiers: [

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -81,9 +81,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
 
     const displayConnection = useMemo((): CardItem<ConnectionData>[] => {
       return connections.map((connection) => {
-        const dAppName = connection.name
-          ? connection.name
-          : ellipsisText(connection.id, 25);
+        const dAppName = connection.name ? connection.name : connection.id;
 
         return {
           id: connection.id,
@@ -154,6 +152,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
           connections.filter((connection) => connection.id !== data.id)
         )
       );
+      dispatch(setPendingDAppMeerKat(null));
       dispatch(setToastMsg(ToastMsgType.WALLET_CONNECTION_DELETED));
     };
 

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -45,7 +45,6 @@ import {
 } from "./ConnectWallet.types";
 import { Agent } from "../../../../../core/agent/agent";
 import { PeerConnection } from "../../../../../core/cardano/walletConnect/peerConnection";
-import { ellipsisText } from "../../../../utils/formatters";
 
 const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
   (props, ref) => {
@@ -161,6 +160,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
         setOpenIdentifierMissingAlert(true);
         return;
       }
+
       if (!actionInfo.data) return;
       const isConnectedItem = actionInfo.data.id === connectedWallet;
       if (isConnectedItem) {

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -44,8 +44,7 @@ import {
 } from "./ConnectWallet.types";
 import { Agent } from "../../../../../core/agent/agent";
 import { PeerConnection } from "../../../../../core/cardano/walletConnect/peerConnection";
-
-const ANIMATION_DURATION = 500;
+import { ANIMATION_DURATION } from "../../../../components/SideSlider/SideSlider.types";
 
 const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
   (props, ref) => {

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -155,7 +155,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
       dispatch(setToastMsg(ToastMsgType.WALLET_CONNECTION_DELETED));
     };
 
-    const handleConnectWallet = () => {
+    const toggleConnected = () => {
       if (identifierCache.length === 0) {
         setOpenIdentifierMissingAlert(true);
         return;
@@ -224,9 +224,13 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
       if (
         toastMsg === ToastMsgType.CONNECT_WALLET_SUCCESS &&
         !pendingDAppMeerkat &&
-        connectConnection
+        connectConnection &&
+        openConfirmConnectModal
       ) {
-        handleOpenConfirmConnectModal(connectConnection);
+        setActionInfo({
+          type: ActionType.Connect,
+          data: connectConnection,
+        });
       }
     }, [getDisplayConnection, toastMsg, pendingDAppMeerkat]);
 
@@ -311,7 +315,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
           isConnectModal={actionInfo.data?.id !== connectedWallet}
           openModal={openConfirmConnectModal}
           closeModal={() => setOpenConfirmConnectModal(false)}
-          onConfirm={handleConnectWallet}
+          onConfirm={toggleConnected}
           connectionData={actionInfo.data}
           onDeleteConnection={handleOpenDeleteAlert}
         />

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.types.ts
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.types.ts
@@ -18,4 +18,4 @@ enum ActionType {
 
 export { ActionType };
 
-export type { ConnectWalletOptionRef, ActionInfo };
+export type { ConnectWalletOptionRef, ActionInfo, ConnectionData };

--- a/src/ui/pages/SidePage/SidePage.test.tsx
+++ b/src/ui/pages/SidePage/SidePage.test.tsx
@@ -36,7 +36,7 @@ describe("Side Page: wallet connect", () => {
       identifiers: [...identifierFix],
     },
     walletConnectionsCache: {
-      pendingDAppMeerKat: "pending-meerkat",
+      pendingConnection: "pending-meerkat",
       walletConnections: [],
     },
   };

--- a/src/ui/pages/SidePage/SidePage.test.tsx
+++ b/src/ui/pages/SidePage/SidePage.test.tsx
@@ -5,7 +5,6 @@ import { act } from "react-dom/test-utils";
 import EN_TRANSLATIONS from "../../../locales/en/en.json";
 import { SidePage } from "./SidePage";
 import { TabsRoutePath } from "../../../routes/paths";
-import { walletConnectionsFix } from "../../__fixtures__/walletConnectionsFix";
 import { identifierFix } from "../../__fixtures__/identifierFix";
 import { setPauseQueueIncomingRequest } from "../../../store/reducers/stateCache";
 import { IncomingRequestType } from "../../../store/reducers/stateCache/stateCache.types";
@@ -38,6 +37,7 @@ describe("Side Page: wallet connect", () => {
     },
     walletConnectionsCache: {
       pendingDAppMeerKat: "pending-meerkat",
+      walletConnections: [],
     },
   };
 

--- a/src/ui/pages/SidePage/SidePage.tsx
+++ b/src/ui/pages/SidePage/SidePage.tsx
@@ -6,7 +6,7 @@ import {
   setPauseQueueIncomingRequest,
 } from "../../../store/reducers/stateCache";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
-import { getPendingDAppMeerkat } from "../../../store/reducers/walletConnectionsCache";
+import { getPendingConnection } from "../../../store/reducers/walletConnectionsCache";
 import { IncomingRequest } from "./components/IncomingRequest";
 import { WalletConnect } from "./components/WalletConnect";
 
@@ -16,12 +16,12 @@ const SidePage = () => {
   const pauseIncommingRequestByConnection = useRef(false);
 
   const queueIncomingRequest = useAppSelector(getQueueIncomingRequest);
-  const pendingDAppMeerkat = useAppSelector(getPendingDAppMeerkat);
+  const pendingConnection = useAppSelector(getPendingConnection);
   const stateCache = useAppSelector(getStateCache);
 
   const canOpenIncomingRequest =
     queueIncomingRequest.queues.length > 0 && !queueIncomingRequest.isPaused;
-  const canOpenPendingWalletConnection = !!pendingDAppMeerkat;
+  const canOpenPendingWalletConnection = !!pendingConnection;
 
   useEffect(() => {
     if (canOpenIncomingRequest || !stateCache.authentication.loggedIn) return;

--- a/src/ui/pages/SidePage/SidePage.tsx
+++ b/src/ui/pages/SidePage/SidePage.tsx
@@ -6,9 +6,13 @@ import {
   setPauseQueueIncomingRequest,
 } from "../../../store/reducers/stateCache";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
-import { getPendingDAppMeerkat } from "../../../store/reducers/walletConnectionsCache";
+import {
+  getPendingDAppMeerkat,
+  getWalletConnectionsCache,
+} from "../../../store/reducers/walletConnectionsCache";
 import { IncomingRequest } from "./components/IncomingRequest";
 import { WalletConnect } from "./components/WalletConnect";
+import { getConnectionsCache } from "../../../store/reducers/connectionsCache";
 
 const SidePage = () => {
   const dispatch = useAppDispatch();
@@ -17,11 +21,16 @@ const SidePage = () => {
 
   const queueIncomingRequest = useAppSelector(getQueueIncomingRequest);
   const pendingDAppMeerkat = useAppSelector(getPendingDAppMeerkat);
+  const walletConnectionCache = useAppSelector(getWalletConnectionsCache);
   const stateCache = useAppSelector(getStateCache);
 
   const canOpenIncomingRequest =
     queueIncomingRequest.queues.length > 0 && !queueIncomingRequest.isPaused;
-  const canOpenPendingWalletConnection = !!pendingDAppMeerkat;
+  const canOpenPendingWalletConnection =
+    !!pendingDAppMeerkat &&
+    !walletConnectionCache.some(
+      (item) => item.id === pendingDAppMeerkat && !item.name
+    );
 
   useEffect(() => {
     if (canOpenIncomingRequest || !stateCache.authentication.loggedIn) return;

--- a/src/ui/pages/SidePage/SidePage.tsx
+++ b/src/ui/pages/SidePage/SidePage.tsx
@@ -6,13 +6,9 @@ import {
   setPauseQueueIncomingRequest,
 } from "../../../store/reducers/stateCache";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
-import {
-  getPendingDAppMeerkat,
-  getWalletConnectionsCache,
-} from "../../../store/reducers/walletConnectionsCache";
+import { getPendingDAppMeerkat } from "../../../store/reducers/walletConnectionsCache";
 import { IncomingRequest } from "./components/IncomingRequest";
 import { WalletConnect } from "./components/WalletConnect";
-import { getConnectionsCache } from "../../../store/reducers/connectionsCache";
 
 const SidePage = () => {
   const dispatch = useAppDispatch();
@@ -21,16 +17,11 @@ const SidePage = () => {
 
   const queueIncomingRequest = useAppSelector(getQueueIncomingRequest);
   const pendingDAppMeerkat = useAppSelector(getPendingDAppMeerkat);
-  const walletConnectionCache = useAppSelector(getWalletConnectionsCache);
   const stateCache = useAppSelector(getStateCache);
 
   const canOpenIncomingRequest =
     queueIncomingRequest.queues.length > 0 && !queueIncomingRequest.isPaused;
-  const canOpenPendingWalletConnection =
-    !!pendingDAppMeerkat &&
-    !walletConnectionCache.some(
-      (item) => item.id === pendingDAppMeerkat && !item.name
-    );
+  const canOpenPendingWalletConnection = !!pendingDAppMeerkat;
 
   useEffect(() => {
     if (canOpenIncomingRequest || !stateCache.authentication.loggedIn) return;

--- a/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
+++ b/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
@@ -13,8 +13,7 @@ import {
   IncomingRequestType,
 } from "../../../../../store/reducers/stateCache/stateCache.types";
 import { getConnectedWallet } from "../../../../../store/reducers/walletConnectionsCache";
-
-const ANIMATION_DURATION = 500;
+import { ANIMATION_DURATION } from "../../../../components/SideSlider/SideSlider.types";
 
 const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
   const pageId = "incoming-request";
@@ -65,7 +64,7 @@ const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
 
     setTimeout(() => {
       dispatch(dequeueCredentialRequest());
-    }, ANIMATION_DURATION);
+    }, 500);
   };
 
   const handleCancel = async () => {

--- a/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
+++ b/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
@@ -14,6 +14,8 @@ import {
 } from "../../../../../store/reducers/stateCache/stateCache.types";
 import { getConnectedWallet } from "../../../../../store/reducers/walletConnectionsCache";
 
+const ANIMATION_DURATION = 500;
+
 const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
   const pageId = "incoming-request";
   const dispatch = useAppDispatch();
@@ -38,7 +40,7 @@ const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
     if (
       incomingRequest.type === IncomingRequestType.PEER_CONNECT_SIGN &&
       (!connectedWallet ||
-        connectedWallet !== incomingRequest.peerConnection?.id)
+        connectedWallet.id !== incomingRequest.peerConnection?.id)
     ) {
       handleReset();
     }
@@ -63,7 +65,7 @@ const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
 
     setTimeout(() => {
       dispatch(dequeueCredentialRequest());
-    }, 500);
+    }, ANIMATION_DURATION);
   };
 
   const handleCancel = async () => {

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.test.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.test.tsx
@@ -14,6 +14,7 @@ import { setToastMsg } from "../../../../../store/reducers/stateCache";
 import { ToastMsgType } from "../../../../globals/types";
 import { WalletConnect } from "./WalletConnect";
 import { setWalletConnectionsCache } from "../../../../../store/reducers/walletConnectionsCache";
+import { walletConnectionsFix } from "../../../../__fixtures__/walletConnectionsFix";
 setupIonicReact();
 mockIonicReact();
 
@@ -260,7 +261,7 @@ describe("Wallet Connect Request", () => {
     },
     walletConnectionsCache: {
       walletConnections: [],
-      pendingDAppMeerKat: "pending-meerkat",
+      pendingConnection: walletConnectionsFix[0],
     },
     identifiersCache: {
       identifiers: [...identifierFix],

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.tsx
@@ -1,23 +1,15 @@
-import { useEffect, useState } from "react";
-import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
-import {
-  getPendingDAppMeerkat,
-  setPendingDAppMeerKat,
-} from "../../../../../store/reducers/walletConnectionsCache";
+import { useState } from "react";
+import { useAppSelector } from "../../../../../store/hooks";
+import { getPendingDAppMeerkat } from "../../../../../store/reducers/walletConnectionsCache";
+import { SideSlider } from "../../../../components/SideSlider";
+import { SidePageContentProps } from "../../SidePage.types";
 import { WalletConnectStageOne } from "./WalletConnectStageOne";
 import { WalletConnectStageTwo } from "./WalletConnectStageTwo";
-import { SidePageContentProps } from "../../SidePage.types";
-import { SideSlider } from "../../../../components/SideSlider";
 
 const WalletConnect = ({ setOpenPage }: SidePageContentProps) => {
-  const dispatch = useAppDispatch();
   const pendingDAppMeerkat = useAppSelector(getPendingDAppMeerkat);
   const [requestStage, setRequestStage] = useState(0);
   const [hiddenStageOne, setHiddenStageOne] = useState(false);
-
-  useEffect(() => {
-    setTimeout(() => setOpenPage(!!pendingDAppMeerkat), 10);
-  }, [pendingDAppMeerkat]);
 
   const changeToStageTwo = () => {
     setTimeout(() => setHiddenStageOne(true), 400);
@@ -31,10 +23,6 @@ const WalletConnect = ({ setOpenPage }: SidePageContentProps) => {
 
   const handleCloseWalletConnect = () => {
     setOpenPage(false);
-
-    setTimeout(() => {
-      dispatch(setPendingDAppMeerKat(null));
-    }, 500);
   };
 
   if (!pendingDAppMeerkat) return null;

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { useAppSelector } from "../../../../../store/hooks";
-import { getPendingDAppMeerkat } from "../../../../../store/reducers/walletConnectionsCache";
+import { getPendingConnection } from "../../../../../store/reducers/walletConnectionsCache";
 import { SideSlider } from "../../../../components/SideSlider";
 import { SidePageContentProps } from "../../SidePage.types";
 import { WalletConnectStageOne } from "./WalletConnectStageOne";
 import { WalletConnectStageTwo } from "./WalletConnectStageTwo";
 
 const WalletConnect = ({ setOpenPage }: SidePageContentProps) => {
-  const pendingDAppMeerkat = useAppSelector(getPendingDAppMeerkat);
+  const pendingConnection = useAppSelector(getPendingConnection);
   const [requestStage, setRequestStage] = useState(0);
   const [hiddenStageOne, setHiddenStageOne] = useState(false);
 
@@ -25,21 +25,21 @@ const WalletConnect = ({ setOpenPage }: SidePageContentProps) => {
     setOpenPage(false);
   };
 
-  if (!pendingDAppMeerkat) return null;
+  if (!pendingConnection) return null;
 
   return (
     <div className="wallet-connect-container">
       {!hiddenStageOne && (
         <WalletConnectStageOne
-          isOpen={!!pendingDAppMeerkat}
+          isOpen={!!pendingConnection}
           onClose={handleCloseWalletConnect}
           onAccept={changeToStageTwo}
         />
       )}
       <SideSlider open={requestStage === 1}>
         <WalletConnectStageTwo
-          pendingDAppMeerkat={pendingDAppMeerkat}
-          isOpen={!!pendingDAppMeerkat}
+          pendingDAppMeerkat={pendingConnection.id}
+          isOpen={!!pendingConnection}
           onClose={handleCloseWalletConnect}
           onBackClick={backToStageOne}
         />

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageOne.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageOne.tsx
@@ -9,6 +9,8 @@ import { ResponsivePageLayout } from "../../../../components/layout/ResponsivePa
 import { combineClassNames } from "../../../../utils/style";
 import "./WalletConnect.scss";
 import { WalletConnectStageOneProps } from "./WalletConnect.types";
+import { useAppDispatch } from "../../../../../store/hooks";
+import { setPendingDAppMeerKat } from "../../../../../store/reducers/walletConnectionsCache";
 
 const WalletConnectStageOne = ({
   isOpen,
@@ -16,6 +18,7 @@ const WalletConnectStageOne = ({
   onClose,
   onAccept,
 }: WalletConnectStageOneProps) => {
+  const dispatch = useAppDispatch();
   const [openDeclineAlert, setOpenDeclineAlert] = useState(false);
 
   const classes = combineClassNames(className, {
@@ -29,6 +32,10 @@ const WalletConnectStageOne = ({
 
   const handleClose = () => {
     onClose();
+
+    setTimeout(() => {
+      dispatch(setPendingDAppMeerKat(null));
+    }, 500);
   };
 
   const handleAccept = () => {

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageOne.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageOne.tsx
@@ -10,7 +10,9 @@ import { combineClassNames } from "../../../../utils/style";
 import "./WalletConnect.scss";
 import { WalletConnectStageOneProps } from "./WalletConnect.types";
 import { useAppDispatch } from "../../../../../store/hooks";
-import { setPendingDAppMeerKat } from "../../../../../store/reducers/walletConnectionsCache";
+import { setPendingConnection } from "../../../../../store/reducers/walletConnectionsCache";
+
+const ANIMATION_DURATION = 500;
 
 const WalletConnectStageOne = ({
   isOpen,
@@ -34,8 +36,8 @@ const WalletConnectStageOne = ({
     onClose();
 
     setTimeout(() => {
-      dispatch(setPendingDAppMeerKat(null));
-    }, 500);
+      dispatch(setPendingConnection(null));
+    }, ANIMATION_DURATION);
   };
 
   const handleAccept = () => {

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageOne.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageOne.tsx
@@ -11,8 +11,7 @@ import "./WalletConnect.scss";
 import { WalletConnectStageOneProps } from "./WalletConnect.types";
 import { useAppDispatch } from "../../../../../store/hooks";
 import { setPendingConnection } from "../../../../../store/reducers/walletConnectionsCache";
-
-const ANIMATION_DURATION = 500;
+import { ANIMATION_DURATION } from "../../../../components/SideSlider/SideSlider.types";
 
 const WalletConnectStageOne = ({
   isOpen,

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
@@ -13,11 +13,7 @@ import { CardItem, CardList } from "../../../../components/CardList";
 import { PageFooter } from "../../../../components/PageFooter";
 import { PageHeader } from "../../../../components/PageHeader";
 import { ResponsivePageLayout } from "../../../../components/layout/ResponsivePageLayout";
-import {
-  IDENTIFIER_BG_MAPPING,
-  OperationType,
-  ToastMsgType,
-} from "../../../../globals/types";
+import { OperationType, ToastMsgType } from "../../../../globals/types";
 import { combineClassNames } from "../../../../utils/style";
 import "./WalletConnect.scss";
 import { WalletConnectStageTwoProps } from "./WalletConnect.types";
@@ -45,7 +41,7 @@ const WalletConnectStageTwo = ({
     (identifier, index): CardItem<IdentifierShortDetails> => ({
       id: index,
       title: identifier.displayName,
-      image: (IDENTIFIER_BG_MAPPING[identifier.theme] as string) || KeriLogo,
+      image: KeriLogo,
       data: identifier,
     })
   );
@@ -67,19 +63,15 @@ const WalletConnectStageTwo = ({
         const existingConnection = existingConnections.find(
           (connection) => connection.id === pendingDAppMeerkat
         );
-        if (!existingConnection) {
+        if (existingConnection) {
+          existingConnection.selectedAid = selectedIdentifier.id;
+          dispatch(setWalletConnectionsCache([...existingConnections]));
+        } else {
           // Insert a new connection if needed
           dispatch(
             setWalletConnectionsCache([
               { id: pendingDAppMeerkat, selectedAid: selectedIdentifier.id },
               ...existingConnections,
-            ])
-          );
-        } else {
-          existingConnection.selectedAid = selectedIdentifier.id;
-          dispatch(
-            setWalletConnectionsCache([
-              ...existingConnections
             ])
           );
         }

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
@@ -5,21 +5,28 @@ import { IdentifierShortDetails } from "../../../../../core/agent/services/ident
 import { i18n } from "../../../../../i18n";
 import { useAppSelector } from "../../../../../store/hooks";
 import { getIdentifiersCache } from "../../../../../store/reducers/identifiersCache";
-import { setToastMsg } from "../../../../../store/reducers/stateCache";
+import {
+  setCurrentOperation,
+  setToastMsg,
+} from "../../../../../store/reducers/stateCache";
 import { CardItem, CardList } from "../../../../components/CardList";
 import { PageFooter } from "../../../../components/PageFooter";
 import { PageHeader } from "../../../../components/PageHeader";
 import { ResponsivePageLayout } from "../../../../components/layout/ResponsivePageLayout";
-import { ToastMsgType } from "../../../../globals/types";
+import {
+  IDENTIFIER_BG_MAPPING,
+  OperationType,
+  ToastMsgType,
+} from "../../../../globals/types";
 import { combineClassNames } from "../../../../utils/style";
 import "./WalletConnect.scss";
 import { WalletConnectStageTwoProps } from "./WalletConnect.types";
 import { PeerConnection } from "../../../../../core/cardano/walletConnect/peerConnection";
-import { Agent } from "../../../../../core/agent/agent";
 import {
   getWalletConnectionsCache,
   setWalletConnectionsCache,
 } from "../../../../../store/reducers/walletConnectionsCache";
+import KeriLogo from "../../../../assets/images/KeriGeneric.jpg";
 
 const WalletConnectStageTwo = ({
   isOpen,
@@ -38,7 +45,7 @@ const WalletConnectStageTwo = ({
     (identifier, index): CardItem<IdentifierShortDetails> => ({
       id: index,
       title: identifier.displayName,
-      image: "",
+      image: (IDENTIFIER_BG_MAPPING[identifier.theme] as string) || KeriLogo,
       data: identifier,
     })
   );
@@ -68,7 +75,18 @@ const WalletConnectStageTwo = ({
               ...existingConnections,
             ])
           );
+        } else {
+          existingConnection.selectedAid = selectedIdentifier.id;
+          dispatch(
+            setWalletConnectionsCache([
+              ...existingConnections
+            ])
+          );
         }
+
+        dispatch(
+          setCurrentOperation(OperationType.OPEN_WALLET_CONNECTION_DETAIL)
+        );
       }
       onClose();
     } catch (e) {

--- a/src/ui/utils/formatters.test.ts
+++ b/src/ui/utils/formatters.test.ts
@@ -1,8 +1,12 @@
-import { formatCurrencyUSD } from "./formatters";
+import { ellipsisText, formatCurrencyUSD } from "./formatters";
 
 describe("Utils", () => {
   test("formatCurrencyUSD", () => {
     const balance = 1012.0;
     expect(formatCurrencyUSD(balance)).toBe("$1,012.00");
+  });
+
+  test("ellipsisText", () => {
+    expect(ellipsisText("text text text", 3)).toBe("tex...");
   });
 });

--- a/src/ui/utils/formatters.ts
+++ b/src/ui/utils/formatters.ts
@@ -34,10 +34,15 @@ const formatCurrencyUSD = (amount: number) => {
   return currencyFormat.format(amount);
 };
 
+const ellipsisText = (raw: string, length: number, suffix = "...") => {
+  return raw.substring(0, length || raw.length) + suffix;
+};
+
 export {
   formatShortDate,
   formatLongDate,
   formatShortTime,
   formatTimeToSec,
   formatCurrencyUSD,
+  ellipsisText,
 };


### PR DESCRIPTION
## Description

Auto open connection modal after create connect. Beside that, I also update new behaviour when user create or connect new connection, they must disconnect connected wallet.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-952](https://cardanofoundation.atlassian.net/browse/DTIS-952)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/5ffc0094-ee4c-41db-9fb8-c52d645adf1c

#### Android

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/2df26130-0877-4283-aca7-7b90427266c6

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/ebf95784-03ce-4274-ad9f-cf43ba75343e

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/fb41773e-5544-4422-84ed-1a2744cc45a8


[DTIS-952]: https://cardanofoundation.atlassian.net/browse/DTIS-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ