### PR TITLE
fix: removed from test credential server UI

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -37,7 +37,7 @@ export default {
   },
   testEnvironment: "jsdom",
   testMatch: ["**/src/**/?(*.)+(test).[tj]s?(x)"],
-  testPathIgnorePatterns: ["/node_modules/"],
+  testPathIgnorePatterns: ["/node_modules/", "/credential-server-ui/"],
   transformIgnorePatterns: [
     "node_modules/(?!(@ionic/react|@ionic/react-router|@ionic/core|@stencil/core|ionicons|swiper|ssr-window|@aparajita/capacitor-biometric-auth)/)",
   ],

--- a/services/credential-server-ui/src/App.test.tsx
+++ b/services/credential-server-ui/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import App from "./App";
-
-test("renders learn react link", () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});


### PR DESCRIPTION
## Description

In the previous merge from this [PR](https://github.com/cardano-foundation/cf-identity-wallet/commit/7e3854295d1ceaa1f93b1794bd94e08c3954aa95) I included a test that it's not relevant and it's making tests fail. In this PR that test has been removed since it's not necessary. Additionally the `credential-server-ui` has been included in the ignored patterns in the jest configuration file. 

## Checklist before requesting a review

### Testing & Validation

- [X] The code has been tested locally with test coverage match expectations.

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications