### PR TITLE
feat(ui): Only show single sig identifiers in Cardano Connect

### DIFF
--- a/src/ui/components/CreateIdentifier/components/IdentifierStage4.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage4.tsx
@@ -61,6 +61,7 @@ const IdentifierStage4 = ({
           theme: state.selectedTheme,
           isPending: !!isPending,
           signifyName,
+          multisigManageAid: ourIdentifier,
         };
         const filteredIdentifiersData = identifiersData.filter(
           (item) => item.id !== ourIdentifier

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.test.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnect.test.tsx
@@ -5,18 +5,48 @@ import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
+import { TabsRoutePath } from "../../../../../routes/paths";
 import { store } from "../../../../../store";
+import { identifierFix } from "../../../../__fixtures__/identifierFix";
+import { walletConnectionsFix } from "../../../../__fixtures__/walletConnectionsFix";
+import { WalletConnect } from "./WalletConnect";
 import { WalletConnectStageOne } from "./WalletConnectStageOne";
 import { WalletConnectStageTwo } from "./WalletConnectStageTwo";
-import { identifierFix } from "../../../../__fixtures__/identifierFix";
-import { TabsRoutePath } from "../../../../../routes/paths";
-import { setToastMsg } from "../../../../../store/reducers/stateCache";
-import { ToastMsgType } from "../../../../globals/types";
-import { WalletConnect } from "./WalletConnect";
-import { setWalletConnectionsCache } from "../../../../../store/reducers/walletConnectionsCache";
-import { walletConnectionsFix } from "../../../../__fixtures__/walletConnectionsFix";
 setupIonicReact();
 mockIonicReact();
+
+const identifierCache = [
+  {
+    displayName: "mutil sign",
+    id: "testid_00",
+    signifyName: "178a2adb-4ce0-4acd-984d-f1408c8a1087",
+    createdAtUTC: "2024-07-02T02:59:06.013Z",
+    theme: 0,
+    isPending: false,
+    multisigManageAid: "EHNPqg5RyNVWfpwUYDK135xuUMFGK1GXZoDVqGc0DPsy",
+  },
+  {
+    displayName: "mutil sign 1",
+    id: "testid_0",
+    signifyName: "178a2adb-4ce0-4acd-984d-f1408c8a1087",
+    createdAtUTC: "2024-07-02T02:59:06.013Z",
+    theme: 0,
+    isPending: false,
+    groupMetadata: {
+      groupId: "test",
+      groupInitiator: true,
+      groupCreated: true,
+    },
+  },
+  {
+    displayName: "mutil sign 2",
+    id: "testid_1",
+    signifyName: "178a2adb-4ce0-4acd-984d-f1408c8a1087",
+    createdAtUTC: "2024-07-02T02:59:06.013Z",
+    theme: 0,
+    isPending: false,
+  },
+];
 
 jest.mock("../../../../../core/cardano/walletConnect/peerConnection", () => ({
   PeerConnection: {
@@ -168,7 +198,7 @@ describe("Wallet Connect Stage Two", () => {
       walletConnections: [],
     },
     identifiersCache: {
-      identifiers: [...identifierFix],
+      identifiers: identifierCache,
     },
   };
 
@@ -205,6 +235,8 @@ describe("Wallet Connect Stage Two", () => {
       )
     ).toBeVisible();
 
+    expect(getByTestId(`card-item-${identifierCache[2].id}`)).toBeVisible();
+
     expect(getByTestId("primary-button")).toBeVisible();
 
     expect(getByTestId("primary-button")).toBeDisabled();
@@ -223,11 +255,13 @@ describe("Wallet Connect Stage Two", () => {
     );
 
     expect(
-      getByTestId("identifier-select-" + identifierFix[0].id)
+      getByTestId("identifier-select-" + identifierCache[2].id)
     ).toBeVisible();
 
     act(() => {
-      fireEvent.click(getByTestId("identifier-select-" + identifierFix[0].id));
+      fireEvent.click(
+        getByTestId("identifier-select-" + identifierCache[2].id)
+      );
     });
 
     await waitFor(() => {

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
@@ -39,7 +39,7 @@ const WalletConnectStageTwo = ({
     useState<IdentifierShortDetails | null>(null);
 
   const displayIdentifiers = identifierCache
-    .filter((item) => !item.groupMetadata)
+    .filter((item) => !item.multisigManageAid)
     .map(
       (identifier, index): CardItem<IdentifierShortDetails> => ({
         id: index,

--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
@@ -39,10 +39,10 @@ const WalletConnectStageTwo = ({
     useState<IdentifierShortDetails | null>(null);
 
   const displayIdentifiers = identifierCache
-    .filter((item) => !item.multisigManageAid)
+    .filter((item) => !item.multisigManageAid && !item.groupMetadata)
     .map(
-      (identifier, index): CardItem<IdentifierShortDetails> => ({
-        id: index,
+      (identifier): CardItem<IdentifierShortDetails> => ({
+        id: identifier.id,
         title: identifier.displayName,
         image: KeriLogo,
         data: identifier,


### PR DESCRIPTION
## Description

I forgot push the commit to filter identifier by `multisigManageAid` instead of `groupMetadata`. This PR created to fix this.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-977](https://cardanofoundation.atlassian.net/browse/DTIS-977)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

#### Android

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/60bffb66-fc2a-43dd-a59f-2bfbba35452e

[DTIS-977]: https://cardanofoundation.atlassian.net/browse/DTIS-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ