### PR TITLE
feat(ui): I already have a wallet

### DIFF
--- a/src/core/storage/secureStorage/secureStorage.ts
+++ b/src/core/storage/secureStorage/secureStorage.ts
@@ -6,8 +6,11 @@ import {
 enum KeyStoreKeys {
   APP_PASSCODE = "app-login-passcode",
   APP_OP_PASSWORD = "app-operations-password",
+  PASSWORD_SKIPPED = "app-password-skip",
   SIGNIFY_BRAN = "signify-bran",
   MEERKAT_SEED = "app-meerkat-seed",
+  RECOVERY_WALLET = "recovery-wallet",
+  RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME = "recovery-wallet-last-fail-attempt-time",
 }
 
 class SecureStorage {

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -679,6 +679,7 @@
   "ssiagent": {
     "title": "Enter your SSI agent details",
     "description": "To continue, please enter the SSI agent boot and connect URLs (in your email or from your command line).",
+    "verifydescription":  "To continue, please enter the SSI agent connect URLs (in your email or from your command line).",
     "button": {
       "info": "Get more information",
       "validate": "Validate"

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -588,6 +588,42 @@
       }
     }
   },
+  "verifyrecoveryseedphrase": {
+    "title": "Recover wallet",
+    "button": {
+      "continue": "Verify",
+      "lock": "Try again in 1 minute",
+      "clear": "Clear all"
+    },
+    "paragraph": {
+      "top": "Please verify your seed phrase to recover your wallet. To start typing click on the first option."
+    },
+    "suggestions": {
+      "title": "Suggestions",
+      "error": "All words must be compatible with the suggestions"
+    },
+    "alert": {
+      "fail": {
+        "text": "Sorry, the seed phrase you have entered is incorrect!",
+        "button": {
+          "confirm": "Try again"
+        }
+      },
+      "clear": {
+        "text": "Are you sure you want to clear all the words you have entered so far?",
+        "button": {
+          "confirm": "Clear all",
+          "cancel": "Cancel"
+        }
+      },
+      "manyattemp": {
+        "text": "Too many failed attempts. Please try again later.",
+        "button": {
+          "confirm": "Ok"
+        }
+      }
+    }
+  },
   "tabsmenu": {
     "label": {
       "identifiers": "Identity",

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -616,7 +616,7 @@
           "cancel": "Cancel"
         }
       },
-      "manyattemp": {
+      "toomanyattempts": {
         "text": "Too many failed attempts. Please try again later.",
         "button": {
           "confirm": "Ok"

--- a/src/routes/backRoute/backRoute.test.ts
+++ b/src/routes/backRoute/backRoute.test.ts
@@ -99,7 +99,7 @@ describe("getBackRoute", () => {
     const result = getBackRoute(currentPath, data);
 
     expect(result.backPath).toEqual({ pathname: "/route2" });
-    expect(result.updateRedux).toHaveLength(3);
+    expect(result.updateRedux).toHaveLength(4);
   });
 
   test("should return the correct back path when currentPath is /verifyseedphrase", () => {

--- a/src/routes/backRoute/backRoute.test.ts
+++ b/src/routes/backRoute/backRoute.test.ts
@@ -38,6 +38,7 @@ describe("getBackRoute", () => {
           userName: "",
           time: 0,
           ssiAgentIsSet: false,
+          recoveryWalletProgress: false,
         },
         currentOperation: OperationType.IDLE,
         queueIncomingRequest: {
@@ -165,6 +166,7 @@ describe("getPreviousRoute", () => {
           userName: "",
           time: 0,
           ssiAgentIsSet: false,
+          recoveryWalletProgress: false,
         },
         currentOperation: OperationType.IDLE,
         queueIncomingRequest: {

--- a/src/routes/backRoute/backRoute.ts
+++ b/src/routes/backRoute/backRoute.ts
@@ -2,7 +2,6 @@ import { AnyAction, ThunkAction } from "@reduxjs/toolkit";
 import { RootState } from "../../store";
 import {
   removeCurrentRoute,
-  setAuthentication,
   setCurrentRoute,
 } from "../../store/reducers/stateCache";
 import { clearSeedPhraseCache } from "../../store/reducers/seedPhraseCache";
@@ -77,6 +76,9 @@ const backRoute: Record<string, any> = {
     ],
   },
   [RoutePath.VERIFY_SEED_PHRASE]: {
+    updateRedux: [removeCurrentRoute, updateStoreSetCurrentRoute],
+  },
+  [RoutePath.VERIFY_RECOVERY_SEED_PHRASE]: {
     updateRedux: [removeCurrentRoute, updateStoreSetCurrentRoute],
   },
   [RoutePath.SSI_AGENT]: {

--- a/src/routes/backRoute/backRoute.ts
+++ b/src/routes/backRoute/backRoute.ts
@@ -1,12 +1,64 @@
 import { AnyAction, ThunkAction } from "@reduxjs/toolkit";
+import { SecureStorage } from "@aparajita/capacitor-secure-storage";
 import { RootState } from "../../store";
 import {
   removeCurrentRoute,
+  setAuthentication,
   setCurrentRoute,
 } from "../../store/reducers/stateCache";
 import { clearSeedPhraseCache } from "../../store/reducers/seedPhraseCache";
 import { DataProps, PayloadProps } from "../nextRoute/nextRoute.types";
 import { RoutePath, TabsRoutePath } from "../paths";
+import { KeyStoreKeys } from "../../core/storage";
+
+const getDefaultPreviousPath = (path: string, data: DataProps) => {
+  const isRecoveryMode =
+    data.store.stateCache.authentication.recoveryWalletProgress;
+
+  if (RoutePath.SSI_AGENT === path) {
+    return isRecoveryMode
+      ? RoutePath.VERIFY_RECOVERY_SEED_PHRASE
+      : RoutePath.GENERATE_SEED_PHRASE;
+  }
+
+  if (RoutePath.VERIFY_SEED_PHRASE === path) {
+    return RoutePath.GENERATE_SEED_PHRASE;
+  }
+
+  if (
+    [
+      RoutePath.VERIFY_RECOVERY_SEED_PHRASE,
+      RoutePath.GENERATE_SEED_PHRASE,
+    ].includes(path as RoutePath)
+  ) {
+    return RoutePath.CREATE_PASSWORD;
+  }
+
+  return RoutePath.ONBOARDING;
+};
+
+const clearSecureStore = (path: string) => {
+  if (
+    [
+      RoutePath.VERIFY_RECOVERY_SEED_PHRASE,
+      RoutePath.GENERATE_SEED_PHRASE,
+    ].includes(path as RoutePath)
+  ) {
+    SecureStorage.remove(KeyStoreKeys.PASSWORD_SKIPPED);
+    SecureStorage.remove(KeyStoreKeys.APP_OP_PASSWORD);
+    return;
+  }
+
+  if (path === RoutePath.CREATE_PASSWORD) {
+    SecureStorage.remove(KeyStoreKeys.RECOVERY_WALLET);
+    return;
+  }
+
+  if (path === RoutePath.SSI_AGENT) {
+    SecureStorage.remove(KeyStoreKeys.SIGNIFY_BRAN);
+    return;
+  }
+};
 
 const getBackRoute = (
   currentPath: string,
@@ -16,6 +68,7 @@ const getBackRoute = (
   updateRedux: (() => ThunkAction<void, RootState, undefined, AnyAction>)[];
 } => {
   const { updateRedux } = backRoute[currentPath];
+  clearSecureStore(currentPath);
 
   return {
     backPath: backPath(data),
@@ -30,11 +83,12 @@ const updateStoreSetCurrentRoute = (data: DataProps) => {
   if (prevPath) {
     path = prevPath.path;
   } else {
-    path = data.store.stateCache.routes[0].path;
+    path = getDefaultPreviousPath(data.store.stateCache.routes[0].path, data);
   }
 
   return setCurrentRoute({ path });
 };
+
 const getPreviousRoute = (data: DataProps): { pathname: string } => {
   const routes = data.store.stateCache.routes;
 
@@ -46,7 +100,7 @@ const getPreviousRoute = (data: DataProps): { pathname: string } => {
   } else if (prevPath) {
     path = prevPath.path;
   } else {
-    path = routes[0].path;
+    path = getDefaultPreviousPath(routes[0].path, data);
   }
 
   return { pathname: path };
@@ -61,6 +115,14 @@ const calcPreviousRoute = (
 
 const backPath = (data: DataProps) => getPreviousRoute(data);
 
+const clearPasswordState = (data: DataProps) => {
+  return setAuthentication({
+    ...data.store.stateCache.authentication,
+    passwordIsSkipped: false,
+    passwordIsSet: false,
+  });
+};
+
 const backRoute: Record<string, any> = {
   [RoutePath.ROOT]: {
     updateRedux: [],
@@ -73,22 +135,27 @@ const backRoute: Record<string, any> = {
       removeCurrentRoute,
       updateStoreSetCurrentRoute,
       clearSeedPhraseCache,
+      clearPasswordState,
     ],
   },
   [RoutePath.VERIFY_SEED_PHRASE]: {
     updateRedux: [removeCurrentRoute, updateStoreSetCurrentRoute],
   },
   [RoutePath.VERIFY_RECOVERY_SEED_PHRASE]: {
-    updateRedux: [removeCurrentRoute, updateStoreSetCurrentRoute],
+    updateRedux: [
+      removeCurrentRoute,
+      updateStoreSetCurrentRoute,
+      clearPasswordState,
+    ],
   },
   [RoutePath.SSI_AGENT]: {
-    updateRedux: [],
+    updateRedux: [removeCurrentRoute, updateStoreSetCurrentRoute],
   },
   [RoutePath.SET_PASSCODE]: {
     updateRedux: [removeCurrentRoute, updateStoreSetCurrentRoute],
   },
   [RoutePath.CREATE_PASSWORD]: {
-    updateRedux: [],
+    updateRedux: [removeCurrentRoute, updateStoreSetCurrentRoute],
   },
   [RoutePath.CONNECTION_DETAILS]: {
     updateRedux: [removeCurrentRoute],

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -20,6 +20,7 @@ import { IdentifierDetails } from "../ui/pages/IdentifierDetails";
 import { CredentialDetails } from "../ui/pages/CredentialDetails";
 import { ConnectionDetails } from "../ui/pages/ConnectionDetails";
 import { CreateSSIAgent } from "../ui/pages/CreateSSIAgent";
+import { VerifyRecoverySeedPhrase } from "../ui/pages/VerifyRecoverySeedPhrase";
 
 const Routes = () => {
   const stateCache = useAppSelector(getStateCache);
@@ -70,6 +71,12 @@ const Routes = () => {
         <Route
           path={RoutePath.CREATE_PASSWORD}
           component={CreatePassword}
+          exact
+        />
+
+        <Route
+          path={RoutePath.VERIFY_RECOVERY_SEED_PHRASE}
+          component={VerifyRecoverySeedPhrase}
           exact
         />
 

--- a/src/routes/nextRoute/nextRoute.test.ts
+++ b/src/routes/nextRoute/nextRoute.test.ts
@@ -33,6 +33,7 @@ describe("NextRoute", () => {
           passwordIsSet: false,
           passwordIsSkipped: true,
           ssiAgentIsSet: false,
+          recoveryWalletProgress: false,
         },
         currentOperation: OperationType.IDLE,
         queueIncomingRequest: {
@@ -166,6 +167,7 @@ describe("getNextRoute", () => {
         passwordIsSet: false,
         passwordIsSkipped: true,
         ssiAgentIsSet: false,
+        recoveryWalletProgress: false,
       },
       currentOperation: OperationType.IDLE,
       queueIncomingRequest: {

--- a/src/routes/nextRoute/nextRoute.ts
+++ b/src/routes/nextRoute/nextRoute.ts
@@ -16,15 +16,24 @@ import { ToastMsgType } from "../../ui/globals/types";
 const getNextRootRoute = (store: StoreState) => {
   const authentication = store.stateCache.authentication;
 
-  let path;
-  if (
-    authentication.passcodeIsSet &&
-    authentication.seedPhraseIsSet &&
-    authentication.ssiAgentIsSet
-  ) {
+  let path = RoutePath.ONBOARDING;
+
+  if (authentication.passcodeIsSet) {
+    path = RoutePath.CREATE_PASSWORD;
+  }
+
+  if (authentication.passwordIsSet || authentication.passwordIsSkipped) {
+    path = authentication.recoveryWalletProgress
+      ? RoutePath.VERIFY_RECOVERY_SEED_PHRASE
+      : RoutePath.GENERATE_SEED_PHRASE;
+  }
+
+  if (authentication.seedPhraseIsSet) {
+    path = RoutePath.SSI_AGENT;
+  }
+
+  if (authentication.ssiAgentIsSet) {
     path = RoutePath.TABS_MENU;
-  } else {
-    path = RoutePath.ONBOARDING;
   }
 
   return { pathname: path };
@@ -38,7 +47,9 @@ const getNextOnboardingRoute = (data: DataProps) => {
   }
 
   if (data.store.stateCache.authentication.passwordIsSet) {
-    path = RoutePath.GENERATE_SEED_PHRASE;
+    path = data.state?.recoveryWalletProgress
+      ? RoutePath.VERIFY_RECOVERY_SEED_PHRASE
+      : RoutePath.GENERATE_SEED_PHRASE;
   }
 
   if (data.store.stateCache.authentication.seedPhraseIsSet) {
@@ -104,6 +115,14 @@ const updateStoreAfterSetupSSI = (data: DataProps) => {
   return setAuthentication({
     ...data.store.stateCache.authentication,
     ssiAgentIsSet: true,
+    recoveryWalletProgress: false,
+  });
+};
+
+const updateStoreRecoveryWallet = (data: DataProps) => {
+  return setAuthentication({
+    ...data.store.stateCache.authentication,
+    recoveryWalletProgress: data.state?.recoveryWalletProgress,
   });
 };
 
@@ -131,7 +150,11 @@ const updateStoreCurrentRoute = (data: DataProps) => {
   return setCurrentRoute({ path: data.state?.nextRoute });
 };
 
-const getNextCreatePasswordRoute = () => {
+const getNextCreatePasswordRoute = (data: DataProps) => {
+  if (data.store.stateCache.authentication.recoveryWalletProgress) {
+    return { pathname: RoutePath.VERIFY_RECOVERY_SEED_PHRASE };
+  }
+
   return { pathname: RoutePath.GENERATE_SEED_PHRASE };
 };
 const updateStoreAfterCreatePassword = (data: DataProps) => {
@@ -180,7 +203,7 @@ const nextRoute: Record<string, any> = {
   },
   [RoutePath.ONBOARDING]: {
     nextPath: (data: DataProps) => getNextOnboardingRoute(data),
-    updateRedux: [],
+    updateRedux: [updateStoreRecoveryWallet],
   },
   [RoutePath.SET_PASSCODE]: {
     nextPath: (data: DataProps) => getNextSetPasscodeRoute(data.store),
@@ -194,12 +217,16 @@ const nextRoute: Record<string, any> = {
     nextPath: () => getNextVerifySeedPhraseRoute(),
     updateRedux: [updateStoreAfterVerifySeedPhraseRoute, clearSeedPhraseCache],
   },
+  [RoutePath.VERIFY_RECOVERY_SEED_PHRASE]: {
+    nextPath: () => getNextVerifySeedPhraseRoute(),
+    updateRedux: [updateStoreAfterVerifySeedPhraseRoute],
+  },
   [RoutePath.SSI_AGENT]: {
     nextPath: () => getNextCreateSSIAgentRoute(),
     updateRedux: [updateStoreAfterSetupSSI],
   },
   [RoutePath.CREATE_PASSWORD]: {
-    nextPath: () => getNextCreatePasswordRoute(),
+    nextPath: (data: DataProps) => getNextCreatePasswordRoute(data),
     updateRedux: [updateStoreAfterCreatePassword],
   },
   [RoutePath.CONNECTION_DETAILS]: {

--- a/src/routes/nextRoute/nextRoute.ts
+++ b/src/routes/nextRoute/nextRoute.ts
@@ -116,6 +116,7 @@ const updateStoreAfterSetupSSI = (data: DataProps) => {
     ...data.store.stateCache.authentication,
     ssiAgentIsSet: true,
     recoveryWalletProgress: false,
+    seedPhraseIsSet: true,
   });
 };
 
@@ -219,7 +220,7 @@ const nextRoute: Record<string, any> = {
   },
   [RoutePath.VERIFY_RECOVERY_SEED_PHRASE]: {
     nextPath: () => getNextVerifySeedPhraseRoute(),
-    updateRedux: [updateStoreAfterVerifySeedPhraseRoute],
+    updateRedux: [],
   },
   [RoutePath.SSI_AGENT]: {
     nextPath: () => getNextCreateSSIAgentRoute(),

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -8,6 +8,7 @@ enum RoutePath {
   CREATE_PASSWORD = "/createpassword",
   SSI_AGENT = "/ssiagent",
   CONNECTION_DETAILS = "/connectiondetails",
+  VERIFY_RECOVERY_SEED_PHRASE = "/verifyrecoveryseedphrase",
 }
 
 enum TabsRoutePath {

--- a/src/store/reducers/stateCache/stateCache.test.ts
+++ b/src/store/reducers/stateCache/stateCache.test.ts
@@ -57,6 +57,7 @@ describe("State Cache", () => {
       passwordIsSet: false,
       passwordIsSkipped: false,
       ssiAgentIsSet: false,
+      recoveryWalletProgress: false,
     };
     const action = setAuthentication(authentication);
     const nextState = stateCacheSlice.reducer(initialState, action);

--- a/src/store/reducers/stateCache/stateCache.ts
+++ b/src/store/reducers/stateCache/stateCache.ts
@@ -19,8 +19,9 @@ const initialState: StateCacheProps = {
     passcodeIsSet: false,
     seedPhraseIsSet: false,
     passwordIsSet: false,
-    passwordIsSkipped: true,
+    passwordIsSkipped: false,
     ssiAgentIsSet: false,
+    recoveryWalletProgress: false,
   },
   currentOperation: OperationType.IDLE,
   queueIncomingRequest: {

--- a/src/store/reducers/stateCache/stateCache.types.ts
+++ b/src/store/reducers/stateCache/stateCache.types.ts
@@ -21,6 +21,7 @@ interface AuthenticationCacheProps {
   passwordIsSet: boolean;
   passwordIsSkipped: boolean;
   ssiAgentIsSet: boolean;
+  recoveryWalletProgress: boolean;
 }
 enum IncomingRequestType {
   CREDENTIAL_OFFER_RECEIVED = "credential-offer-received",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -127,9 +127,7 @@ const App = () => {
     );
   };
 
-  const isPublicPage = PublicRoutes.includes(
-    window.location.pathname as RoutePath
-  );
+  const isPublicPage = PublicRoutes.includes(currentRoute?.path as RoutePath);
 
   return (
     <IonApp>

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -311,6 +311,12 @@ const AppWrapper = (props: { children: ReactNode }) => {
     let userName: { userName: string } = { userName: "" };
     const passcodeIsSet = await checkKeyStore(KeyStoreKeys.APP_PASSCODE);
     const seedPhraseIsSet = await checkKeyStore(KeyStoreKeys.SIGNIFY_BRAN);
+    const recoveryWalletProgress = await checkKeyStore(
+      KeyStoreKeys.RECOVERY_WALLET
+    );
+    const passwordIsSkipped = await checkKeyStore(
+      KeyStoreKeys.PASSWORD_SKIPPED
+    );
 
     const passwordIsSet = await checkKeyStore(KeyStoreKeys.APP_OP_PASSWORD);
     const keriaConnectUrlRecord = await Agent.agent.basicStorage.findById(
@@ -364,8 +370,10 @@ const AppWrapper = (props: { children: ReactNode }) => {
         passcodeIsSet,
         seedPhraseIsSet,
         passwordIsSet,
+        passwordIsSkipped,
         ssiAgentIsSet:
           !!keriaConnectUrlRecord && !!keriaConnectUrlRecord.content.url,
+        recoveryWalletProgress,
       })
     );
 

--- a/src/ui/components/SeedPhraseModule/SeedPhraseModule.scss
+++ b/src/ui/components/SeedPhraseModule/SeedPhraseModule.scss
@@ -50,9 +50,26 @@
       padding-inline: 0.625rem;
       font-size: 1rem;
 
+      &:focus-within {
+        border: 1px dashed var(--ion-color-secondary);
+        background-color: transparent;
+      }
+
+      .word-input {
+        min-height: auto;
+
+        .input-highlight.sc-ion-input-md {
+          display: none;
+        }
+      }
+
       &.empty-word {
         border: 1px dashed var(--ion-color-dark-grey);
         background-color: transparent;
+
+        &.error {
+          border-color: var(--ion-color-danger);
+        }
       }
 
       .index {
@@ -69,6 +86,10 @@
         margin: 0.2rem auto;
 
         span {
+          font-size: 0.8rem;
+        }
+
+        .word-input {
           font-size: 0.8rem;
         }
 

--- a/src/ui/components/SeedPhraseModule/SeedPhraseModule.tsx
+++ b/src/ui/components/SeedPhraseModule/SeedPhraseModule.tsx
@@ -1,82 +1,136 @@
-import { IonButton, IonChip, IonIcon } from "@ionic/react";
+import { IonButton, IonChip, IonIcon, IonInput } from "@ionic/react";
 import { eyeOffOutline } from "ionicons/icons";
 import { i18n } from "../../../i18n";
 import "./SeedPhraseModule.scss";
-import { SeedPhraseModuleProps } from "./SeedPhraseModule.types";
+import {
+  SeedPhraseModuleProps,
+  SeedPhraseModuleRef,
+} from "./SeedPhraseModule.types";
+import { forwardRef, useImperativeHandle, useRef } from "react";
+import { combineClassNames } from "../../utils/style";
 
-const SeedPhraseModule = ({
-  testId,
-  seedPhrase,
-  hideSeedPhrase,
-  setHideSeedPhrase,
-  addSeedPhraseSelected,
-  removeSeedPhraseSelected,
-  emptyWord,
-  hideSeedNumber,
-}: SeedPhraseModuleProps) => {
-  return (
-    <div
-      data-testid="seed-phrase-module"
-      className={`seed-phrase-module ${
-        hideSeedPhrase ? "seed-phrase-hidden" : "seed-phrase-visible"
-      }`}
-    >
+const SeedPhraseModule = forwardRef<SeedPhraseModuleRef, SeedPhraseModuleProps>(
+  (
+    {
+      testId,
+      seedPhrase,
+      hideSeedPhrase,
+      setHideSeedPhrase,
+      addSeedPhraseSelected,
+      removeSeedPhraseSelected,
+      emptyWord,
+      hideSeedNumber,
+      inputMode,
+      errorInputIndexs,
+      onInputChange,
+      onInputBlur,
+      onInputFocus,
+    },
+    ref
+  ) => {
+    const seedInputs = useRef<(HTMLElement | null)[]>([]);
+
+    useImperativeHandle(ref, () => ({
+      focusInputByIndex: (index) => {
+        const input = seedInputs.current.at(index);
+        if (!input) return;
+
+        (input as any).setFocus();
+      },
+    }));
+
+    const getClassName = (word: string, index: number) => {
+      if (!inputMode) return;
+
+      return combineClassNames("seed-chips", {
+        "empty-word": !word && index === seedPhrase.length - 1,
+        "empty-word error":
+          !!errorInputIndexs?.includes(index) ||
+          (!word && index !== seedPhrase.length - 1),
+      });
+    };
+
+    return (
       <div
-        data-testid="seed-phrase-privacy-overlay"
-        className="overlay"
+        data-testid="seed-phrase-module"
+        className={`seed-phrase-module ${
+          hideSeedPhrase ? "seed-phrase-hidden" : "seed-phrase-visible"
+        }`}
       >
-        <IonIcon icon={eyeOffOutline} />
-        <p data-testid="seed-phrase-privacy-overlay-text">
-          {i18n.t("generateseedphrase.privacy.overlay.text")}
-        </p>
-        <IonButton
-          shape="round"
-          fill="outline"
-          data-testid="reveal-seed-phrase-button"
-          onClick={() => setHideSeedPhrase && setHideSeedPhrase(false)}
+        <div
+          data-testid="seed-phrase-privacy-overlay"
+          className="overlay"
         >
-          {i18n.t("generateseedphrase.privacy.overlay.button")}
-        </IonButton>
-      </div>
-      <div
-        data-testid={testId}
-        className="seed-phrase-container"
-      >
-        {seedPhrase.map((word, index) => {
-          return (
-            <IonChip
-              key={index}
-              onClick={() => {
-                if (removeSeedPhraseSelected) {
-                  removeSeedPhraseSelected(index);
-                } else if (addSeedPhraseSelected) {
-                  addSeedPhraseSelected(word);
-                }
-              }}
-            >
-              {!hideSeedNumber && (
-                <span
-                  data-testid={`word-index-number-${index}`}
-                  className="index"
-                >
-                  {index + 1}.
-                </span>
-              )}
-              <span data-testid={`word-index-${index + 1}`}>{word}</span>
-            </IonChip>
-          );
-        })}
-        {emptyWord && (
-          <IonChip
-            className="empty-word"
-            data-testid={`empty-word-${seedPhrase.length + 1}`}
+          <IonIcon icon={eyeOffOutline} />
+          <p data-testid="seed-phrase-privacy-overlay-text">
+            {i18n.t("generateseedphrase.privacy.overlay.text")}
+          </p>
+          <IonButton
+            shape="round"
+            fill="outline"
+            data-testid="reveal-seed-phrase-button"
+            onClick={() => setHideSeedPhrase && setHideSeedPhrase(false)}
           >
-            <span className="index">{seedPhrase.length + 1}.</span>
-          </IonChip>
-        )}
+            {i18n.t("generateseedphrase.privacy.overlay.button")}
+          </IonButton>
+        </div>
+        <div
+          data-testid={testId}
+          className="seed-phrase-container"
+        >
+          {seedPhrase.map((word, index) => {
+            return (
+              <IonChip
+                key={index}
+                onClick={() => {
+                  if (removeSeedPhraseSelected) {
+                    removeSeedPhraseSelected(index);
+                  } else if (addSeedPhraseSelected) {
+                    addSeedPhraseSelected(word);
+                  }
+                }}
+                className={getClassName(word, index)}
+              >
+                {!hideSeedNumber && (
+                  <span
+                    data-testid={`word-index-number-${index}`}
+                    className="index"
+                  >
+                    {index + 1}.
+                  </span>
+                )}
+                {inputMode ? (
+                  <IonInput
+                    className="word-input"
+                    ref={(ref) => (seedInputs.current[index] = ref)}
+                    value={word}
+                    onIonInput={(e) => {
+                      onInputChange?.(e.target.value as string, index);
+                    }}
+                    onIonFocus={() => onInputFocus?.(index)}
+                    onIonBlur={() => onInputBlur?.(index)}
+                    name={`word-input-${index}`}
+                    id={`word-input-${index}`}
+                    data-testid={`word-input-${index}`}
+                  />
+                ) : (
+                  <span data-testid={`word-index-${index + 1}`}>{word}</span>
+                )}
+              </IonChip>
+            );
+          })}
+          {emptyWord && (
+            <IonChip
+              className="empty-word"
+              data-testid={`empty-word-${seedPhrase.length + 1}`}
+            >
+              <span className="index">{seedPhrase.length + 1}.</span>
+            </IonChip>
+          )}
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 export { SeedPhraseModule };

--- a/src/ui/components/SeedPhraseModule/SeedPhraseModule.types.ts
+++ b/src/ui/components/SeedPhraseModule/SeedPhraseModule.types.ts
@@ -7,6 +7,15 @@ interface SeedPhraseModuleProps {
   removeSeedPhraseSelected?: (index: number) => void;
   emptyWord?: boolean;
   hideSeedNumber?: boolean;
+  inputMode?: boolean;
+  onInputChange?: (value: string, index: number) => void;
+  onInputFocus?: (index: number) => void;
+  onInputBlur?: (index: number) => void;
+  errorInputIndexs?: number[];
 }
 
-export type { SeedPhraseModuleProps };
+interface SeedPhraseModuleRef {
+  focusInputByIndex: (index: number) => void;
+}
+
+export type { SeedPhraseModuleProps, SeedPhraseModuleRef };

--- a/src/ui/pages/CreatePassword/CreatePassword.tsx
+++ b/src/ui/pages/CreatePassword/CreatePassword.tsx
@@ -72,6 +72,8 @@ const CreatePassword = () => {
           })
         );
       }
+    } else {
+      await SecureStorage.set(KeyStoreKeys.PASSWORD_SKIPPED, String(true));
     }
 
     const { nextPath, updateRedux } = getNextRoute(RoutePath.CREATE_PASSWORD, {

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
@@ -13,15 +13,17 @@ import { setCurrentOperation } from "../../../store/reducers/stateCache";
 import { OperationType } from "../../globals/types";
 import { setBootUrl, setConnectUrl } from "../../../store/reducers/ssiAgent";
 import { RoutePath } from "../../../routes";
-import { Agent } from "../../../core/agent/agent";
+import { KeyStoreKeys } from "../../../core/storage";
 
 const bootAndConnectMock = jest.fn((...args: any) => Promise.resolve());
+const recoverKeriaAgentMock = jest.fn();
 
 jest.mock("../../../core/agent/agent", () => ({
   Agent: {
     ...jest.requireActual("../../../core/agent/agent"),
     agent: {
       bootAndConnect: (...args: any) => bootAndConnectMock(...args),
+      recoverKeriaAgent: (...args: any) => recoverKeriaAgentMock(...args),
     },
   },
 }));
@@ -67,6 +69,15 @@ jest.mock("../../components/CustomInput", () => ({
   },
 }));
 
+const secureStorageDeleteFunc = jest.fn();
+
+jest.mock("../../../core/storage", () => ({
+  ...jest.requireActual("../../../core/storage"),
+  SecureStorage: {
+    delete: (...args: any) => secureStorageDeleteFunc(...args),
+  },
+}));
+
 describe("SSI agent page", () => {
   const mockStore = configureStore();
   const dispatchMock = jest.fn();
@@ -74,6 +85,14 @@ describe("SSI agent page", () => {
     ssiAgentCache: {
       bootUrl: undefined,
       connectUrl: undefined,
+    },
+    stateCache: {
+      authentication: {
+        loggedIn: true,
+        time: Date.now(),
+        passcodeIsSet: true,
+        recoveryWalletProgress: false,
+      },
     },
   };
 
@@ -156,6 +175,14 @@ describe("SSI agent page", () => {
         bootUrl: "11111",
         connectUrl: undefined,
       },
+      stateCache: {
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          recoveryWalletProgress: false,
+        },
+      },
     };
 
     const storeMocked = {
@@ -184,6 +211,14 @@ describe("SSI agent page", () => {
       ssiAgentCache: {
         bootUrl: undefined,
         connectUrl: "11111",
+      },
+      stateCache: {
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          recoveryWalletProgress: false,
+        },
       },
     };
 
@@ -216,6 +251,14 @@ describe("SSI agent page", () => {
         bootUrl: undefined,
         connectUrl: "https://connectUrl.com/",
       },
+      stateCache: {
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          recoveryWalletProgress: false,
+        },
+      },
     };
 
     const storeMocked = {
@@ -246,6 +289,14 @@ describe("SSI agent page", () => {
       ssiAgentCache: {
         bootUrl: "11111",
         connectUrl: "11111",
+      },
+      stateCache: {
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          recoveryWalletProgress: false,
+        },
       },
     };
 
@@ -317,6 +368,106 @@ describe("SSI agent page", () => {
       bootUrl:
         "https://dev.keria-boot.cf-keripy.metadata.dev.cf-deployments.org",
       url: "https://dev.keria.cf-keripy.metadata.dev.cf-deployments.org",
+    });
+  });
+});
+
+describe("SSI agent page: recovery mode", () => {
+  const mockStore = configureStore();
+  const dispatchMock = jest.fn();
+  const initialState = {
+    ssiAgentCache: {
+      bootUrl: undefined,
+      connectUrl: undefined,
+    },
+    stateCache: {
+      authentication: {
+        loggedIn: true,
+        time: Date.now(),
+        passcodeIsSet: true,
+        recoveryWalletProgress: true,
+      },
+    },
+  };
+
+  const storeMocked = {
+    ...mockStore(initialState),
+    dispatch: dispatchMock,
+  };
+
+  test("Renders ssi agent page", () => {
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={storeMocked}>
+        <CreateSSIAgent />
+      </Provider>
+    );
+
+    expect(getByText(ENG_Trans.ssiagent.title)).toBeVisible();
+    expect(getByText(ENG_Trans.ssiagent.description)).toBeVisible();
+    expect(getByText(ENG_Trans.ssiagent.button.info)).toBeVisible();
+    expect(getByText(ENG_Trans.ssiagent.button.validate)).toBeVisible();
+    expect(
+      getByText(ENG_Trans.ssiagent.button.validate).getAttribute("disabled")
+    ).toBe("true");
+
+    expect(queryByTestId("boot-url-input")).toBe(null);
+    expect(getByTestId("connect-url-input")).toBeVisible();
+  });
+
+  test("Connect and boot success", async () => {
+    const mockStore = configureStore();
+    const initialState = {
+      stateCache: {
+        authentication: {
+          passcodeIsSet: true,
+          seedPhraseIsSet: true,
+          passwordIsSet: true,
+          passwordIsSkipped: true,
+          loggedIn: false,
+          userName: "",
+          time: 0,
+          ssiAgentIsSet: false,
+          recoveryWalletProgress: true,
+        },
+      },
+      ssiAgentCache: {
+        bootUrl:
+          "https://dev.keria-boot.cf-keripy.metadata.dev.cf-deployments.org",
+        connectUrl:
+          "https://dev.keria.cf-keripy.metadata.dev.cf-deployments.org",
+      },
+      seedPhraseCache: {
+        seedPhrase: "mock-seed",
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const history = createMemoryHistory();
+    history.push(RoutePath.SSI_AGENT);
+
+    const { getByTestId } = render(
+      <IonReactMemoryRouter history={history}>
+        <Provider store={storeMocked}>
+          <CreateSSIAgent />
+        </Provider>
+      </IonReactMemoryRouter>
+    );
+
+    act(() => {
+      fireEvent.click(getByTestId("primary-button-create-ssi-agent"));
+    });
+
+    await waitFor(() => {
+      expect(secureStorageDeleteFunc).toBeCalledWith(
+        KeyStoreKeys.RECOVERY_WALLET
+      );
+      expect(secureStorageDeleteFunc).toBeCalledWith(
+        KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME
+      );
     });
   });
 });

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
@@ -465,9 +465,6 @@ describe("SSI agent page: recovery mode", () => {
       expect(secureStorageDeleteFunc).toBeCalledWith(
         KeyStoreKeys.RECOVERY_WALLET
       );
-      expect(secureStorageDeleteFunc).toBeCalledWith(
-        KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME
-      );
     });
   });
 });

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
@@ -403,7 +403,7 @@ describe("SSI agent page: recovery mode", () => {
     );
 
     expect(getByText(ENG_Trans.ssiagent.title)).toBeVisible();
-    expect(getByText(ENG_Trans.ssiagent.description)).toBeVisible();
+    expect(getByText(ENG_Trans.ssiagent.verifydescription)).toBeVisible();
     expect(getByText(ENG_Trans.ssiagent.button.info)).toBeVisible();
     expect(getByText(ENG_Trans.ssiagent.button.validate)).toBeVisible();
     expect(

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -267,7 +267,11 @@ const CreateSSIAgent = () => {
           className="page-paragraph"
           data-testid={`${pageId}-top-paragraph`}
         >
-          {i18n.t("ssiagent.description")}
+          {i18n.t(
+            isRecoveryMode
+              ? "ssiagent.verifydescription"
+              : "ssiagent.description"
+          )}
         </p>
         <div>
           <IonButton

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -157,8 +157,14 @@ const CreateSSIAgent = () => {
         [SSI_URLS_EMPTY, SEED_PHRASE_EMPTY, Agent.INVALID_MNEMONIC].includes(
           errorMessage
         )
-      )
+      ) {
         return;
+      }
+
+      if (Agent.KERIA_NOT_BOOTED === errorMessage) {
+        setHasMismatchError(true);
+        return;
+      }
 
       setInvalidConnectUrl(true);
     } finally {

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -146,7 +146,6 @@ const CreateSSIAgent = () => {
         updateRedux
       );
 
-      SecureStorage.delete(KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME);
       SecureStorage.delete(KeyStoreKeys.RECOVERY_WALLET);
 
       ionRouter.push(nextPath.pathname, "forward", "push");

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -33,8 +33,11 @@ import { TermsModal } from "../../components/TermsModal";
 import { Agent } from "../../../core/agent/agent";
 import { ScrollablePageLayout } from "../../components/layout/ScrollablePageLayout";
 import { ConfigurationService } from "../../../core/configuration";
+import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
+import { getSeedPhraseCache } from "../../../store/reducers/seedPhraseCache";
 
 const SSI_URLS_EMPTY = "SSI url is empty";
+const SEED_PHRASE_EMPTY = "Invalid seed phrase";
 
 const InputError = ({
   showError,
@@ -53,8 +56,9 @@ const InputError = ({
 const CreateSSIAgent = () => {
   const pageId = "create-ssi-agent";
   const ssiAgent = useAppSelector(getSSIAgent);
-
+  const seedPhraseCache = useAppSelector(getSeedPhraseCache);
   const stateCache = useAppSelector(getStateCache);
+
   const ionRouter = useAppIonRouter();
   const dispatch = useAppDispatch();
   const [connectUrlInputTouched, setConnectUrlTouched] = useState(false);
@@ -63,6 +67,9 @@ const CreateSSIAgent = () => {
   const [loading, setLoading] = useState(false);
   const [hasMismatchError, setHasMismatchError] = useState(false);
   const [isInvalidBootUrl, setIsInvalidBootUrl] = useState(false);
+  const [isInvalidConnectUrl, setInvalidConnectUrl] = useState(false);
+
+  const isRecoveryMode = stateCache.authentication.recoveryWalletProgress;
 
   useEffect(() => {
     if (!ssiAgent.bootUrl && !ssiAgent.connectUrl) {
@@ -84,7 +91,9 @@ const CreateSSIAgent = () => {
   };
 
   const validBootUrl = useMemo(() => {
-    return ssiAgent.bootUrl && isValidHttpUrl(ssiAgent.bootUrl);
+    return (
+      isRecoveryMode || (ssiAgent.bootUrl && isValidHttpUrl(ssiAgent.bootUrl))
+    );
   }, [ssiAgent]);
 
   const validConnectUrl = useMemo(() => {
@@ -92,6 +101,7 @@ const CreateSSIAgent = () => {
   }, [ssiAgent]);
 
   const displayBootUrlError =
+    !isRecoveryMode &&
     bootUrlInputTouched &&
     ssiAgent.bootUrl &&
     !isValidHttpUrl(ssiAgent.bootUrl);
@@ -107,7 +117,57 @@ const CreateSSIAgent = () => {
     dispatch(clearSSIAgent());
   };
 
-  const handleValidate = async () => {
+  const handleRecoveryWallet = async () => {
+    setLoading(true);
+    try {
+      if (!ssiAgent.connectUrl) {
+        throw new Error(SSI_URLS_EMPTY);
+      }
+
+      if (!seedPhraseCache.seedPhrase) {
+        throw new Error(SEED_PHRASE_EMPTY);
+      }
+
+      await Agent.agent.recoverKeriaAgent(
+        seedPhraseCache.seedPhrase.split(" "),
+        ssiAgent.connectUrl
+      );
+
+      const { nextPath, updateRedux } = getNextRoute(RoutePath.SSI_AGENT, {
+        store: { stateCache },
+      });
+
+      updateReduxState(
+        nextPath.pathname,
+        {
+          store: { stateCache },
+        },
+        dispatch,
+        updateRedux
+      );
+
+      SecureStorage.delete(KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME);
+      SecureStorage.delete(KeyStoreKeys.RECOVERY_WALLET);
+
+      ionRouter.push(nextPath.pathname, "forward", "push");
+      handleClearState();
+    } catch (e) {
+      const errorMessage = (e as Error).message;
+
+      if (
+        [SSI_URLS_EMPTY, SEED_PHRASE_EMPTY, Agent.INVALID_MNEMONIC].includes(
+          errorMessage
+        )
+      )
+        return;
+
+      setInvalidConnectUrl(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateSSI = async () => {
     setLoading(true);
     try {
       if (!ssiAgent.bootUrl || !ssiAgent.connectUrl) {
@@ -115,7 +175,7 @@ const CreateSSIAgent = () => {
       }
 
       await Agent.agent.bootAndConnect({
-        bootUrl: ssiAgent.bootUrl,
+        bootUrl: ssiAgent.bootUrl || "",
         url: ssiAgent.connectUrl,
       });
 
@@ -148,6 +208,14 @@ const CreateSSIAgent = () => {
     }
   };
 
+  const handleValidate = () => {
+    if (isRecoveryMode) {
+      handleRecoveryWallet();
+    } else {
+      handleCreateSSI();
+    }
+  };
+
   const scanBootUrl = (event: ReactMouseEvent<HTMLElement, MouseEvent>) => {
     event.stopPropagation();
     dispatch(setCurrentOperation(OperationType.SCAN_SSI_BOOT_URL));
@@ -166,6 +234,17 @@ const CreateSSIAgent = () => {
     }
 
     return result;
+  };
+
+  const handleChangeConnectUrl = (connectionUrl: string) => {
+    setInvalidConnectUrl(false);
+    setHasMismatchError(false);
+    dispatch(setConnectUrl(connectionUrl));
+  };
+
+  const handleChangeBootUrl = (bootUrl: string) => {
+    setIsInvalidBootUrl(false);
+    dispatch(setBootUrl(bootUrl));
   };
 
   return (
@@ -203,44 +282,45 @@ const CreateSSIAgent = () => {
             {i18n.t("ssiagent.button.info")}
           </IonButton>
         </div>
-        <CustomInput
-          dataTestId="boot-url-input"
-          title={`${i18n.t("ssiagent.input.boot.label")}`}
-          placeholder={`${i18n.t("ssiagent.input.boot.placeholder")}`}
-          actionIcon={scanOutline}
-          action={scanBootUrl}
-          onChangeInput={(bootUrl: string) => {
-            setIsInvalidBootUrl(false);
-            dispatch(setBootUrl(bootUrl));
-          }}
-          value={ssiAgent.bootUrl || ""}
-          onChangeFocus={(result) => {
-            setTouchedBootUrlInput();
+        {!isRecoveryMode && (
+          <>
+            <CustomInput
+              dataTestId="boot-url-input"
+              title={`${i18n.t("ssiagent.input.boot.label")}`}
+              placeholder={`${i18n.t("ssiagent.input.boot.placeholder")}`}
+              actionIcon={scanOutline}
+              action={scanBootUrl}
+              onChangeInput={handleChangeBootUrl}
+              value={ssiAgent.bootUrl || ""}
+              onChangeFocus={(result) => {
+                setTouchedBootUrlInput();
 
-            if (!result && ssiAgent.bootUrl) {
-              dispatch(setBootUrl(removeLastSlash(ssiAgent.bootUrl.trim())));
-            }
-          }}
-          error={!!displayBootUrlError || isInvalidBootUrl}
-        />
-        <InputError
-          showError={!!displayBootUrlError || isInvalidBootUrl}
-          errorMessage={
-            (displayBootUrlError || isInvalidBootUrl) && !displayConnectUrlError
-              ? `${i18n.t("ssiagent.error.invalidbooturl")}`
-              : `${i18n.t("ssiagent.error.invalidurl")}`
-          }
-        />
+                if (!result && ssiAgent.bootUrl) {
+                  dispatch(
+                    setBootUrl(removeLastSlash(ssiAgent.bootUrl.trim()))
+                  );
+                }
+              }}
+              error={!!displayBootUrlError || isInvalidBootUrl}
+            />
+            <InputError
+              showError={!!displayBootUrlError || isInvalidBootUrl}
+              errorMessage={
+                (displayBootUrlError || isInvalidBootUrl) &&
+                !displayConnectUrlError
+                  ? `${i18n.t("ssiagent.error.invalidbooturl")}`
+                  : `${i18n.t("ssiagent.error.invalidurl")}`
+              }
+            />
+          </>
+        )}
         <CustomInput
           dataTestId="connect-url-input"
           title={`${i18n.t("ssiagent.input.connect.label")}`}
           placeholder={`${i18n.t("ssiagent.input.connect.placeholder")}`}
           actionIcon={scanOutline}
           action={scanConnectUrl}
-          onChangeInput={(connectionUrl: string) => {
-            setHasMismatchError(false);
-            dispatch(setConnectUrl(connectionUrl));
-          }}
+          onChangeInput={handleChangeConnectUrl}
           onChangeFocus={(result) => {
             setTouchedConnectUrlInput();
 
@@ -251,14 +331,18 @@ const CreateSSIAgent = () => {
             }
           }}
           value={ssiAgent.connectUrl || ""}
-          error={!!displayConnectUrlError || hasMismatchError}
+          error={
+            !!displayConnectUrlError || hasMismatchError || isInvalidConnectUrl
+          }
         />
         <InputError
-          showError={!!displayConnectUrlError || hasMismatchError}
+          showError={
+            !!displayConnectUrlError || hasMismatchError || isInvalidConnectUrl
+          }
           errorMessage={
             hasMismatchError
               ? `${i18n.t("ssiagent.error.mismatchconnecturl")}`
-              : displayBootUrlError
+              : displayBootUrlError && !isInvalidConnectUrl
                 ? `${i18n.t("ssiagent.error.invalidurl")}`
                 : `${i18n.t("ssiagent.error.invalidconnecturl")}`
           }

--- a/src/ui/pages/Onboarding/Onboarding.tsx
+++ b/src/ui/pages/Onboarding/Onboarding.tsx
@@ -17,6 +17,7 @@ import introImg4 from "../../assets/images/intro-4.png";
 import { PageFooter } from "../../components/PageFooter";
 import { ResponsivePageLayout } from "../../components/layout/ResponsivePageLayout";
 import { useEffect, useState } from "react";
+import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
 
 export type IntroImg0Type = typeof introImg0;
 
@@ -62,15 +63,19 @@ const Onboarding = () => {
 
   // @TODO - foconnor: This should be op: OperationType when available (non optional)
   const handleNavigation = (op?: string) => {
-    if (op) {
-      // @TODO - sdisalvo: Remove this condition and default to dispatch when the restore route is ready
-      return;
-    }
     const data: DataProps = {
       store: { stateCache },
+      state: {
+        recoveryWalletProgress: !!op,
+      },
     };
     const { nextPath, updateRedux } = getNextRoute(RoutePath.ONBOARDING, data);
     updateReduxState(nextPath.pathname, data, dispatch, updateRedux);
+
+    if (op) {
+      SecureStorage.set(KeyStoreKeys.RECOVERY_WALLET, String(!!op));
+    }
+
     history.push({
       pathname: nextPath.pathname,
       state: data.state,

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.scss
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.scss
@@ -11,6 +11,13 @@
     }
   }
 
+  .page-title {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    margin-top: 0.5rem;
+    font-weight: 700;
+  }
+
   .content-container {
     display: flex;
     flex-direction: column;

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.scss
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.scss
@@ -1,0 +1,86 @@
+.verify-recovery-seed-phrase {
+  --background: var(--ion-color-light);
+
+  .seed-phrase-module:nth-of-type(1) {
+    background: var(--ion-color-light-grey);
+  }
+
+  .page-header {
+    ion-toolbar {
+      --background: transparent;
+    }
+  }
+
+  .content-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: calc(100vh - (5.25rem + var(--ion-safe-area-top)));
+
+    .page-content {
+      display: flex;
+      flex-direction: column;
+
+      & > * {
+        flex: 0 1 auto;
+      }
+    }
+  }
+
+  .paragraph-top {
+    margin: 0.75rem 0 1rem;
+  }
+
+  .suggest-error {
+    font-size: 1rem;
+    line-height: 1.115rem;
+    color: var(--ion-color-primary);
+    text-align: center;
+    font-weight: 400;
+  }
+
+  .suggestion-title {
+    margin: 1.5rem 0 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.5rem;
+  }
+
+  .seed-phrase-module:nth-of-type(2) {
+    border: none;
+  }
+
+  .clear-button {
+    display: flex;
+    width: fit-content;
+    margin: 1.5rem auto 1rem;
+  }
+
+  @media screen and (min-width: 250px) and (max-width: 370px) {
+    .responsive-page-layout {
+      padding: 0 0.9rem;
+
+      .responsive-page-content {
+        & > * {
+          margin: 0;
+        }
+
+        & > .paragraph-top {
+          margin: 0.2rem 0;
+        }
+      }
+    }
+
+    .suggest-error {
+      font-size: 0.8rem;
+    }
+
+    .clear-button {
+      margin-top: 1rem;
+    }
+
+    .suggestion-title {
+      margin-top: 1rem;
+    }
+  }
+}

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.test.tsx
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.test.tsx
@@ -1,0 +1,368 @@
+import { IonReactMemoryRouter } from "@ionic/react-router";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import ENG_Trans from "../../../locales/en/en.json";
+import { RoutePath } from "../../../routes";
+import { VerifyRecoverySeedPhrase } from "./VerifyRecoverySeedPhrase";
+import { setSeedPhraseCache } from "../../../store/reducers/seedPhraseCache";
+
+const SEED_PHRASE_LENGTH = 18;
+
+const secureStorageGetFunc = jest.fn();
+const secureStorageSetFunc = jest.fn();
+const secureStorageDeleteFunc = jest.fn();
+const verifySeedPhraseFnc = jest.fn();
+
+jest.mock("../../../core/agent/agent", () => ({
+  Agent: {
+    agent: {
+      isMnemonicValid: () => verifySeedPhraseFnc(),
+    },
+  },
+}));
+
+jest.mock("../../../core/storage", () => ({
+  ...jest.requireActual("../../../core/storage"),
+  SecureStorage: {
+    get: (...args: any) => secureStorageGetFunc(...args),
+    set: (...args: any) => secureStorageSetFunc(...args),
+    delete: (...args: any) => secureStorageDeleteFunc(...args),
+  },
+}));
+
+jest.mock("@ionic/react", () => ({
+  ...jest.requireActual("@ionic/react"),
+  IonInput: (props: any) => {
+    return (
+      <input
+        {...props}
+        data-testid={props["data-testid"]}
+        onBlur={(e) => props.onIonBlur(e)}
+        onFocus={(e) => props.onIonFocus(e)}
+        onChange={(e) => props.onIonInput?.(e)}
+      />
+    );
+  },
+}));
+
+describe("Verify Recovery Seed Phrase", () => {
+  const mockStore = configureStore();
+  const dispatchMock = jest.fn();
+  const initialState = {
+    stateCache: {
+      authentication: {
+        loggedIn: true,
+        time: Date.now(),
+        passcodeIsSet: true,
+        recoveryWalletProgress: true,
+      },
+    },
+  };
+
+  const storeMocked = {
+    ...mockStore(initialState),
+    dispatch: dispatchMock,
+  };
+
+  test("Render screen", () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <VerifyRecoverySeedPhrase />
+      </Provider>
+    );
+
+    expect(getByText(ENG_Trans.verifyrecoveryseedphrase.title)).toBeVisible();
+    expect(
+      getByText(ENG_Trans.verifyrecoveryseedphrase.paragraph.top)
+    ).toBeVisible();
+    expect(
+      getByText(
+        ENG_Trans.verifyrecoveryseedphrase.button.continue
+      ).getAttribute("disabled")
+    ).toBe("true");
+    expect(getByTestId("word-input-0")).toBeVisible();
+  });
+
+  test("Render suggest seed phrase", async () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <VerifyRecoverySeedPhrase />
+      </Provider>
+    );
+
+    expect(getByText(ENG_Trans.verifyrecoveryseedphrase.title)).toBeVisible();
+
+    const firstInput = getByTestId("word-input-0");
+    act(() => {
+      fireEvent.focus(firstInput);
+      fireEvent.change(firstInput, {
+        target: { value: "a" },
+      });
+    });
+
+    expect(
+      getByText(ENG_Trans.verifyrecoveryseedphrase.suggestions.title)
+    ).toBeVisible();
+    expect(getByText("abandon")).toBeVisible();
+    expect(getByTestId("word-input-1")).toBeVisible();
+
+    act(() => {
+      fireEvent.click(getByText("abandon"));
+    });
+
+    await waitFor(() => {
+      expect((firstInput as HTMLInputElement).value).toEqual("abandon");
+    });
+  });
+
+  test("Render/clear word should match suggestion error", async () => {
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={storeMocked}>
+        <VerifyRecoverySeedPhrase />
+      </Provider>
+    );
+
+    expect(getByText(ENG_Trans.verifyrecoveryseedphrase.title)).toBeVisible();
+
+    const firstInput = getByTestId("word-input-0");
+    act(() => {
+      fireEvent.focus(firstInput);
+      fireEvent.change(firstInput, {
+        target: { value: "a" },
+      });
+    });
+
+    expect(
+      getByText(ENG_Trans.verifyrecoveryseedphrase.suggestions.title)
+    ).toBeVisible();
+
+    act(() => {
+      fireEvent.blur(firstInput);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("no-suggest-error")).toBeVisible();
+    });
+
+    act(() => {
+      fireEvent.focus(firstInput);
+      fireEvent.change(firstInput, {
+        target: { value: "abandon" },
+      });
+    });
+
+    expect(
+      getByText(ENG_Trans.verifyrecoveryseedphrase.suggestions.title)
+    ).toBeVisible();
+
+    act(() => {
+      fireEvent.blur(firstInput);
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId("no-suggest-error")).toBe(null);
+    });
+  });
+
+  test("Fill all seed", async () => {
+    const history = createMemoryHistory();
+    history.push(RoutePath.VERIFY_RECOVERY_SEED_PHRASE);
+
+    verifySeedPhraseFnc.mockImplementation(() => {
+      return Promise.resolve(true);
+    });
+
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <IonReactMemoryRouter
+          history={history}
+          initialEntries={[RoutePath.VERIFY_RECOVERY_SEED_PHRASE]}
+        >
+          <VerifyRecoverySeedPhrase />
+        </IonReactMemoryRouter>
+      </Provider>
+    );
+
+    expect(getByText(ENG_Trans.verifyrecoveryseedphrase.title)).toBeVisible();
+    for (let i = 0; i < SEED_PHRASE_LENGTH; i++) {
+      act(() => {
+        const input = getByTestId(`word-input-${i}`);
+        fireEvent.focus(input);
+        fireEvent.change(input, {
+          target: { value: "a" },
+        });
+      });
+
+      await waitFor(() => {
+        expect(getByText("abandon")).toBeVisible();
+      });
+
+      act(() => {
+        fireEvent.click(getByText("abandon"));
+      });
+
+      if (i < SEED_PHRASE_LENGTH - 1) {
+        await waitFor(() => {
+          expect(getByTestId(`word-input-${i}`)).toBeVisible();
+        });
+      }
+    }
+
+    expect(
+      getByText(
+        ENG_Trans.verifyrecoveryseedphrase.button.continue
+      ).getAttribute("disabled")
+    ).toBe("false");
+
+    act(() => {
+      fireEvent.click(
+        getByText(ENG_Trans.verifyrecoveryseedphrase.button.continue)
+      );
+    });
+
+    await waitFor(() => {
+      expect(dispatchMock).toBeCalledWith(
+        setSeedPhraseCache({
+          seedPhrase:
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon",
+          bran: "",
+        })
+      );
+    });
+  });
+
+  test("Lock when try max attempt", async () => {
+    const history = createMemoryHistory();
+    history.push(RoutePath.VERIFY_RECOVERY_SEED_PHRASE);
+
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <IonReactMemoryRouter
+          history={history}
+          initialEntries={[RoutePath.VERIFY_RECOVERY_SEED_PHRASE]}
+        >
+          <VerifyRecoverySeedPhrase />
+        </IonReactMemoryRouter>
+      </Provider>
+    );
+
+    expect(getByText(ENG_Trans.verifyrecoveryseedphrase.title)).toBeVisible();
+    for (let i = 0; i < SEED_PHRASE_LENGTH; i++) {
+      act(() => {
+        const input = getByTestId(`word-input-${i}`);
+        fireEvent.focus(input);
+        fireEvent.change(input, {
+          target: { value: "a" },
+        });
+      });
+
+      await waitFor(() => {
+        expect(getByText("abandon")).toBeVisible();
+      });
+
+      act(() => {
+        fireEvent.click(getByText("abandon"));
+      });
+
+      if (i < SEED_PHRASE_LENGTH - 1) {
+        await waitFor(() => {
+          expect(getByTestId(`word-input-${i}`)).toBeVisible();
+        });
+      }
+    }
+
+    expect(
+      getByText(
+        ENG_Trans.verifyrecoveryseedphrase.button.continue
+      ).getAttribute("disabled")
+    ).toBe("false");
+
+    verifySeedPhraseFnc.mockImplementation(() => {
+      return Promise.resolve(false);
+    });
+
+    for (let i = 0; i < 5; i++) {
+      act(() => {
+        fireEvent.click(
+          getByText(ENG_Trans.verifyrecoveryseedphrase.button.continue)
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          getByText(ENG_Trans.verifyrecoveryseedphrase.alert.fail.text)
+        ).toBeVisible();
+      });
+
+      act(() => {
+        fireEvent.click(
+          getByText(
+            ENG_Trans.verifyrecoveryseedphrase.alert.fail.button.confirm
+          )
+        );
+      });
+    }
+
+    await waitFor(() => {
+      expect(
+        getByText(ENG_Trans.verifyrecoveryseedphrase.alert.manyattemp.text)
+      ).toBeVisible();
+      expect(
+        getByText(ENG_Trans.verifyrecoveryseedphrase.button.lock)
+      ).toBeVisible();
+    });
+  });
+
+  test("Lock when try max attempt after reload page", async () => {
+    const history = createMemoryHistory();
+    history.push(RoutePath.VERIFY_RECOVERY_SEED_PHRASE);
+
+    secureStorageGetFunc.mockImplementation(() => {
+      return Promise.resolve(Date.now() - 1000);
+    });
+
+    const { getByText } = render(
+      <Provider store={storeMocked}>
+        <IonReactMemoryRouter
+          history={history}
+          initialEntries={[RoutePath.VERIFY_RECOVERY_SEED_PHRASE]}
+        >
+          <VerifyRecoverySeedPhrase />
+        </IonReactMemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText(ENG_Trans.verifyrecoveryseedphrase.button.lock)
+      ).toBeVisible();
+    });
+  });
+
+  test("Remove last lock time when duration greater than 10 minutes", async () => {
+    const history = createMemoryHistory();
+    history.push(RoutePath.VERIFY_RECOVERY_SEED_PHRASE);
+
+    secureStorageGetFunc.mockImplementation(() => {
+      return Promise.resolve(Date.now() - 11 * 60 * 1000);
+    });
+
+    render(
+      <Provider store={storeMocked}>
+        <IonReactMemoryRouter
+          history={history}
+          initialEntries={[RoutePath.VERIFY_RECOVERY_SEED_PHRASE]}
+        >
+          <VerifyRecoverySeedPhrase />
+        </IonReactMemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(secureStorageDeleteFunc).toBeCalled();
+    });
+  });
+});

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.test.tsx
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.test.tsx
@@ -308,7 +308,7 @@ describe("Verify Recovery Seed Phrase", () => {
 
     await waitFor(() => {
       expect(
-        getByText(ENG_Trans.verifyrecoveryseedphrase.alert.manyattemp.text)
+        getByText(ENG_Trans.verifyrecoveryseedphrase.alert.toomanyattempts.text)
       ).toBeVisible();
       expect(
         getByText(ENG_Trans.verifyrecoveryseedphrase.button.lock)

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
@@ -367,7 +367,10 @@ const VerifyRecoverySeedPhrase = () => {
       >
         <div className="content-container">
           <div className="page-content">
-            <h2 data-testid={`${pageId}-title`}>
+            <h2
+              className="page-title"
+              data-testid={`${pageId}-title`}
+            >
               {i18n.t("verifyrecoveryseedphrase.title")}
             </h2>
             <p

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
@@ -294,7 +294,7 @@ const VerifyRecoverySeedPhrase = () => {
   const handleBack = () => {
     handleClearState();
     const { backPath, updateRedux } = getBackRoute(
-      RoutePath.VERIFY_SEED_PHRASE,
+      RoutePath.VERIFY_RECOVERY_SEED_PHRASE,
       {
         store: { stateCache },
       }
@@ -358,7 +358,7 @@ const VerifyRecoverySeedPhrase = () => {
               handleClearState();
               handleBack();
             }}
-            currentPath={RoutePath.VERIFY_SEED_PHRASE}
+            currentPath={RoutePath.VERIFY_RECOVERY_SEED_PHRASE}
             progressBar={true}
             progressBarValue={0.75}
             progressBarBuffer={1}
@@ -467,9 +467,11 @@ const VerifyRecoverySeedPhrase = () => {
         isOpen={alertManyAttempOpen}
         setIsOpen={setAlertManyAttempOpen}
         dataTestId="alert-fail"
-        headerText={i18n.t("verifyrecoveryseedphrase.alert.manyattemp.text")}
+        headerText={i18n.t(
+          "verifyrecoveryseedphrase.alert.toomanyattempts.text"
+        )}
         confirmButtonText={`${i18n.t(
-          "verifyrecoveryseedphrase.alert.manyattemp.button.confirm"
+          "verifyrecoveryseedphrase.alert.toomanyattempts.button.confirm"
         )}`}
         actionConfirm={handleClearState}
         actionCancel={closeClearAlert}

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
@@ -250,6 +250,9 @@ const VerifyRecoverySeedPhrase = () => {
           bran: "",
         })
       );
+      SecureStorage.delete(KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME);
+      setFailAttempt(0);
+
       handleNavigate();
     } catch (e) {
       setFailAttempt((value) => value + 1);

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.tsx
@@ -1,0 +1,468 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useHistory } from "react-router-dom";
+import { closeOutline } from "ionicons/icons";
+import { wordlists } from "bip39";
+import { IonButton, IonIcon } from "@ionic/react";
+import { i18n } from "../../../i18n";
+import { RoutePath } from "../../../routes";
+import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { Alert as AlertFail } from "../../components/Alert";
+import "./VerifyRecoverySeedPhrase.scss";
+import { getNextRoute } from "../../../routes/nextRoute";
+import { updateReduxState } from "../../../store/utils";
+import { getStateCache } from "../../../store/reducers/stateCache";
+import { getBackRoute } from "../../../routes/backRoute";
+import { DataProps } from "../../../routes/nextRoute/nextRoute.types";
+import { PageHeader } from "../../components/PageHeader";
+import { PageFooter } from "../../components/PageFooter";
+import { SeedPhraseModule } from "../../components/SeedPhraseModule";
+import { useAppIonRouter } from "../../hooks";
+import { ScrollablePageLayout } from "../../components/layout/ScrollablePageLayout";
+import { SeedPhraseModuleRef } from "../../components/SeedPhraseModule/SeedPhraseModule.types";
+import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
+import { setSeedPhraseCache } from "../../../store/reducers/seedPhraseCache";
+import { Agent } from "../../../core/agent/agent";
+
+const SEED_PHRASE_LENGTH = 18;
+const SUGGEST_SEED_PHRASE_LENGTH = 4;
+const MAX_ATTEMPT_FAIL = 5;
+const LOCK_TIME = 60000;
+const RESET_ATTEMPT_TIME = 600000;
+const SELECT_WORD_LIST = wordlists.english;
+const INVALID_SEED_PHRASE = "Invalid seed phrase";
+
+const VerifyRecoverySeedPhrase = () => {
+  const pageId = "verify-recovery-seed-phrase";
+  const history = useHistory();
+  const dispatch = useAppDispatch();
+  const stateCache = useAppSelector(getStateCache);
+
+  const [alertIsOpen, setAlertIsOpen] = useState(false);
+  const [clearAlertOpen, setClearAlertOpen] = useState(false);
+  const [alertManyAttempOpen, setAlertManyAttempOpen] = useState(false);
+  const ionRouter = useAppIonRouter();
+
+  const [seedPhrase, setSeedPhrase] = useState<string[]>([""]);
+  const [suggestSeedPhrase, setSuggestSeedPhrase] = useState<string[]>([]);
+  const [errorInputIndex, setErrorInputIndex] = useState<number[]>([]);
+
+  const [failAttempt, setFailAttempt] = useState(0);
+  const [lastLockTime, setLastLockTime] = useState<Date | null>(null);
+  const [lockFailAttempt, setLockFailAttempt] = useState(false);
+
+  const lastFocusIndex = useRef<number | null>(null);
+  const seedPhraseRef = useRef<SeedPhraseModuleRef>(null);
+
+  const removeLockAttempt = () => {
+    SecureStorage.delete(KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME);
+    setFailAttempt(0);
+    setLockFailAttempt(false);
+  };
+
+  const getLockDuration = useCallback(() => {
+    return Date.now() - (!lastLockTime ? 0 : lastLockTime.getTime());
+  }, [lastLockTime]);
+
+  useEffect(() => {
+    async function getFailAttemptInfo() {
+      try {
+        const lastFailedTime = await SecureStorage.get(
+          KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME
+        );
+        if (!lastFailedTime) return;
+
+        const lockDuration = Date.now() - Number(lastFailedTime);
+
+        if (lockDuration >= RESET_ATTEMPT_TIME) {
+          removeLockAttempt();
+          return;
+        }
+
+        setFailAttempt(MAX_ATTEMPT_FAIL);
+        setLastLockTime(new Date(Number(lastFailedTime)));
+      } catch (e) {
+        // TODO: handle error
+      }
+    }
+
+    getFailAttemptInfo();
+  }, []);
+
+  // Reset attempt numbers after 10 minutes from last lock period
+  useEffect(() => {
+    if (!lastLockTime) return;
+
+    const resetAttemptTime = RESET_ATTEMPT_TIME - getLockDuration();
+
+    if (resetAttemptTime <= 0) return;
+
+    const timerId = setTimeout(() => {
+      removeLockAttempt();
+    }, resetAttemptTime);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [lastLockTime]);
+
+  useEffect(() => {
+    if (!lastLockTime) return;
+
+    const lockTime = LOCK_TIME - getLockDuration();
+
+    if (lockTime <= 0) {
+      setLockFailAttempt(false);
+      return;
+    }
+
+    setLockFailAttempt(true);
+    setFailAttempt(MAX_ATTEMPT_FAIL);
+
+    const timerId = setTimeout(() => {
+      setLockFailAttempt(false);
+    }, lockTime);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [lastLockTime]);
+
+  const handleClearState = () => {
+    setSeedPhrase([""]);
+    setSuggestSeedPhrase([]);
+    setAlertIsOpen(false);
+    seedPhraseRef.current?.focusInputByIndex(0);
+  };
+
+  const clearErrorIndex = (errorIndex: number | null) => {
+    if (errorIndex === null) return;
+
+    setErrorInputIndex((errorIndexs) => {
+      return errorIndexs.filter((index) => index !== errorIndex);
+    });
+  };
+
+  const renderSuggestSeedPhrase = (inputWord: string) => {
+    inputWord = inputWord.toLowerCase().trim();
+
+    if (!inputWord) {
+      clearErrorIndex(lastFocusIndex.current);
+      setSuggestSeedPhrase([]);
+      return;
+    }
+
+    const suggestionWords: string[] = [];
+    for (let index = 0; index < SELECT_WORD_LIST.length; index++) {
+      const word = SELECT_WORD_LIST[index];
+
+      if (word.startsWith(inputWord)) {
+        suggestionWords.push(word);
+      }
+
+      if (suggestionWords.length >= SUGGEST_SEED_PHRASE_LENGTH) {
+        break;
+      }
+    }
+
+    setErrorInputIndex((errorIndexs) => {
+      if (lastFocusIndex.current === null) return errorIndexs;
+
+      if (suggestionWords.length > 0) {
+        return errorIndexs.filter((index) => index !== lastFocusIndex.current);
+      }
+
+      errorIndexs.push(lastFocusIndex.current);
+      return [...errorIndexs];
+    });
+
+    setSuggestSeedPhrase(suggestionWords);
+  };
+
+  const handleUpdateSeedPhrase = (value: string, index: number) => {
+    const currentValue = [...seedPhrase];
+
+    renderSuggestSeedPhrase(value);
+
+    currentValue[index] = value;
+
+    if (!value && index === currentValue.length - 2) {
+      currentValue.splice(currentValue.length - 2, 1);
+    } else if (
+      index + 1 === currentValue.length &&
+      index + 1 < SEED_PHRASE_LENGTH
+    ) {
+      currentValue.push("");
+    }
+
+    setSeedPhrase(currentValue);
+
+    return currentValue;
+  };
+
+  const addSeedPhraseSelected = (word: string) => {
+    if (lastFocusIndex.current === null) return;
+
+    const newValue = handleUpdateSeedPhrase(word, lastFocusIndex.current);
+    setSuggestSeedPhrase([]);
+    clearErrorIndex(lastFocusIndex.current);
+
+    if (
+      lastFocusIndex.current !== SEED_PHRASE_LENGTH - 1 &&
+      filledSeedPhrase.length !== SEED_PHRASE_LENGTH
+    ) {
+      seedPhraseRef.current?.focusInputByIndex(newValue.length - 1);
+    }
+  };
+
+  const handleContinue = async () => {
+    try {
+      const seedPhraseText = seedPhrase.join(" ");
+      const verifyResult = await Agent.agent.isMnemonicValid(seedPhraseText);
+
+      if (!verifyResult) {
+        throw new Error(INVALID_SEED_PHRASE);
+      }
+
+      dispatch(
+        setSeedPhraseCache({
+          seedPhrase: seedPhraseText,
+          bran: "",
+        })
+      );
+      handleNavigate();
+    } catch (e) {
+      setFailAttempt((value) => value + 1);
+
+      if (failAttempt + 1 >= MAX_ATTEMPT_FAIL) {
+        const now = new Date();
+        SecureStorage.set(
+          KeyStoreKeys.RECOVERY_WALLET_LAST_FAIL_ATTEMPT_TIME,
+          String(now.getTime())
+        );
+        setLastLockTime(now);
+        setAlertManyAttempOpen(true);
+        setLockFailAttempt(true);
+      } else {
+        setAlertIsOpen(true);
+      }
+    }
+  };
+
+  const handleNavigate = () => {
+    const data: DataProps = {
+      store: { stateCache },
+      state: {
+        currentOperation: stateCache.currentOperation,
+      },
+    };
+
+    const { nextPath, updateRedux } = getNextRoute(
+      RoutePath.VERIFY_RECOVERY_SEED_PHRASE,
+      data
+    );
+
+    updateReduxState(nextPath.pathname, data, dispatch, updateRedux);
+    handleClearState();
+
+    ionRouter.push(nextPath.pathname, "root", "replace");
+  };
+
+  const handleBack = () => {
+    handleClearState();
+    const { backPath, updateRedux } = getBackRoute(
+      RoutePath.VERIFY_SEED_PHRASE,
+      {
+        store: { stateCache },
+      }
+    );
+    updateReduxState(
+      backPath.pathname,
+      { store: { stateCache } },
+      dispatch,
+      updateRedux
+    );
+    history.push({
+      pathname: backPath.pathname,
+    });
+  };
+
+  const closeFailAlert = () => {
+    setAlertIsOpen(false);
+  };
+
+  const closeClearAlert = () => {
+    setClearAlertOpen(false);
+  };
+
+  const onFocusInput = (index: number) => {
+    lastFocusIndex.current = index;
+    const word = seedPhrase[index];
+    renderSuggestSeedPhrase(word);
+  };
+
+  const checkMatchWithSuggestion = (selectWord: string | undefined) => {
+    return SELECT_WORD_LIST.some(
+      (word) => selectWord?.toLowerCase().trim() === word
+    );
+  };
+
+  const validateOnBlur = (selectWord: string | undefined, index: number) => {
+    if (index === seedPhrase.length - 1 && !selectWord) return;
+
+    if (checkMatchWithSuggestion(selectWord)) {
+      setErrorInputIndex((errorIndexs) =>
+        errorIndexs.filter((errorIndex) => index !== errorIndex)
+      );
+    } else {
+      setErrorInputIndex((errorIndexs) => [...errorIndexs, index]);
+    }
+  };
+
+  const onBlurInput = (index: number) => {
+    const word = seedPhrase[index];
+    validateOnBlur(word, index);
+    setSuggestSeedPhrase([]);
+  };
+
+  const verifyButtonLabel = `${i18n.t(
+    lockFailAttempt
+      ? "verifyrecoveryseedphrase.button.lock"
+      : "verifyrecoveryseedphrase.button.continue"
+  )}`;
+
+  const displaySuggestionError = errorInputIndex.length > 0;
+  const filledSeedPhrase = seedPhrase.filter((item) => !!item);
+  const isMatchAllSuggestion = filledSeedPhrase.every((seedPhrase) =>
+    checkMatchWithSuggestion(seedPhrase)
+  );
+
+  return (
+    <>
+      <ScrollablePageLayout
+        pageId={pageId}
+        header={
+          <PageHeader
+            backButton={true}
+            onBack={() => {
+              handleClearState();
+              handleBack();
+            }}
+            currentPath={RoutePath.VERIFY_SEED_PHRASE}
+            progressBar={true}
+            progressBarValue={0.75}
+            progressBarBuffer={1}
+          />
+        }
+      >
+        <div className="content-container">
+          <div className="page-content">
+            <h2 data-testid={`${pageId}-title`}>
+              {i18n.t("verifyrecoveryseedphrase.title")}
+            </h2>
+            <p
+              className="paragraph-top"
+              data-testid={`${pageId}-paragraph-top`}
+            >
+              {i18n.t("verifyrecoveryseedphrase.paragraph.top")}
+            </p>
+            <SeedPhraseModule
+              testId="user-input-seed-phrase-container"
+              seedPhrase={seedPhrase}
+              inputMode
+              onInputChange={handleUpdateSeedPhrase}
+              onInputFocus={onFocusInput}
+              onInputBlur={onBlurInput}
+              ref={seedPhraseRef}
+              errorInputIndexs={errorInputIndex}
+            />
+            {(suggestSeedPhrase.length > 0 || displaySuggestionError) && (
+              <h3 className="suggestion-title">
+                {i18n.t("verifyrecoveryseedphrase.suggestions.title")}
+              </h3>
+            )}
+            {suggestSeedPhrase.length > 0 && (
+              <SeedPhraseModule
+                testId="suggestion-seed-phrase-container"
+                seedPhrase={suggestSeedPhrase}
+                addSeedPhraseSelected={addSeedPhraseSelected}
+                hideSeedNumber
+              />
+            )}
+            {displaySuggestionError && (
+              <p
+                className="suggest-error"
+                data-testid="no-suggest-error"
+              >
+                {i18n.t("verifyrecoveryseedphrase.suggestions.error")}
+              </p>
+            )}
+            {seedPhrase.filter((item) => !!item).length > 0 && (
+              <IonButton
+                onClick={() => setClearAlertOpen(true)}
+                fill="outline"
+                data-testid="verify-clear-button"
+                className="clear-button secondary-button"
+              >
+                <IonIcon
+                  slot="start"
+                  icon={closeOutline}
+                />
+                {i18n.t("verifyrecoveryseedphrase.button.clear")}
+              </IonButton>
+            )}
+          </div>
+          <PageFooter
+            pageId={pageId}
+            primaryButtonText={verifyButtonLabel}
+            primaryButtonAction={() => handleContinue()}
+            primaryButtonDisabled={
+              filledSeedPhrase.length < SEED_PHRASE_LENGTH ||
+              lockFailAttempt ||
+              displaySuggestionError ||
+              !isMatchAllSuggestion
+            }
+          />
+        </div>
+      </ScrollablePageLayout>
+      <AlertFail
+        isOpen={alertIsOpen}
+        setIsOpen={setAlertIsOpen}
+        dataTestId="alert-fail"
+        headerText={i18n.t("verifyrecoveryseedphrase.alert.fail.text")}
+        confirmButtonText={`${i18n.t(
+          "verifyrecoveryseedphrase.alert.fail.button.confirm"
+        )}`}
+        actionConfirm={closeFailAlert}
+      />
+      <AlertFail
+        isOpen={clearAlertOpen}
+        setIsOpen={setClearAlertOpen}
+        dataTestId="alert-fail"
+        headerText={i18n.t("verifyrecoveryseedphrase.alert.clear.text")}
+        confirmButtonText={`${i18n.t(
+          "verifyrecoveryseedphrase.alert.clear.button.confirm"
+        )}`}
+        cancelButtonText={`${i18n.t(
+          "verifyrecoveryseedphrase.alert.clear.button.cancel"
+        )}`}
+        actionConfirm={handleClearState}
+        actionCancel={closeClearAlert}
+        actionDismiss={closeClearAlert}
+      />
+      <AlertFail
+        isOpen={alertManyAttempOpen}
+        setIsOpen={setAlertManyAttempOpen}
+        dataTestId="alert-fail"
+        headerText={i18n.t("verifyrecoveryseedphrase.alert.manyattemp.text")}
+        confirmButtonText={`${i18n.t(
+          "verifyrecoveryseedphrase.alert.manyattemp.button.confirm"
+        )}`}
+        actionConfirm={handleClearState}
+        actionCancel={closeClearAlert}
+        actionDismiss={closeClearAlert}
+      />
+    </>
+  );
+};
+
+export { VerifyRecoverySeedPhrase };

--- a/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.types.ts
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/VerifyRecoverySeedPhrase.types.ts
@@ -1,0 +1,6 @@
+interface SeedPhraseInfo {
+  value: string;
+  suggestions: string[];
+}
+
+export type { SeedPhraseInfo };

--- a/src/ui/pages/VerifyRecoverySeedPhrase/index.ts
+++ b/src/ui/pages/VerifyRecoverySeedPhrase/index.ts
@@ -1,0 +1,1 @@
+export * from "./VerifyRecoverySeedPhrase";

--- a/src/ui/pages/VerifySeedPhrase/VerifySeedPhrase.test.tsx
+++ b/src/ui/pages/VerifySeedPhrase/VerifySeedPhrase.test.tsx
@@ -298,7 +298,7 @@ describe("Verify Seed Phrase Page", () => {
       fireEvent.click(backButton);
     });
 
-    expect(continueButton.disabled).toBe(true);
+    expect(dispatchMock).toBeCalledTimes(2);
   });
 
   test("The user can remove words from the Seed Phrase", async () => {


### PR DESCRIPTION
## Description

Implement recovery wallet flow when user click on `I already have a wallet` button.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-898](https://cardanofoundation.atlassian.net/browse/DTIS-898)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/ce9a1452-cdcb-45f1-9aec-d2dc4ee3b7bd

#### Android

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/dba74a4e-cc77-4e97-b1b3-e1f7193e3fad

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/e1e7975b-7006-469d-b10f-7900b0a5a850

#### Verify Seed Phrase Fail

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/3eec4c0d-8754-4d79-a7cf-0625487b58c2






[DTIS-898]: https://cardanofoundation.atlassian.net/browse/DTIS-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ