### PR TITLE
fix(ui): The URL should not affect the onboarding flows initial page after app restart

### DIFF
--- a/src/core/storage/secureStorage/secureStorage.ts
+++ b/src/core/storage/secureStorage/secureStorage.ts
@@ -6,6 +6,7 @@ import {
 enum KeyStoreKeys {
   APP_PASSCODE = "app-login-passcode",
   APP_OP_PASSWORD = "app-operations-password",
+  APP_PASSWORD_SKIPPED = "app-password-skipped",
   SIGNIFY_BRAN = "signify-bran",
   MEERKAT_SEED = "app-meerkat-seed",
 }

--- a/src/routes/backRoute/backRoute.test.ts
+++ b/src/routes/backRoute/backRoute.test.ts
@@ -87,7 +87,7 @@ describe("getBackRoute", () => {
     const result = getBackRoute(currentPath, data);
 
     expect(result.backPath).toEqual({ pathname: "/route2" });
-    expect(result.updateRedux).toEqual([]);
+    expect(result.updateRedux).toHaveLength(1);
   });
 
   test("should return the correct back path when currentPath is /generateseedphrase", () => {
@@ -99,7 +99,7 @@ describe("getBackRoute", () => {
     const result = getBackRoute(currentPath, data);
 
     expect(result.backPath).toEqual({ pathname: "/route2" });
-    expect(result.updateRedux).toHaveLength(3);
+    expect(result.updateRedux).toHaveLength(4);
   });
 
   test("should return the correct back path when currentPath is /verifyseedphrase", () => {
@@ -111,7 +111,7 @@ describe("getBackRoute", () => {
     const result = getBackRoute(currentPath, data);
 
     expect(result.backPath).toEqual({ pathname: "/route2" });
-    expect(result.updateRedux).toHaveLength(2);
+    expect(result.updateRedux).toHaveLength(3);
   });
 
   test("should return the correct back path when currentPath is /setpasscode", () => {
@@ -123,7 +123,7 @@ describe("getBackRoute", () => {
     const result = getBackRoute(currentPath, data);
 
     expect(result.backPath).toEqual({ pathname: "/route2" });
-    expect(result.updateRedux).toHaveLength(2);
+    expect(result.updateRedux).toHaveLength(3);
   });
 });
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -32,7 +32,7 @@ const Routes = () => {
 
   useEffect(() => {
     if (!routes.length) dispatch(setCurrentRoute({ path: nextPath.pathname }));
-  });
+  }, [routes, nextPath.pathname]);
 
   return (
     <IonReactRouter>
@@ -110,10 +110,14 @@ const Routes = () => {
           component={CredentialDetails}
           exact
         />
-        <Redirect
-          exact
-          from="/"
-          to={nextPath}
+        <Route
+          render={() => (
+            <Redirect
+              exact
+              from="/"
+              to={nextPath}
+            />
+          )}
         />
       </IonRouterOutlet>
     </IonReactRouter>

--- a/src/routes/nextRoute/nextRoute.test.ts
+++ b/src/routes/nextRoute/nextRoute.test.ts
@@ -31,7 +31,7 @@ describe("NextRoute", () => {
           passcodeIsSet: false,
           seedPhraseIsSet: false,
           passwordIsSet: false,
-          passwordIsSkipped: true,
+          passwordIsSkipped: false,
           ssiAgentIsSet: false,
         },
         currentOperation: OperationType.IDLE,
@@ -105,6 +105,108 @@ describe("NextRoute", () => {
     });
   });
 
+  test("should return correct route for /onboarding when passwordIsSet is true", () => {
+    data = {
+      store: {
+        ...storeMock,
+        stateCache: {
+          initialized: true,
+          routes: [],
+          authentication: {
+            loggedIn: false,
+            userName: "",
+            time: 0,
+            passcodeIsSet: true,
+            seedPhraseIsSet: false,
+            passwordIsSet: true,
+            passwordIsSkipped: false,
+            ssiAgentIsSet: false,
+          },
+          currentOperation: OperationType.IDLE,
+          queueIncomingRequest: {
+            isProcessing: false,
+            queues: [],
+            isPaused: false,
+          },
+        },
+      },
+    };
+
+    const result = getNextOnboardingRoute(data as DataProps);
+
+    expect(result).toEqual({
+      pathname: RoutePath.GENERATE_SEED_PHRASE,
+    });
+  });
+
+  test("should return correct route for /onboarding when ssiAgentIsSet is true", () => {
+    data = {
+      store: {
+        ...storeMock,
+        stateCache: {
+          initialized: true,
+          routes: [],
+          authentication: {
+            loggedIn: false,
+            userName: "",
+            time: 0,
+            passcodeIsSet: true,
+            seedPhraseIsSet: false,
+            passwordIsSet: true,
+            passwordIsSkipped: false,
+            ssiAgentIsSet: true,
+          },
+          currentOperation: OperationType.IDLE,
+          queueIncomingRequest: {
+            isProcessing: false,
+            queues: [],
+            isPaused: false,
+          },
+        },
+      },
+    };
+
+    const result = getNextOnboardingRoute(data as DataProps);
+
+    expect(result).toEqual({
+      pathname: RoutePath.TABS_MENU,
+    });
+  });
+
+  test("should return correct route for /onboarding seedPhraseIsSet is true", () => {
+    data = {
+      store: {
+        ...storeMock,
+        stateCache: {
+          initialized: true,
+          routes: [],
+          authentication: {
+            loggedIn: false,
+            userName: "",
+            time: 0,
+            passcodeIsSet: true,
+            seedPhraseIsSet: true,
+            passwordIsSet: true,
+            passwordIsSkipped: false,
+            ssiAgentIsSet: false,
+          },
+          currentOperation: OperationType.IDLE,
+          queueIncomingRequest: {
+            isProcessing: false,
+            queues: [],
+            isPaused: false,
+          },
+        },
+      },
+    };
+
+    const result = getNextOnboardingRoute(data as DataProps);
+
+    expect(result).toEqual({
+      pathname: RoutePath.SSI_AGENT,
+    });
+  });
+
   test("should return correct route for /setpasscode when seedPhrase is not set", () => {
     localStorageMock.getItem = jest.fn().mockReturnValue("someSeedPhrase");
 
@@ -165,7 +267,7 @@ describe("getNextRoute", () => {
         passcodeIsSet: true,
         seedPhraseIsSet: false,
         passwordIsSet: false,
-        passwordIsSkipped: true,
+        passwordIsSkipped: false,
         ssiAgentIsSet: false,
       },
       currentOperation: OperationType.IDLE,

--- a/src/store/reducers/stateCache/stateCache.ts
+++ b/src/store/reducers/stateCache/stateCache.ts
@@ -19,7 +19,7 @@ const initialState: StateCacheProps = {
     passcodeIsSet: false,
     seedPhraseIsSet: false,
     passwordIsSet: false,
-    passwordIsSkipped: true,
+    passwordIsSkipped: false,
     ssiAgentIsSet: false,
   },
   currentOperation: OperationType.IDLE,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -127,9 +127,7 @@ const App = () => {
     );
   };
 
-  const isPublicPage = PublicRoutes.includes(
-    window.location.pathname as RoutePath
-  );
+  const isPublicPage = PublicRoutes.includes(currentRoute?.path as RoutePath);
 
   return (
     <IonApp>

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -317,6 +317,9 @@ const AppWrapper = (props: { children: ReactNode }) => {
     let userName: { userName: string } = { userName: "" };
     const passcodeIsSet = await checkKeyStore(KeyStoreKeys.APP_PASSCODE);
     const seedPhraseIsSet = await checkKeyStore(KeyStoreKeys.SIGNIFY_BRAN);
+    const passwordIsSkipped = await checkKeyStore(
+      KeyStoreKeys.APP_PASSWORD_SKIPPED
+    );
 
     const passwordIsSet = await checkKeyStore(KeyStoreKeys.APP_OP_PASSWORD);
     const keriaConnectUrlRecord = await Agent.agent.basicStorage.findById(
@@ -380,6 +383,7 @@ const AppWrapper = (props: { children: ReactNode }) => {
         passcodeIsSet,
         seedPhraseIsSet,
         passwordIsSet,
+        passwordIsSkipped,
         ssiAgentIsSet:
           !!keriaConnectUrlRecord && !!keriaConnectUrlRecord.content.url,
       })

--- a/src/ui/components/navigation/TabsMenu/TabsMenu.tsx
+++ b/src/ui/components/navigation/TabsMenu/TabsMenu.tsx
@@ -19,18 +19,24 @@ import {
   apps,
   appsOutline,
 } from "ionicons/icons";
-import { ComponentType } from "react";
+import { ComponentType, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { i18n } from "../../../../i18n";
 import "./TabsMenu.scss";
-import { TabsRoutePath } from "../../../../routes/paths";
+import { RoutePath, TabsRoutePath } from "../../../../routes/paths";
 import { Identifiers } from "../../../pages/Identifiers";
 import { Creds } from "../../../pages/Credentials";
 import { Scan } from "../../../pages/Scan";
 import { Chat } from "../../../pages/Chat";
 import { Menu } from "../../../pages/Menu";
-import { useAppDispatch } from "../../../../store/hooks";
-import { setCurrentRoute } from "../../../../store/reducers/stateCache";
+import { useAppDispatch, useAppSelector } from "../../../../store/hooks";
+import {
+  getStateCache,
+  removeCurrentRoute,
+  setCurrentRoute,
+} from "../../../../store/reducers/stateCache";
+import { getNextRootRoute } from "../../../../routes/nextRoute";
+import { useAppIonRouter } from "../../../hooks";
 
 const tabsRoutes = [
   {
@@ -65,12 +71,19 @@ const tabsRoutes = [
   },
 ];
 const TabsMenu = ({ tab, path }: { tab: ComponentType; path: string }) => {
+  const stateCache = useAppSelector(getStateCache);
   const location = useLocation();
   const dispatch = useAppDispatch();
 
   const handleTabClick = (tabPath: string) => {
     dispatch(setCurrentRoute({ path: tabPath }));
   };
+
+  const exactPath = getNextRootRoute({ store: { stateCache: stateCache } });
+
+  if (exactPath.pathname !== RoutePath.TABS_MENU) {
+    return <Redirect to={exactPath.pathname} />;
+  }
 
   return (
     <IonTabs>

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
@@ -36,6 +36,7 @@ jest.mock("../../../core/agent/agent", () => ({
 jest.mock("@aparajita/capacitor-secure-storage", () => ({
   SecureStorage: {
     get: jest.fn(),
+    remove: jest.fn(),
   },
 }));
 

--- a/src/ui/pages/CreatePassword/CreatePassword.tsx
+++ b/src/ui/pages/CreatePassword/CreatePassword.tsx
@@ -72,6 +72,8 @@ const CreatePassword = () => {
           })
         );
       }
+    } else {
+      await SecureStorage.set(KeyStoreKeys.APP_PASSWORD_SKIPPED, String(true));
     }
 
     const { nextPath, updateRedux } = getNextRoute(RoutePath.CREATE_PASSWORD, {

--- a/src/ui/pages/VerifySeedPhrase/VerifySeedPhrase.test.tsx
+++ b/src/ui/pages/VerifySeedPhrase/VerifySeedPhrase.test.tsx
@@ -298,7 +298,7 @@ describe("Verify Seed Phrase Page", () => {
       fireEvent.click(backButton);
     });
 
-    expect(continueButton.disabled).toBe(true);
+    expect(dispatchMock).toBeCalledTimes(3);
   });
 
   test("The user can remove words from the Seed Phrase", async () => {


### PR DESCRIPTION
## Description

Fix the issue about display wrong screen after restart app on onboarding flow.
Beside that I also update logic of back button of onboarding flow, that I got from Robert: 

When in the onboarding flow and NOT having left the flow:
- Passcode - back to intro screens
- Passcode confirm - back to create passcode
- Password - back to create passcode
- Generate seed phrase - back to create password
- Verify seed phrase - back to generate seed phrase
- Enter SSI - back to generate seed phrase

When in the onboarding flow and having left the flow at various points:
- If the user leaves without having created a passcode they will land on the intro screens and will go through the flow as normal

- If the user leaves after having created a passcode they will need to enter their passcode to create a password - if they then click back from the password section they will see the intro screens
The rest of the back buttons after this would work the same as above if they continue through the flow

- If the user has entered their passcode and their password (or skipped this) when they re-enter the app they will need to enter their passcode. They will then see the generate seed phrase. If they click back here they will see the intro screens.
The rest of the back buttons after this would work the same as above if they continue through the flow

- If they user has entered their passcode, their password and had generated their seed phrase they will have to enter their passcode when entering the app and they will land on the generate seed phrase again as they have not verified this. Again clicking back will then result in landing on the intro screens
The rest of the back buttons after this would work the same as above if they continue through the flow

- If the user has entered their passcode, password and generated & verified their seed phrase, they will land on the SSI agent screen after confirming their pin. Clicking back here will go to the intro screens.

- If the user has entered the passcode, password, generated & verified their seed phrase and entered their SSI agent information they will land on the enter name screen after entering their passcode. There is no option to go back from here.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-962](https://cardanofoundation.atlassian.net/browse/DTIS-962)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/44567c42-ae07-400a-8333-9aeaba8ddad0

#### Android

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/9946b668-df48-4878-b7e1-fb9291ef31ae

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/4444e079-ec6b-4419-adda-c1a355e40e39



[DTIS-962]: https://cardanofoundation.atlassian.net/browse/DTIS-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ