### PR TITLE
ci(gha): stop docker builds on every push

### DIFF
--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -1,12 +1,6 @@
 name: Build and publish docker artifacts
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    types: [ opened, synchronize ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Not required to be pushed so often, and right now not directly used.