### PR TITLE
feat(ui): Unable to show the correct toast message when scanning a QR to join a Multi-Sig

### DIFF
--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -74,6 +74,7 @@ enum KeriaStatusEventTypes {
 interface ConnectionStateChangedEvent extends BaseEventEmitter {
   type: typeof ConnectionEventTypes.ConnectionStateChanged;
   payload: {
+    isMultiSigInvite?: boolean;
     connectionId?: string;
     status: ConnectionStatus;
   };

--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -71,6 +71,7 @@ class ConnectionService extends AgentService {
     this.props.eventService.emit<ConnectionStateChangedEvent>({
       type: ConnectionEventTypes.ConnectionStateChanged,
       payload: {
+        isMultiSigInvite: multiSigInvite,
         connectionId: undefined,
         status: ConnectionStatus.PENDING,
       },

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1284,7 +1284,8 @@
     "peeridnotrecognised": "Peer ID not recognised",
     "setupbiometricsuccess": "Biometrics setup successfully",
     "rotatekeysuccess": "Keys rotated successfully",
-    "rotatekeyerror": "Unable to rotate keys"
+    "rotatekeyerror": "Unable to rotate keys",
+    "newmultisignmember": "New member added to multi-sig"
   },
   "request": {
     "sign": {

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1286,7 +1286,8 @@
     "rotatekeysuccess": "Keys rotated successfully",
     "rotatekeyerror": "Unable to rotate keys",
     "newmultisignmember": "New member added to multi-sig",
-    "multisignidentifiercreated": "Identifier added to \"For multiple signers\"" 
+    "multisignidentifiercreated": "Identifier added to \"For multiple signers\"",
+    "delegatedidentifiercreated": "Identifier added to \"For delegates\"" 
   },
   "request": {
     "sign": {

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1285,7 +1285,8 @@
     "setupbiometricsuccess": "Biometrics setup successfully",
     "rotatekeysuccess": "Keys rotated successfully",
     "rotatekeyerror": "Unable to rotate keys",
-    "newmultisignmember": "New member added to multi-sig"
+    "newmultisignmember": "New member added to multi-sig",
+    "multisignidentifiercreated": "Identifier added to \"For multiple signers\"" 
   },
   "request": {
     "sign": {

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -74,6 +74,8 @@ const connectionStateChangedHandler = async (
   dispatch: ReturnType<typeof useAppDispatch>
 ) => {
   if (event.payload.status === ConnectionStatus.PENDING) {
+    if (event.payload.isMultiSigInvite) return;
+
     dispatch(setCurrentOperation(OperationType.RECEIVE_CONNECTION));
     dispatch(setToastMsg(ToastMsgType.CONNECTION_REQUEST_PENDING));
   } else {

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
@@ -143,9 +143,11 @@ const IdentifierStage0 = ({
       }
       dispatch(
         setToastMsg(
-          state.selectedAidType === 1
+          state.selectedAidType === 1 || multiSigGroup
             ? ToastMsgType.MULTI_SIGN_IDENTIFIER_CREATED
-            : ToastMsgType.IDENTIFIER_CREATED
+            : state.selectedAidType === 2
+              ? ToastMsgType.DELEGATED_IDENTIFIER_CREATED
+              : ToastMsgType.IDENTIFIER_CREATED
         )
       );
     }, CREATE_IDENTIFIER_BLUR_TIMEOUT);

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
@@ -141,7 +141,13 @@ const IdentifierStage0 = ({
       } else {
         resetModal && resetModal();
       }
-      dispatch(setToastMsg(ToastMsgType.IDENTIFIER_CREATED));
+      dispatch(
+        setToastMsg(
+          state.selectedAidType === 1
+            ? ToastMsgType.MULTI_SIGN_IDENTIFIER_CREATED
+            : ToastMsgType.IDENTIFIER_CREATED
+        )
+      );
     }, CREATE_IDENTIFIER_BLUR_TIMEOUT);
   };
 

--- a/src/ui/components/Scanner/Scanner.test.tsx
+++ b/src/ui/components/Scanner/Scanner.test.tsx
@@ -214,6 +214,13 @@ describe("Scanner", () => {
         setCurrentOperation(OperationType.MULTI_SIG_INITIATOR_INIT)
       );
       expect(getByTestId("create-identifier-modal")).toBeVisible();
+      expect(dispatchMock).toBeCalledWith(
+        setToastMsg(ToastMsgType.NEW_MULTI_SIGN_MEMBER)
+      );
+
+      expect(dispatchMock).not.toBeCalledWith(
+        setToastMsg(ToastMsgType.CONNECTION_REQUEST_PENDING)
+      );
     });
   });
 

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -150,6 +150,7 @@ const Scanner = forwardRef(
         if (invitation.type === KeriConnectionType.MULTI_SIG_INITIATOR) {
           setGroupId(invitation.groupId);
           setCreateIdentifierModalIsOpen(true);
+          dispatch(setToastMsg(ToastMsgType.NEW_MULTI_SIGN_MEMBER));
         }
       } catch (e) {
         dispatch(setToastMsg(ToastMsgType.SCANNER_ERROR));

--- a/src/ui/globals/types.ts
+++ b/src/ui/globals/types.ts
@@ -36,6 +36,7 @@ enum ToastMsgType {
   COPIED_TO_CLIPBOARD = "copiedToClipboard",
   IDENTIFIER_REQUESTED = "identifierRequested",
   IDENTIFIER_CREATED = "identifierCreated",
+  MULTI_SIGN_IDENTIFIER_CREATED = "multiSignIdentifierCreated",
   IDENTIFIER_UPDATED = "identifierUpdated",
   IDENTIFIER_DELETED = "identifierDeleted",
   CREDENTIAL_DELETED = "credentialDeleted",

--- a/src/ui/globals/types.ts
+++ b/src/ui/globals/types.ts
@@ -37,6 +37,7 @@ enum ToastMsgType {
   IDENTIFIER_REQUESTED = "identifierRequested",
   IDENTIFIER_CREATED = "identifierCreated",
   MULTI_SIGN_IDENTIFIER_CREATED = "multiSignIdentifierCreated",
+  DELEGATED_IDENTIFIER_CREATED = "delegatedidentifiercreated",
   IDENTIFIER_UPDATED = "identifierUpdated",
   IDENTIFIER_DELETED = "identifierDeleted",
   CREDENTIAL_DELETED = "credentialDeleted",

--- a/src/ui/globals/types.ts
+++ b/src/ui/globals/types.ts
@@ -64,6 +64,7 @@ enum ToastMsgType {
   ROTATE_KEY_SUCCESS = "rotatekeysuccess",
   ROTATE_KEY_ERROR = "rotatekeyerror",
   SCANNER_ERROR = "qrerror",
+  NEW_MULTI_SIGN_MEMBER = "newmultisignmember",
 }
 
 const IDENTIFIER_BG_MAPPING: Record<number, unknown> = {

--- a/src/ui/pages/Connections/Connections.tsx
+++ b/src/ui/pages/Connections/Connections.tsx
@@ -61,6 +61,7 @@ const Connections = ({
 
     if (openConnections) {
       setShowConnections(true);
+      history.replace(history.location.pathname, {});
     }
   }, [history.location.state]);
 


### PR DESCRIPTION
## Description

Fix an issue about display wrong message when scanning a QR to join multi-sign identifier. I added new flag on resolve oobi event to know this event has been dispatched by scan multi-sign data. It seem dev server has issue and I can't test on emulator now, therefore I only capture evidence on browser.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-813](https://cardanofoundation.atlassian.net/browse/DTIS-813)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

#### Android

#### Browser

https://github.com/cardano-foundation/cf-identity-wallet/assets/162310763/101cbed4-0702-4649-be51-f29f44584cd2


[DTIS-813]: https://cardanofoundation.atlassian.net/browse/DTIS-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ