### PR TITLE
fix(ui): correct params.id for identifier details screen

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -117,14 +117,10 @@ const Routes = () => {
           component={CredentialDetails}
           exact
         />
-        <Route
-          render={() => (
-            <Redirect
-              exact
-              from="/"
-              to={nextPath}
-            />
-          )}
+        <Redirect
+          exact
+          from="/"
+          to={nextPath}
         />
       </IonRouterOutlet>
     </IonReactRouter>


### PR DESCRIPTION
## Description

https://github.com/cardano-foundation/cf-identity-wallet/pull/535/files seems to have broken some things. We will be changing the onboarding routing again based on a discussion this morning, so for now this fixes the issue where when you try to load the identifier details, it fails as `params.id` is `undefined`.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
