### PR TITLE
End of sprint fixes

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-clipboard')
     implementation project(':capacitor-keyboard')
+    implementation project(':capacitor-preferences')
     implementation project(':capacitor-screen-orientation')
     implementation project(':capacitor-share')
     implementation project(':capacitor-splash-screen')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -23,6 +23,9 @@ project(':capacitor-clipboard').projectDir = new File('../node_modules/@capacito
 include ':capacitor-keyboard'
 project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
 
+include ':capacitor-preferences'
+project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')
+
 include ':capacitor-screen-orientation'
 project(':capacitor-screen-orientation').projectDir = new File('../node_modules/@capacitor/screen-orientation/android')
 

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -18,6 +18,7 @@ def capacitor_pods
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorClipboard', :path => '../../node_modules/@capacitor/clipboard'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
+  pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'
   pod 'CapacitorScreenOrientation', :path => '../../node_modules/@capacitor/screen-orientation'
   pod 'CapacitorShare', :path => '../../node_modules/@capacitor/share'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -21,6 +21,8 @@ PODS:
     - Capacitor
   - CapacitorNativeSettings (5.0.1):
     - Capacitor
+  - CapacitorPreferences (5.0.8):
+    - Capacitor
   - CapacitorScreenOrientation (5.0.7):
     - Capacitor
   - CapacitorShare (5.0.7):
@@ -48,6 +50,7 @@ DEPENDENCIES:
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - CapacitorNativeSettings (from `../../node_modules/capacitor-native-settings`)
+  - "CapacitorPreferences (from `../../node_modules/@capacitor/preferences`)"
   - "CapacitorScreenOrientation (from `../../node_modules/@capacitor/screen-orientation`)"
   - "CapacitorShare (from `../../node_modules/@capacitor/share`)"
   - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
@@ -80,6 +83,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/keyboard"
   CapacitorNativeSettings:
     :path: "../../node_modules/capacitor-native-settings"
+  CapacitorPreferences:
+    :path: "../../node_modules/@capacitor/preferences"
   CapacitorScreenOrientation:
     :path: "../../node_modules/@capacitor/screen-orientation"
   CapacitorShare:
@@ -100,6 +105,7 @@ SPEC CHECKSUMS:
   CapacitorCordova: a6e87fccc0307dee7aec1560ec9398485f2b0ce7
   CapacitorKeyboard: aec619a578235c6ce279075009a2689c2cf5c42c
   CapacitorNativeSettings: 6e94ed3c0465206756f320df18efc52f053ce3c7
+  CapacitorPreferences: 9e59596c5fd9915ed45279d1fda68978c5706401
   CapacitorScreenOrientation: cc638c369cb2b1dfc55f8265485a8b4e0b3cafd9
   CapacitorShare: c6a1ebbf0114ff9e863b966cd6052678fa25d480
   CapacitorSplashScreen: dd3de3f3644710fa2a697cfb91ec262eece4d242
@@ -108,6 +114,6 @@ SPEC CHECKSUMS:
   SQLCipher: f2e96b3822e3006b379181a0e4fd145f6de29b56
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 227349d5dcfc878b902c4a3bda2c6e701c6df134
+PODFILE CHECKSUM: f17d8c92af7514371ab66701e64dde4c13796c54
 
 COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@capacitor/core": "^5.0.0",
         "@capacitor/ios": "^5.0.0",
         "@capacitor/keyboard": "^5.0.0",
+        "@capacitor/preferences": "^5.0.0",
         "@capacitor/screen-orientation": "^5.0.7",
         "@capacitor/share": "^5.0.0",
         "@capacitor/splash-screen": "^5.0.0",
@@ -2537,6 +2538,14 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-5.0.8.tgz",
       "integrity": "sha512-XYyBzGlzjgLPqyPVdu5McGLYV6+G2efVR4I3l5cF1B27M6U/oFqv9CQU74WNG08nee28bfccboNpv6eWCLYn1A==",
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-5.0.8.tgz",
+      "integrity": "sha512-zzz8JC2NuZ+xdBP2Cfhu4uyRUMAFoxMl7l8w5ahQPzckyt7Fk/pWATXj6IcTm7DzbsKc8ryXSsYTkv9ZL3Pfmw==",
       "peerDependencies": {
         "@capacitor/core": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@capacitor/core": "^5.0.0",
     "@capacitor/ios": "^5.0.0",
     "@capacitor/keyboard": "^5.0.0",
+    "@capacitor/preferences": "^5.0.0",
     "@capacitor/screen-orientation": "^5.0.7",
     "@capacitor/share": "^5.0.0",
     "@capacitor/splash-screen": "^5.0.0",

--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -5,7 +5,6 @@ import {
   ready as signifyReady,
   Tier,
 } from "signify-ts";
-import { DataType } from "@aparajita/capacitor-secure-storage";
 import { entropyToMnemonic, mnemonicToEntropy } from "bip39";
 import {
   ConnectionService,
@@ -46,7 +45,6 @@ import { IonicSession } from "../storage/ionicStorage/ionicSession";
 import { IonicStorage } from "../storage/ionicStorage";
 import { SqliteStorage } from "../storage/sqliteStorage";
 import { BaseRecord } from "../storage/storage.types";
-import { ConfigurationService } from "../configuration";
 import { OperationPendingStorage } from "./records/operationPendingStorage";
 import { OperationPendingRecord } from "./records/operationPendingRecord";
 
@@ -60,6 +58,7 @@ class Agent {
   static readonly KERIA_NOT_BOOTED =
     "Agent has not been booted for a given Signify passcode";
   static readonly INVALID_MNEMONIC = "Seed phrase is invalid";
+
   private static instance: Agent;
   private agentServicesProps: AgentServicesProps = {
     eventService: undefined as any,
@@ -243,6 +242,7 @@ class Agent {
       this.markAgentOnline();
     }
   }
+
   async recoverKeriaAgent(
     seedPhrase: string[],
     connectUrl: string

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -180,15 +180,17 @@ class IdentifierService extends AgentService {
     const metadata = await this.identifierStorage.getIdentifierMetadata(
       identifier
     );
-    const connectedDApp =
-      PeerConnection.peerConnection.getConnectedDAppAddress();
-    const peerConnectingIdentifier =
-      await PeerConnection.peerConnection.getConnectingIdentifier();
     this.validArchivedIdentifier(metadata);
     await this.identifierStorage.updateIdentifierMetadata(identifier, {
       isDeleted: true,
     });
-    if (connectedDApp !== "" && metadata.id === peerConnectingIdentifier.id) {
+    const connectedDApp =
+      PeerConnection.peerConnection.getConnectedDAppAddress();
+    if (
+      connectedDApp !== "" &&
+      metadata.id ===
+        (await PeerConnection.peerConnection.getConnectingIdentifier()).id
+    ) {
       PeerConnection.peerConnection.disconnectDApp(connectedDApp, true);
     }
   }

--- a/src/core/cardano/walletConnect/peerConnection.ts
+++ b/src/core/cardano/walletConnect/peerConnection.ts
@@ -38,7 +38,7 @@ class PeerConnection {
   ];
 
   private identityWalletConnect: IdentityWalletConnect | undefined;
-  private connectedDAppAdress = "";
+  private connectedDAppAddress = "";
   private eventService = new EventService();
   private static instance: PeerConnection;
 
@@ -103,9 +103,9 @@ class PeerConnection {
     }
     if (
       this.identityWalletConnect &&
-      this.connectedDAppAdress.trim().length !== 0
+      this.connectedDAppAddress.trim().length !== 0
     ) {
-      this.disconnectDApp(this.connectedDAppAdress);
+      this.disconnectDApp(this.connectedDAppAddress);
     }
     this.identityWalletConnect = new IdentityWalletConnect(
       this.walletInfo,
@@ -118,7 +118,7 @@ class PeerConnection {
       async (connectMessage: IConnectMessage) => {
         if (!connectMessage.error) {
           const { name, url, address, icon } = connectMessage.dApp;
-          this.connectedDAppAdress = address;
+          this.connectedDAppAddress = address;
           let iconB64;
           // Check if the icon is base64
           if (
@@ -151,7 +151,7 @@ class PeerConnection {
 
     this.identityWalletConnect.setOnDisconnect(
       (disConnectMessage: IConnectMessage) => {
-        this.connectedDAppAdress = "";
+        this.connectedDAppAddress = "";
         this.eventService.emit<PeerDisconnectedEvent>({
           type: PeerConnectionEventTypes.PeerDisconnected,
           payload: {
@@ -217,7 +217,7 @@ class PeerConnection {
   }
 
   getConnectedDAppAddress() {
-    return this.connectedDAppAdress;
+    return this.connectedDAppAddress;
   }
 
   async getConnectingIdentifier() {

--- a/src/core/storage/preferences/preferencesStorage.ts
+++ b/src/core/storage/preferences/preferencesStorage.ts
@@ -1,0 +1,38 @@
+import { Preferences } from "@capacitor/preferences";
+import {
+  RemoveOptions,
+  SetOptions,
+} from "@capacitor/preferences/dist/esm/definitions";
+import { PreferencesStorageItem } from "./preferencesStorage.types";
+
+enum PreferencesKeys {
+  APP_ALREADY_INIT = "app-already-init",
+}
+
+class PreferencesStorage {
+  static readonly KEY_NOT_FOUND =
+    "Preferences Storage does not contain an item with specified key";
+  static readonly INVALID_OBJECT = "Object format cannot be parsed";
+
+  static async get(key: string): Promise<PreferencesStorageItem> {
+    const item = await Preferences.get({ key });
+    if (!item || !item?.value) {
+      throw new Error(`${PreferencesStorage.KEY_NOT_FOUND} ${key}`);
+    }
+    return JSON.parse(item.value);
+  }
+
+  static async set(key: string, obj: PreferencesStorageItem): Promise<void> {
+    const objStr: string = JSON.stringify(obj);
+    await Preferences.set({
+      key,
+      value: objStr,
+    } as SetOptions);
+  }
+
+  static async remove(key: string): Promise<void> {
+    await Preferences.remove({ key } as RemoveOptions);
+  }
+}
+
+export { PreferencesStorage, PreferencesKeys };

--- a/src/core/storage/preferences/preferencesStorage.types.ts
+++ b/src/core/storage/preferences/preferencesStorage.types.ts
@@ -1,0 +1,5 @@
+interface PreferencesStorageItem {
+  [key: string]: string | number | boolean | Array<any>;
+}
+
+export type { PreferencesStorageItem };

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -62,6 +62,10 @@ import { setCredsArchivedCache } from "../../../store/reducers/credsArchivedCach
 import { OperationPendingRecordType } from "../../../core/agent/records/operationPendingRecord.type";
 import { i18n } from "../../../i18n";
 import { Alert } from "../Alert";
+import {
+  PreferencesKeys,
+  PreferencesStorage,
+} from "../../../core/storage/preferences/preferencesStorage";
 
 const connectionStateChangedHandler = async (
   event: ConnectionStateChangedEvent,
@@ -379,10 +383,11 @@ const AppWrapper = (props: { children: ReactNode }) => {
     await Agent.agent.initDatabaseConnection();
     // @TODO - foconnor: This is a temp hack for development to be removed pre-release.
     // These items are removed from the secure storage on re-install to re-test the on-boarding for iOS devices.
-    const appAlreadyInit = await Agent.agent.basicStorage.findById(
-      MiscRecordId.APP_ALREADY_INIT
-    );
-    if (!appAlreadyInit) {
+    try {
+      // @TODO - foconnor: This should use our normal DB - keeping Preferences temporarily to not break existing mobile builds.
+      // Will remove preferences again once we have better handling on APP_ALREADY_INIT with user input.
+      await PreferencesStorage.get(PreferencesKeys.APP_ALREADY_INIT);
+    } catch (e) {
       await SecureStorage.delete(KeyStoreKeys.APP_PASSCODE);
       await SecureStorage.delete(KeyStoreKeys.APP_OP_PASSWORD);
       await SecureStorage.delete(KeyStoreKeys.SIGNIFY_BRAN);

--- a/src/ui/pages/SetPasscode/SetPasscode.test.tsx
+++ b/src/ui/pages/SetPasscode/SetPasscode.test.tsx
@@ -24,8 +24,15 @@ import { store } from "../../../store";
 import { RoutePath } from "../../../routes";
 import { MiscRecordId } from "../../../core/agent/agent.types";
 import { Agent } from "../../../core/agent/agent";
+import {
+  PreferencesKeys,
+  PreferencesStorage,
+} from "../../../core/storage/preferences/preferencesStorage";
 
 const setKeyStoreSpy = jest.spyOn(SecureStorage, "set").mockResolvedValue();
+const setPreferenceStorageSpy = jest
+  .spyOn(PreferencesStorage, "set")
+  .mockResolvedValue();
 
 jest.mock("../../../core/agent/agent", () => ({
   Agent: {
@@ -343,13 +350,11 @@ describe("SetPasscode Page", () => {
     });
 
     expect(setKeyStoreSpy).toBeCalledWith(KeyStoreKeys.APP_PASSCODE, "111111");
-    expect(Agent.agent.basicStorage.createOrUpdateBasicRecord).toBeCalledWith(
-      expect.objectContaining({
-        id: MiscRecordId.APP_ALREADY_INIT,
-        content: {
-          initialized: true,
-        },
-      })
+    expect(setPreferenceStorageSpy).toBeCalledWith(
+      PreferencesKeys.APP_ALREADY_INIT,
+      {
+        initialized: true,
+      }
     );
   });
 
@@ -461,13 +466,11 @@ describe("SetPasscode Page", () => {
     await waitFor(() =>
       expect(setKeyStoreSpy).toBeCalledWith(KeyStoreKeys.APP_PASSCODE, "111111")
     );
-    expect(Agent.agent.basicStorage.createOrUpdateBasicRecord).toBeCalledWith(
-      expect.objectContaining({
-        id: MiscRecordId.APP_ALREADY_INIT,
-        content: {
-          initialized: true,
-        },
-      })
+    expect(setPreferenceStorageSpy).toBeCalledWith(
+      PreferencesKeys.APP_ALREADY_INIT,
+      {
+        initialized: true,
+      }
     );
   });
 

--- a/src/ui/pages/SetPasscode/SetPasscode.tsx
+++ b/src/ui/pages/SetPasscode/SetPasscode.tsx
@@ -3,11 +3,7 @@ import { i18n } from "../../../i18n";
 import { ErrorMessage } from "../../components/ErrorMessage";
 import { SecureStorage, KeyStoreKeys } from "../../../core/storage";
 import { PasscodeModule } from "../../components/PasscodeModule";
-import {
-  getStateCache,
-  setInitialized,
-  setToastMsg,
-} from "../../../store/reducers/stateCache";
+import { getStateCache, setToastMsg } from "../../../store/reducers/stateCache";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import { getNextRoute } from "../../../routes/nextRoute";
 import { updateReduxState } from "../../../store/utils";
@@ -28,6 +24,10 @@ import { MiscRecordId } from "../../../core/agent/agent.types";
 import { BasicRecord } from "../../../core/agent/records";
 import { setEnableBiometryCache } from "../../../store/reducers/biometryCache";
 import { ToastMsgType } from "../../globals/types";
+import {
+  PreferencesKeys,
+  PreferencesStorage,
+} from "../../../core/storage/preferences/preferencesStorage";
 
 const SetPasscode = () => {
   const pageId = "set-passcode";
@@ -114,12 +114,9 @@ const SetPasscode = () => {
     ionRouter.push(nextPath.pathname, "forward", "push");
     handleClearState();
 
-    await Agent.agent.basicStorage.createOrUpdateBasicRecord(
-      new BasicRecord({
-        id: MiscRecordId.APP_ALREADY_INIT,
-        content: { initialized: true },
-      })
-    );
+    await PreferencesStorage.set(PreferencesKeys.APP_ALREADY_INIT, {
+      initialized: true,
+    });
   };
 
   const handleSetupAndroidBiometry = async () => {


### PR DESCRIPTION
- Re-introduce preferences storage until we properly handle `APP_ALREADY_INIT` flag. Otherwise we break some existing deployments.
- Fix on identifier deletion to not require peer connect to be activated.