### PR TITLE
feat(ui): Only show single sig identifiers in Cardano Connect

### DIFF
--- a/src/core/agent/services/identifier.types.ts
+++ b/src/core/agent/services/identifier.types.ts
@@ -20,6 +20,7 @@ interface IdentifierShortDetails {
   theme: number;
   isPending: boolean;
   groupMetadata?: GroupMetadata;
+  multisigManageAid?: string;
 }
 
 interface IdentifierDetails extends IdentifierShortDetails {

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -54,7 +54,7 @@ class IdentifierService extends AgentService {
 
     for (let i = 0; i < listMetadata.length; i++) {
       const metadata = listMetadata[i];
-      identifiers.push({
+      const identifier: IdentifierShortDetails = {
         displayName: metadata.displayName,
         id: metadata.id,
         signifyName: metadata.signifyName,
@@ -62,7 +62,11 @@ class IdentifierService extends AgentService {
         theme: metadata.theme,
         isPending: metadata.isPending ?? false,
         groupMetadata: metadata.groupMetadata,
-      });
+      };
+      if (metadata.multisigManageAid) {
+        identifier.multisigManageAid = metadata.multisigManageAid;
+      }
+      identifiers.push(identifier);
     }
     return identifiers;
   }

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -899,7 +899,7 @@
           "title": "Connections"
         },
         "connectwallet": {
-          "title": "Connect Wallet",
+          "title": "Cardano connect",
           "cip": "CIP-45",
           "tabheader": "Cardano Connect",
           "connectbtn": "Connect with Cardano",

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
@@ -37,14 +37,17 @@ const WalletConnectStageTwo = ({
 
   const [selectedIdentifier, setSelectedIdentifier] =
     useState<IdentifierShortDetails | null>(null);
-  const displayIdentifiers = identifierCache.map(
-    (identifier, index): CardItem<IdentifierShortDetails> => ({
-      id: index,
-      title: identifier.displayName,
-      image: KeriLogo,
-      data: identifier,
-    })
-  );
+
+  const displayIdentifiers = identifierCache
+    .filter((item) => !item.groupMetadata)
+    .map(
+      (identifier, index): CardItem<IdentifierShortDetails> => ({
+        id: index,
+        title: identifier.displayName,
+        image: KeriLogo,
+        data: identifier,
+      })
+    );
 
   const classes = combineClassNames("wallet-connect-stage-two", className, {
     show: !!isOpen,


### PR DESCRIPTION
## Description

Filter the list of identifiers to show only single signature identifier when connect dApp on Cardano Connect screen. This PR do not change UI, therefore I only capture on web browser.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-977](https://cardanofoundation.atlassian.net/browse/DTIS-977)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

#### Android

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/60bffb66-fc2a-43dd-a59f-2bfbba35452e



[DTIS-977]: https://cardanofoundation.atlassian.net/browse/DTIS-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ