### PR TITLE
feat(core): rework core notification flow

### DIFF
--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -101,6 +101,8 @@ interface KeriaNotification {
   createdAt: Date;
   a: Record<string, unknown>;
   multisigId?: string;
+  timeStamp: number;
+  connectionId: string;
 }
 
 enum KeriConnectionType {

--- a/src/core/agent/records/notificationRecord.ts
+++ b/src/core/agent/records/notificationRecord.ts
@@ -7,15 +7,19 @@ interface NotificationRecordStorageProps {
   tags?: Tags;
   a: Record<string, unknown>;
   route: string;
-  isDismissed: boolean;
+  isReadByUser: boolean;
   multisigId?: string;
+  timeStamp: number;
+  connectionId: string;
 }
 
 class NotificationRecord extends BaseRecord {
   a!: Record<string, unknown>;
   route!: string;
-  isDismissed!: boolean;
+  isReadByUser!: boolean;
   multisigId?: string;
+  timeStamp!: number;
+  connectionId!: string;
   static readonly type = "NotificationRecord";
   readonly type = NotificationRecord.type;
 
@@ -26,8 +30,10 @@ class NotificationRecord extends BaseRecord {
       this.createdAt = props.createdAt ?? new Date();
       this.a = props.a;
       this.route = props.route;
-      this.isDismissed = props.isDismissed;
+      this.isReadByUser = props.isReadByUser;
       this.multisigId = props.multisigId ?? undefined;
+      this.timeStamp = props.timeStamp;
+      this.connectionId = props.connectionId;
       this._tags = props.tags ?? {};
     }
   }
@@ -35,7 +41,7 @@ class NotificationRecord extends BaseRecord {
   getTags() {
     return {
       route: this.route,
-      isDismissed: this.isDismissed,
+      isReadByUser: this.isReadByUser,
       multisigId: this.multisigId,
       ...this._tags,
     };

--- a/src/core/agent/records/notificationRecord.ts
+++ b/src/core/agent/records/notificationRecord.ts
@@ -7,7 +7,7 @@ interface NotificationRecordStorageProps {
   tags?: Tags;
   a: Record<string, unknown>;
   route: string;
-  isReadByUser: boolean;
+  read: boolean;
   multisigId?: string;
   timeStamp: number;
   connectionId: string;
@@ -16,7 +16,7 @@ interface NotificationRecordStorageProps {
 class NotificationRecord extends BaseRecord {
   a!: Record<string, unknown>;
   route!: string;
-  isReadByUser!: boolean;
+  read!: boolean;
   multisigId?: string;
   timeStamp!: number;
   connectionId!: string;
@@ -30,7 +30,7 @@ class NotificationRecord extends BaseRecord {
       this.createdAt = props.createdAt ?? new Date();
       this.a = props.a;
       this.route = props.route;
-      this.isReadByUser = props.isReadByUser;
+      this.read = props.read;
       this.multisigId = props.multisigId ?? undefined;
       this.timeStamp = props.timeStamp;
       this.connectionId = props.connectionId;
@@ -41,7 +41,7 @@ class NotificationRecord extends BaseRecord {
   getTags() {
     return {
       route: this.route,
-      isReadByUser: this.isReadByUser,
+      read: this.read,
       multisigId: this.multisigId,
       ...this._tags,
     };

--- a/src/core/agent/services/credentialService.test.ts
+++ b/src/core/agent/services/credentialService.test.ts
@@ -434,7 +434,7 @@ describe("Credential service of agent", () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     const notificationRecord = {
       _tags: {
-        isDismiss: true,
+        isReadByUser: true,
         route: NotificationRoute.ExnIpexGrant,
       },
       id: "AIeGgKkS23FDK4mxpfodpbWhTydFz2tdM64DER6EdgG-",
@@ -443,6 +443,8 @@ describe("Credential service of agent", () => {
         r: NotificationRoute.ExnIpexGrant,
         d: "EF6Nmxz8hs0oVc4loyh2J5Sq9H3Z7apQVqjO6e4chtsp",
       },
+      timeStamp: new Date().getTime(),
+      connectionId: "connection-id",
     };
     notificationStorage.findAllByQuery = jest
       .fn()
@@ -454,6 +456,8 @@ describe("Credential service of agent", () => {
         id: notificationRecord.id,
         createdAt: notificationRecord.createdAt,
         a: notificationRecord.a,
+        timeStamp: notificationRecord.timeStamp,
+        connectionId: notificationRecord.connectionId,
       },
     ]);
   });
@@ -462,11 +466,11 @@ describe("Credential service of agent", () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
     await credentialService.getUnhandledIpexGrantNotifications({
-      isDismissed: false,
+      isReadByUser: false,
     });
     expect(notificationStorage.findAllByQuery).toBeCalledWith({
       route: NotificationRoute.ExnIpexGrant,
-      isDismissed: false,
+      isReadByUser: false,
     });
   });
 });

--- a/src/core/agent/services/credentialService.test.ts
+++ b/src/core/agent/services/credentialService.test.ts
@@ -372,9 +372,6 @@ describe("Credential service of agent", () => {
     await expect(
       credentialService.getCredentialDetailsById("not-found-id")
     ).rejects.toThrowError(Agent.KERIA_CONNECTION_BROKEN);
-    await expect(
-      credentialService.getUnhandledIpexGrantNotifications()
-    ).rejects.toThrowError(Agent.KERIA_CONNECTION_BROKEN);
     await expect(credentialService.syncACDCs()).rejects.toThrowError(
       Agent.KERIA_CONNECTION_BROKEN
     );
@@ -428,49 +425,5 @@ describe("Credential service of agent", () => {
     await expect(
       credentialService.getCredentialDetailsById(id)
     ).rejects.toThrowError(CredentialService.CREDENTIAL_NOT_FOUND);
-  });
-
-  test("Should be able to getExnIpexGrantpexGrantNotifications", async () => {
-    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
-    const notificationRecord = {
-      _tags: {
-        isReadByUser: true,
-        route: NotificationRoute.ExnIpexGrant,
-      },
-      id: "AIeGgKkS23FDK4mxpfodpbWhTydFz2tdM64DER6EdgG-",
-      createdAt: new Date(),
-      a: {
-        r: NotificationRoute.ExnIpexGrant,
-        d: "EF6Nmxz8hs0oVc4loyh2J5Sq9H3Z7apQVqjO6e4chtsp",
-      },
-      timeStamp: new Date().getTime(),
-      connectionId: "connection-id",
-    };
-    notificationStorage.findAllByQuery = jest
-      .fn()
-      .mockResolvedValue([notificationRecord]);
-    expect(
-      await credentialService.getUnhandledIpexGrantNotifications()
-    ).toStrictEqual([
-      {
-        id: notificationRecord.id,
-        createdAt: notificationRecord.createdAt,
-        a: notificationRecord.a,
-        timeStamp: notificationRecord.timeStamp,
-        connectionId: notificationRecord.connectionId,
-      },
-    ]);
-  });
-
-  test("Should pass the filter throught findAllByQuery when call getUnhandledIpexGrantNotifications", async () => {
-    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
-    notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
-    await credentialService.getUnhandledIpexGrantNotifications({
-      isReadByUser: false,
-    });
-    expect(notificationStorage.findAllByQuery).toBeCalledWith({
-      route: NotificationRoute.ExnIpexGrant,
-      isReadByUser: false,
-    });
   });
 });

--- a/src/core/agent/services/credentialService.ts
+++ b/src/core/agent/services/credentialService.ts
@@ -155,27 +155,6 @@ class CredentialService extends AgentService {
     return metadata;
   }
 
-  @OnlineOnly
-  async getUnhandledIpexGrantNotifications(
-    filters: {
-      isReadByUser?: boolean;
-    } = {}
-  ): Promise<KeriaNotification[]> {
-    const results = await this.notificationStorage.findAllByQuery({
-      route: NotificationRoute.ExnIpexGrant,
-      ...filters,
-    });
-    return results.map((result) => {
-      return {
-        id: result.id,
-        createdAt: result.createdAt,
-        a: result.a,
-        timeStamp: result.timeStamp,
-        connectionId: result.connectionId,
-      };
-    });
-  }
-
   private async saveAcdcMetadataRecord(
     credentialId: string,
     dateTime: string,

--- a/src/core/agent/services/credentialService.ts
+++ b/src/core/agent/services/credentialService.ts
@@ -158,7 +158,7 @@ class CredentialService extends AgentService {
   @OnlineOnly
   async getUnhandledIpexGrantNotifications(
     filters: {
-      isDismissed?: boolean;
+      isReadByUser?: boolean;
     } = {}
   ): Promise<KeriaNotification[]> {
     const results = await this.notificationStorage.findAllByQuery({
@@ -170,6 +170,8 @@ class CredentialService extends AgentService {
         id: result.id,
         createdAt: result.createdAt,
         a: result.a,
+        timeStamp: result.timeStamp,
+        connectionId: result.connectionId,
       };
     });
   }

--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -299,6 +299,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "keri",
       },
+      timeStamp: date.getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
 
     getExchangeMock = jest.fn().mockReturnValue({
@@ -335,6 +337,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "keri",
       },
+      timeStamp: date.getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
     getExchangeMock = jest.fn().mockReturnValue({
       exn: {
@@ -368,6 +372,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "agreeD",
       },
+      timeStamp: date.getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
     getExchangeMock = jest.fn().mockImplementation((id) => {
       if (id === "agreeD") {
@@ -417,6 +423,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "agreeD",
       },
+      timeStamp: date.getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
     getExchangeMock = jest.fn().mockImplementation((id) => {
       if (id === "agreeD") {
@@ -461,6 +469,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "agreeD",
       },
+      timeStamp: date.getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
     getExchangeMock = jest.fn().mockImplementation((id) => {
       if (id === "agreeD") {
@@ -507,6 +517,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "saidForUuid",
       },
+      timeStamp: new Date().getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
     schemaGetMock.mockResolvedValue({
       title: "Qualified vLEI Issuer Credential",
@@ -557,6 +569,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "saidForUuid",
       },
+      timeStamp: new Date().getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
     schemaGetMock.mockResolvedValue(null);
     await expect(
@@ -574,6 +588,8 @@ describe("Ipex communication service of agent", () => {
       a: {
         d: "keri",
       },
+      timeStamp: new Date().getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     };
     await expect(
       ipexCommunicationService.offerAcdcFromApply(noti, {})

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -249,6 +249,8 @@ class IpexCommunicationService extends AgentService {
       id: result.id,
       createdAt: result.createdAt,
       a: result.a,
+      timeStamp: result.timeStamp,
+      connectionId: result.connectionId,
     };
   }
 

--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -826,6 +826,8 @@ describe("Multisig sig service of agent", () => {
         id: "id",
         createdAt: new Date(),
         a: { d: "d" },
+        timeStamp: 1718247648152,
+        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       })
     ).rejects.toThrowError(MultiSigService.EXN_MESSAGE_NOT_FOUND);
   });
@@ -869,6 +871,8 @@ describe("Multisig sig service of agent", () => {
         id: "id",
         createdAt: new Date(),
         a: { d: "d" },
+        timeStamp: 1718247648152,
+        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       })
     ).rejects.toThrowError(MultiSigService.AID_IS_NOT_MULTI_SIG);
   });
@@ -942,6 +946,8 @@ describe("Multisig sig service of agent", () => {
         id: "id",
         createdAt: new Date(),
         a: { d: "d" },
+        timeStamp: 1718247648152,
+        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       })
     ).toBe(multisigIdentifier);
   });
@@ -1236,7 +1242,7 @@ describe("Multisig sig service of agent", () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     const notificationRecord = {
       _tags: {
-        isDismiss: true,
+        isReadByUser: true,
         route: NotificationRoute.MultiSigIcp,
       },
       id: "AIeGgKkS23FDK4mxpfodpbWhTydFz2tdM64DER6EdgG-",
@@ -1246,6 +1252,8 @@ describe("Multisig sig service of agent", () => {
         d: "EF6Nmxz8hs0oVc4loyh2J5Sq9H3Z7apQVqjO6e4chtsp",
       },
       multisigId: "multisig-id",
+      timeStamp: new Date().getTime(),
+      connectionId: "connection-id",
     };
     notificationStorage.findAllByQuery = jest
       .fn()
@@ -1258,6 +1266,8 @@ describe("Multisig sig service of agent", () => {
         createdAt: notificationRecord.createdAt,
         a: notificationRecord.a,
         multisigId: "multisig-id",
+        timeStamp: notificationRecord.timeStamp,
+        connectionId: notificationRecord.connectionId,
       },
     ]);
   });
@@ -1266,11 +1276,11 @@ describe("Multisig sig service of agent", () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
     await multiSigService.getUnhandledMultisigIdentifiers({
-      isDismissed: false,
+      isReadByUser: false,
     });
     expect(notificationStorage.findAllByQuery).toBeCalledWith({
       route: NotificationRoute.MultiSigIcp,
-      isDismissed: false,
+      isReadByUser: false,
       $or: [
         { route: NotificationRoute.MultiSigIcp },
         {
@@ -1418,6 +1428,8 @@ describe("Multisig sig service of agent", () => {
         id: "id",
         createdAt: new Date(),
         a: { d: "d" },
+        timeStamp: 1718247648152,
+        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       })
     ).rejects.toThrowError(Agent.KERIA_CONNECTION_BROKEN);
     await expect(

--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -1238,58 +1238,6 @@ describe("Multisig sig service of agent", () => {
     );
   });
 
-  test("Can get unhandled Multisig Identifier notifications", async () => {
-    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
-    const notificationRecord = {
-      _tags: {
-        isReadByUser: true,
-        route: NotificationRoute.MultiSigIcp,
-      },
-      id: "AIeGgKkS23FDK4mxpfodpbWhTydFz2tdM64DER6EdgG-",
-      createdAt: new Date(),
-      a: {
-        r: NotificationRoute.MultiSigIcp,
-        d: "EF6Nmxz8hs0oVc4loyh2J5Sq9H3Z7apQVqjO6e4chtsp",
-      },
-      multisigId: "multisig-id",
-      timeStamp: new Date().getTime(),
-      connectionId: "connection-id",
-    };
-    notificationStorage.findAllByQuery = jest
-      .fn()
-      .mockResolvedValue([notificationRecord]);
-    expect(
-      await multiSigService.getUnhandledMultisigIdentifiers()
-    ).toStrictEqual([
-      {
-        id: notificationRecord.id,
-        createdAt: notificationRecord.createdAt,
-        a: notificationRecord.a,
-        multisigId: "multisig-id",
-        timeStamp: notificationRecord.timeStamp,
-        connectionId: notificationRecord.connectionId,
-      },
-    ]);
-  });
-
-  test("Should pass the filter throught findAllByQuery when call getUnhandledMultisigIdentifiers", async () => {
-    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
-    notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
-    await multiSigService.getUnhandledMultisigIdentifiers({
-      isReadByUser: false,
-    });
-    expect(notificationStorage.findAllByQuery).toBeCalledWith({
-      route: NotificationRoute.MultiSigIcp,
-      isReadByUser: false,
-      $or: [
-        { route: NotificationRoute.MultiSigIcp },
-        {
-          route: NotificationRoute.MultiSigRot,
-        },
-      ],
-    });
-  });
-
   test("Should throw errors when create KERI multisigs with invalid identifier", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
     const creatorIdentifier = "creatorIdentifier";
@@ -1440,10 +1388,6 @@ describe("Multisig sig service of agent", () => {
         theme: 0,
         displayName: "Multisig",
       })
-    ).rejects.toThrowError(Agent.KERIA_CONNECTION_BROKEN);
-
-    await expect(
-      multiSigService.getUnhandledMultisigIdentifiers()
     ).rejects.toThrowError(Agent.KERIA_CONNECTION_BROKEN);
   });
 

--- a/src/core/agent/services/multiSigService.ts
+++ b/src/core/agent/services/multiSigService.ts
@@ -465,34 +465,6 @@ class MultiSigService extends AgentService {
     return { done: false };
   }
 
-  @OnlineOnly
-  async getUnhandledMultisigIdentifiers(
-    filters: {
-      isReadByUser?: boolean;
-    } = {}
-  ): Promise<KeriaNotification[]> {
-    const results = await this.notificationStorage.findAllByQuery({
-      route: NotificationRoute.MultiSigIcp,
-      ...filters,
-      $or: [
-        { route: NotificationRoute.MultiSigIcp },
-        {
-          route: NotificationRoute.MultiSigRot,
-        },
-      ],
-    });
-    return results.map((result) => {
-      return {
-        id: result.id,
-        createdAt: result.createdAt,
-        a: result.a,
-        multisigId: result.multisigId,
-        timeStamp: result.timeStamp,
-        connectionId: result.connectionId,
-      };
-    });
-  }
-
   private async rotateMultisigAid(
     aid: Aid,
     multisigAidMembers: Pick<Aid, "state">[],

--- a/src/core/agent/services/multiSigService.ts
+++ b/src/core/agent/services/multiSigService.ts
@@ -468,7 +468,7 @@ class MultiSigService extends AgentService {
   @OnlineOnly
   async getUnhandledMultisigIdentifiers(
     filters: {
-      isDismissed?: boolean;
+      isReadByUser?: boolean;
     } = {}
   ): Promise<KeriaNotification[]> {
     const results = await this.notificationStorage.findAllByQuery({
@@ -487,6 +487,8 @@ class MultiSigService extends AgentService {
         createdAt: result.createdAt,
         a: result.a,
         multisigId: result.multisigId,
+        timeStamp: result.timeStamp,
+        connectionId: result.connectionId,
       };
     });
   }

--- a/src/core/agent/services/signifyNotificationService.test.ts
+++ b/src/core/agent/services/signifyNotificationService.test.ts
@@ -174,7 +174,7 @@ describe("Signify notification service of agent", () => {
     const notification = {
       id: "id",
       _tags: {
-        isReadByUser: false,
+        read: false,
       } as any,
       setTag: function (name: string, value: any) {
         this._tags[name] = value;

--- a/src/core/agent/services/signifyNotificationService.test.ts
+++ b/src/core/agent/services/signifyNotificationService.test.ts
@@ -61,7 +61,7 @@ const signifyClient = jest.mocked({
     list: jest.fn(),
   }),
   exchanges: () => ({
-    get: jest.fn(),
+    get: jest.fn().mockResolvedValue({ exn: { i: "connection-id" } }),
     send: jest.fn(),
   }),
   agent: {
@@ -170,25 +170,26 @@ describe("Signify notification service of agent", () => {
     expect(callback).toBeCalledTimes(2);
   });
 
-  test("Should call update when dismiss a notification", async () => {
+  test("Should call update when read a notification", async () => {
     const notification = {
       id: "id",
       _tags: {
-        isDismissed: false,
+        isReadByUser: false,
       } as any,
       setTag: function (name: string, value: any) {
         this._tags[name] = value;
       },
     };
+
     notificationStorage.findById = jest.fn().mockResolvedValue(notification);
-    await signifyNotificationService.dismissNotification(notification.id);
+    await signifyNotificationService.readNotification(notification.id);
     expect(notificationStorage.update).toBeCalledTimes(1);
   });
 
-  test("Should throw error when dismiss an invalid notification", async () => {
+  test("Should throw error when read an invalid notification", async () => {
     notificationStorage.findById = jest.fn().mockResolvedValue(null);
     await expect(
-      signifyNotificationService.dismissNotification("not-exist-noti-id")
+      signifyNotificationService.readNotification("not-exist-noti-id")
     ).rejects.toThrowError(SignifyNotificationService.NOTIFICATION_NOT_FOUND);
   });
 

--- a/src/core/agent/services/signifyNotificationService.ts
+++ b/src/core/agent/services/signifyNotificationService.ts
@@ -181,11 +181,15 @@ class SignifyNotificationService extends AgentService {
   private async createNotificationRecord(
     event: Notification
   ): Promise<KeriaNotification> {
+    const exchange = await this.props.signifyClient.exchanges().get(event.a.d);
+
     const metadata: any = {
       id: event.i,
       a: event.a,
-      isDismissed: false,
+      isReadByUser: false,
       route: event.a.r,
+      timeStamp: new Date().getTime(),
+      connectionId: exchange.exn.i,
     };
     if (event.a.r === NotificationRoute.MultiSigIcp) {
       const multisigNotification = await this.props.signifyClient
@@ -201,25 +205,32 @@ class SignifyNotificationService extends AgentService {
       createdAt: result.createdAt,
       a: result.a,
       multisigId: result.multisigId,
+      timeStamp: result.timeStamp,
+      connectionId: result.connectionId,
     };
   }
 
-  async dismissNotification(notificationId: string) {
+  async readNotification(notificationId: string) {
     const notificationRecord = await this.notificationStorage.findById(
       notificationId
     );
     if (!notificationRecord) {
       throw new Error(SignifyNotificationService.NOTIFICATION_NOT_FOUND);
     }
-    notificationRecord.setTag("isDismissed", true);
+    notificationRecord.setTag("isReadByUser", true);
     await this.notificationStorage.update(notificationRecord);
   }
 
-  // This allow us to get all dismissed notifications
-  async getDismissedNotifications() {
+  // This allow us to get all read notifications
+  async getReadNotifications() {
     const notifications = await this.notificationStorage.findAllByQuery({
-      isDismissed: true,
+      isReadByUser: true,
     });
+    return notifications;
+  }
+
+  async getAllNotifications() {
+    const notifications = await this.notificationStorage.getAll();
     return notifications;
   }
 

--- a/src/core/agent/services/signifyNotificationService.ts
+++ b/src/core/agent/services/signifyNotificationService.ts
@@ -186,7 +186,7 @@ class SignifyNotificationService extends AgentService {
     const metadata: any = {
       id: event.i,
       a: event.a,
-      isReadByUser: false,
+      read: false,
       route: event.a.r,
       timeStamp: new Date().getTime(),
       connectionId: exchange.exn.i,
@@ -217,16 +217,8 @@ class SignifyNotificationService extends AgentService {
     if (!notificationRecord) {
       throw new Error(SignifyNotificationService.NOTIFICATION_NOT_FOUND);
     }
-    notificationRecord.setTag("isReadByUser", true);
+    notificationRecord.setTag("read", true);
     await this.notificationStorage.update(notificationRecord);
-  }
-
-  // This allow us to get all read notifications
-  async getReadNotifications() {
-    const notifications = await this.notificationStorage.findAllByQuery({
-      isReadByUser: true,
-    });
-    return notifications;
   }
 
   async getAllNotifications() {

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -17,9 +17,6 @@ jest.mock("../core/agent/agent", () => ({
         getIdentifiers: jest.fn().mockResolvedValue([]),
         syncKeriaIdentifiers: jest.fn(),
       },
-      multiSigs: {
-        getUnhandledMultisigIdentifiers: jest.fn(),
-      },
       connections: {
         getConnections: jest.fn().mockResolvedValue([]),
         onConnectionStateChanged: jest.fn(),
@@ -41,7 +38,6 @@ jest.mock("../core/agent/agent", () => ({
         createMetadata: jest.fn(),
         isCredentialDone: jest.fn(),
         updateMetadataCompleted: jest.fn(),
-        getUnhandledIpexGrantNotifications: jest.fn(),
         onAcdcStateChanged: jest.fn(),
         syncACDCs: jest.fn(),
       },

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -65,7 +65,6 @@ jest.mock("../../../core/agent/agent", () => ({
         syncKeriaIdentifiers: jest.fn(),
       },
       multiSigs: {
-        getUnhandledMultisigIdentifiers: jest.fn(),
         getMultisigIcpDetails: jest.fn().mockResolvedValue({}),
       },
       connections: {
@@ -89,7 +88,6 @@ jest.mock("../../../core/agent/agent", () => ({
         createMetadata: jest.fn(),
         isCredentialDone: jest.fn(),
         updateMetadataCompleted: jest.fn(),
-        getUnhandledIpexGrantNotifications: jest.fn(),
         onAcdcStateChanged: jest.fn(),
         syncACDCs: jest.fn(),
       },
@@ -271,50 +269,6 @@ describe("AppWrapper handler", () => {
       expect(dispatch).toBeCalledWith(setCurrentOperation(OperationType.IDLE));
       expect(dispatch).toBeCalledWith(
         setToastMsg(ToastMsgType.NEW_CREDENTIAL_ADDED)
-      );
-    });
-  });
-
-  describe("Keria notification state changed handler", () => {
-    test("handles credential notification", async () => {
-      const keriNoti = {
-        id: "id",
-        a: {
-          r: NotificationRoute.ExnIpexGrant,
-        },
-        createdAt: new Date(),
-        timeStamp: new Date().getTime(),
-        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
-      } as KeriaNotification;
-      await keriaNotificationsChangeHandler(keriNoti, dispatch);
-      expect(dispatch).toBeCalledWith(
-        setQueueIncomingRequest({
-          id: keriNoti.id,
-          type: IncomingRequestType.CREDENTIAL_OFFER_RECEIVED,
-          logo: "", // TODO: must define Keri logo
-          label: "Credential Issuance Server", // TODO: must define it
-        })
-      );
-    });
-
-    test("handles multisig notification", async () => {
-      const keriNoti = {
-        id: "id",
-        a: {
-          r: NotificationRoute.MultiSigIcp,
-        },
-        createdAt: new Date(),
-        timeStamp: new Date().getTime(),
-        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
-      } as KeriaNotification;
-      await keriaNotificationsChangeHandler(keriNoti, dispatch);
-      expect(dispatch).toBeCalledWith(
-        setQueueIncomingRequest({
-          id: keriNoti?.id,
-          event: keriNoti,
-          type: IncomingRequestType.MULTI_SIG_REQUEST_INCOMING,
-          multisigIcpDetails: {} as any,
-        })
       );
     });
   });

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -283,6 +283,8 @@ describe("AppWrapper handler", () => {
           r: NotificationRoute.ExnIpexGrant,
         },
         createdAt: new Date(),
+        timeStamp: new Date().getTime(),
+        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       } as KeriaNotification;
       await keriaNotificationsChangeHandler(keriNoti, dispatch);
       expect(dispatch).toBeCalledWith(
@@ -302,6 +304,8 @@ describe("AppWrapper handler", () => {
           r: NotificationRoute.MultiSigIcp,
         },
         createdAt: new Date(),
+        timeStamp: new Date().getTime(),
+        connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       } as KeriaNotification;
       await keriaNotificationsChangeHandler(keriNoti, dispatch);
       expect(dispatch).toBeCalledWith(

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -213,7 +213,7 @@ const AppWrapper = (props: { children: ReactNode }) => {
 
   useEffect(() => {
     if (authentication.loggedIn) {
-      const handleMessages = async () => {
+      const syncWithKeria = async () => {
         // Fetch and sync the identifiers, contacts and ACDCs from KERIA to our storage
         // await Promise.all([
         //   Agent.agent.identifiers.syncKeriaIdentifiers(),
@@ -222,7 +222,7 @@ const AppWrapper = (props: { children: ReactNode }) => {
         // ]);
       };
       if (!isMessagesHandled && isOnline) {
-        handleMessages();
+        syncWithKeria();
         setIsMessagesHandled(true);
       }
       dispatch(setPauseQueueIncomingRequest(!isOnline));

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -234,10 +234,10 @@ const AppWrapper = (props: { children: ReactNode }) => {
         const oldMessages = (
           await Promise.all([
             Agent.agent.credentials.getUnhandledIpexGrantNotifications({
-              isDismissed: false,
+              isReadByUser: false,
             }),
             Agent.agent.multiSigs.getUnhandledMultisigIdentifiers({
-              isDismissed: false,
+              isReadByUser: false,
             }),
           ])
         )
@@ -245,9 +245,6 @@ const AppWrapper = (props: { children: ReactNode }) => {
           .sort(function (messageA, messageB) {
             return messageA.createdAt.valueOf() - messageB.createdAt.valueOf();
           });
-        oldMessages.forEach(async (message) => {
-          await keriaNotificationsChangeHandler(message, dispatch);
-        });
         // Fetch and sync the identifiers, contacts and ACDCs from KERIA to our storage
         // await Promise.all([
         //   Agent.agent.identifiers.syncKeriaIdentifiers(),
@@ -412,9 +409,6 @@ const AppWrapper = (props: { children: ReactNode }) => {
     });
     Agent.agent.connections.onConnectionStateChanged((event) => {
       return connectionStateChangedHandler(event, dispatch);
-    });
-    Agent.agent.signifyNotifications.onNotificationStateChanged((event) => {
-      return keriaNotificationsChangeHandler(event, dispatch);
     });
     Agent.agent.credentials.onAcdcStateChanged((event) => {
       return acdcChangeHandler(event, dispatch);

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -203,7 +203,6 @@ const AppWrapper = (props: { children: ReactNode }) => {
   const authentication = useAppSelector(getAuthentication);
   const connectedWallet = useAppSelector(getConnectedWallet);
   const [isOnline, setIsOnline] = useState(false);
-  const [isMessagesHandled, setIsMessagesHandled] = useState(false);
   const [isAlertPeerBrokenOpen, setIsAlertPeerBrokenOpen] = useState(false);
   useActivityTimer();
 
@@ -212,24 +211,23 @@ const AppWrapper = (props: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    const syncWithKeria = async () => {
+      // Fetch and sync the identifiers, contacts and ACDCs from KERIA to our storage
+      await Promise.all([
+        Agent.agent.identifiers.syncKeriaIdentifiers(),
+        Agent.agent.connections.syncKeriaContacts(),
+        Agent.agent.credentials.syncACDCs(),
+      ]);
+    };
+    if (isOnline) {
+      syncWithKeria();
+    }
     if (authentication.loggedIn) {
-      const syncWithKeria = async () => {
-        // Fetch and sync the identifiers, contacts and ACDCs from KERIA to our storage
-        // await Promise.all([
-        //   Agent.agent.identifiers.syncKeriaIdentifiers(),
-        //   Agent.agent.connections.syncKeriaContacts(),
-        //   Agent.agent.credentials.syncACDCs(),
-        // ]);
-      };
-      if (!isMessagesHandled && isOnline) {
-        syncWithKeria();
-        setIsMessagesHandled(true);
-      }
       dispatch(setPauseQueueIncomingRequest(!isOnline));
     } else {
       dispatch(setPauseQueueIncomingRequest(true));
     }
-  }, [isOnline, authentication.loggedIn, isMessagesHandled, dispatch]);
+  }, [isOnline, authentication.loggedIn, dispatch]);
 
   useEffect(() => {
     PeerConnection.peerConnection.onPeerDisconnectedStateChanged(

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -211,6 +211,14 @@ const AppWrapper = (props: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    if (authentication.loggedIn) {
+      dispatch(setPauseQueueIncomingRequest(!isOnline));
+    } else {
+      dispatch(setPauseQueueIncomingRequest(true));
+    }
+  }, [isOnline, authentication.loggedIn, dispatch]);
+
+  useEffect(() => {
     const syncWithKeria = async () => {
       // Fetch and sync the identifiers, contacts and ACDCs from KERIA to our storage
       await Promise.all([
@@ -222,12 +230,7 @@ const AppWrapper = (props: { children: ReactNode }) => {
     if (isOnline) {
       syncWithKeria();
     }
-    if (authentication.loggedIn) {
-      dispatch(setPauseQueueIncomingRequest(!isOnline));
-    } else {
-      dispatch(setPauseQueueIncomingRequest(true));
-    }
-  }, [isOnline, authentication.loggedIn, dispatch]);
+  }, [isOnline, dispatch]);
 
   useEffect(() => {
     PeerConnection.peerConnection.onPeerDisconnectedStateChanged(

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -85,24 +85,7 @@ const keriaNotificationsChangeHandler = async (
   event: KeriaNotification,
   dispatch: ReturnType<typeof useAppDispatch>
 ) => {
-  if (event?.a?.r === NotificationRoute.ExnIpexGrant) {
-    dispatch(
-      setQueueIncomingRequest({
-        id: event?.id,
-        type: IncomingRequestType.CREDENTIAL_OFFER_RECEIVED,
-        logo: "", // TODO: must define Keri logo
-        label: "Credential Issuance Server", // TODO: must define it
-      })
-    );
-  } else if (event?.a?.r === NotificationRoute.MultiSigIcp) {
-    processMultiSigIcpNotification(event, dispatch);
-  } else if (event?.a?.r === NotificationRoute.MultiSigRot) {
-    //TODO: Use dispatch here, handle logic for the multisig rotation notification
-  } else if (event?.a?.r === NotificationRoute.ExnIpexApply) {
-    //TODO: Use dispatch here, handle logic for the exchange apply message
-  } else if (event?.a?.r === NotificationRoute.ExnIpexAgree) {
-    //TODO: Use dispatch here, handle logic for the exchange apply agree
-  }
+  // TODO: update notification counter and emit push notifications
 };
 
 const processMultiSigIcpNotification = async (
@@ -231,20 +214,6 @@ const AppWrapper = (props: { children: ReactNode }) => {
   useEffect(() => {
     if (authentication.loggedIn) {
       const handleMessages = async () => {
-        const oldMessages = (
-          await Promise.all([
-            Agent.agent.credentials.getUnhandledIpexGrantNotifications({
-              isReadByUser: false,
-            }),
-            Agent.agent.multiSigs.getUnhandledMultisigIdentifiers({
-              isReadByUser: false,
-            }),
-          ])
-        )
-          .flat()
-          .sort(function (messageA, messageB) {
-            return messageA.createdAt.valueOf() - messageB.createdAt.valueOf();
-          });
         // Fetch and sync the identifiers, contacts and ACDCs from KERIA to our storage
         // await Promise.all([
         //   Agent.agent.identifiers.syncKeriaIdentifiers(),
@@ -409,6 +378,9 @@ const AppWrapper = (props: { children: ReactNode }) => {
     });
     Agent.agent.connections.onConnectionStateChanged((event) => {
       return connectionStateChangedHandler(event, dispatch);
+    });
+    Agent.agent.signifyNotifications.onNotificationStateChanged((event) => {
+      return keriaNotificationsChangeHandler(event, dispatch);
     });
     Agent.agent.credentials.onAcdcStateChanged((event) => {
       return acdcChangeHandler(event, dispatch);

--- a/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.test.tsx
+++ b/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.test.tsx
@@ -141,6 +141,8 @@ describe("Multi-Sig request", () => {
       id: "event-id",
       createdAt: new Date(),
       a: { d: "d" },
+      timeStamp: new Date().getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     },
     multisigIcpDetails: {
       ourIdentifier: filteredIdentifierFix[0],

--- a/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
+++ b/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
@@ -109,10 +109,6 @@ const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
     }, ANIMATION_DELAY);
   };
 
-  const handleIgnore = async () => {
-    handleReset();
-  };
-
   if (!requestData) {
     return null;
   }
@@ -126,7 +122,7 @@ const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
       initiateAnimation={initiateAnimation}
       handleAccept={handleAccept}
       handleCancel={handleCancel}
-      handleIgnore={handleIgnore}
+      handleIgnore={handleReset}
     />
   );
 };

--- a/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
+++ b/src/ui/pages/SidePage/components/IncomingRequest/IncomingRequest.tsx
@@ -110,16 +110,6 @@ const IncomingRequest = ({ open, setOpenPage }: SidePageContentProps) => {
   };
 
   const handleIgnore = async () => {
-    if (!incomingRequest) {
-      return handleReset();
-    }
-    if (
-      incomingRequest.type === IncomingRequestType.MULTI_SIG_REQUEST_INCOMING
-    ) {
-      await Agent.agent.signifyNotifications.dismissNotification(
-        incomingRequest.id
-      );
-    }
     handleReset();
   };
 

--- a/src/ui/pages/SidePage/components/IncomingRequest/components/RequestComponent.test.tsx
+++ b/src/ui/pages/SidePage/components/IncomingRequest/components/RequestComponent.test.tsx
@@ -51,6 +51,8 @@ describe("Multi-Sig request", () => {
       id: "event-id",
       createdAt: new Date(),
       a: { d: "d" },
+      timeStamp: new Date().getTime(),
+      connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
     },
     multisigIcpDetails: {
       ourIdentifier: filteredIdentifierFix[0],


### PR DESCRIPTION
## Description

- From now on, notifications from KERIA will go to a notifications section of the wallet, and not appear in the normal queue of notifications.
- The normal queue of notifications will only be for (at the moment) peer connect.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
