### PR TITLE
fix(ui): UI: Jest: Test fails when placed at the bottom

### DIFF
--- a/src/ui/components/AppWrapper/hooks/useActivityTimer.tsx
+++ b/src/ui/components/AppWrapper/hooks/useActivityTimer.tsx
@@ -44,8 +44,8 @@ const useActivityTimer = () => {
       });
 
       return () => {
-        pauseListener.remove();
-        resumeListener.remove();
+        pauseListener.then((listener) => listener.remove());
+        resumeListener.then((listener) => listener.remove());
         clearTimer();
       };
     }

--- a/src/ui/components/VerifyPasscode/VerifyPasscode.test.tsx
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.test.tsx
@@ -65,59 +65,6 @@ describe("Verify Passcode on Cards Details page", () => {
     };
   });
 
-  test("It renders verify passcode when clicking on the big button", async () => {
-    jest
-      .spyOn(Agent.agent.credentials, "getCredentialDetailsById")
-      .mockResolvedValue(credsFixAcdc[0]);
-    const { findByTestId, getAllByText, getAllByTestId } = render(
-      <Provider store={storeMocked}>
-        <MemoryRouter initialEntries={[path]}>
-          <Route
-            path={path}
-            component={CredentialDetails}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const archiveButton = await findByTestId(
-      "archive-button-credential-card-details"
-    );
-    act(() => {
-      fireEvent.click(archiveButton);
-    });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(EN_TRANSLATIONS.credentials.details.alert.archive.title)[0]
-      ).toBeVisible();
-    });
-
-    await waitFor(() => {
-      expect(getAllByTestId("verify-passcode")[0]).toHaveAttribute(
-        "is-open",
-        "false"
-      );
-    });
-
-    act(() => {
-      fireEvent.click(
-        getAllByText(
-          EN_TRANSLATIONS.credentials.details.alert.archive.confirm
-        )[0]
-      );
-    });
-
-    await waitForIonicReact();
-
-    await waitFor(() => {
-      expect(getAllByTestId("verify-passcode")[0]).toHaveAttribute(
-        "is-open",
-        "true"
-      );
-    });
-  });
-
   test.skip("It asks to verify the passcode when users try to delete the cred using the button in the modal", async () => {
     const mockStore = configureStore();
     const dispatchMock = jest.fn();
@@ -183,6 +130,59 @@ describe("Verify Passcode on Cards Details page", () => {
 
     await waitFor(() => {
       expect(getByTestId("close-button-label")).toBeInTheDocument();
+    });
+  });
+
+  test("It renders verify passcode when clicking on the big button", async () => {
+    jest
+      .spyOn(Agent.agent.credentials, "getCredentialDetailsById")
+      .mockResolvedValue(credsFixAcdc[0]);
+    const { findByTestId, getAllByText, getAllByTestId } = render(
+      <Provider store={storeMocked}>
+        <MemoryRouter initialEntries={[path]}>
+          <Route
+            path={path}
+            component={CredentialDetails}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const archiveButton = await findByTestId(
+      "archive-button-credential-card-details"
+    );
+    act(() => {
+      fireEvent.click(archiveButton);
+    });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(EN_TRANSLATIONS.credentials.details.alert.archive.title)[0]
+      ).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(getAllByTestId("verify-passcode")[0]).toHaveAttribute(
+        "is-open",
+        "false"
+      );
+    });
+
+    act(() => {
+      fireEvent.click(
+        getAllByText(
+          EN_TRANSLATIONS.credentials.details.alert.archive.confirm
+        )[0]
+      );
+    });
+
+    await waitForIonicReact();
+
+    await waitFor(() => {
+      expect(getAllByTestId("verify-passcode")[0]).toHaveAttribute(
+        "is-open",
+        "true"
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

Fix UT: `It renders verify passcode when clicking on the big button` failed when placed on bottom.

I got an error `TypeError: remove is not a function` when move this test case to bottom. I tried skip this test case and `TypeError` continue occur on `Render passcode` test case. 

With version 6 of `@capacitor/app`, we cannot call `remove` function directly on plugin listener handle (https://github.com/ionic-team/capacitor/blob/main/core/src/web-plugin.ts#L58). (We also got warning when call `remove` function directly with version 5).

Therefore I guess this issue occur when we call `remove` function directly.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-255](https://cardanofoundation.atlassian.net/browse/DTIS-255)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences

[DTIS-255]: https://cardanofoundation.atlassian.net/browse/DTIS-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ