### PR TITLE
fix(ui): fix background issue after join multi sign

### DIFF
--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -1,4 +1,7 @@
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import {
+  BarcodeScanner,
+  SupportedFormat,
+} from "@capacitor-community/barcode-scanner";
 import {
   IonCol,
   IonGrid,
@@ -7,46 +10,41 @@ import {
   IonSpinner,
   isPlatform,
 } from "@ionic/react";
-import {
-  BarcodeScanner,
-  SupportedFormat,
-} from "@capacitor-community/barcode-scanner";
 import { scanOutline } from "ionicons/icons";
-import "./Scanner.scss";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { Agent } from "../../../core/agent/agent";
+import { KeriConnectionType } from "../../../core/agent/agent.types";
 import { i18n } from "../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
-import {
-  getCurrentOperation,
-  getCurrentRoute,
-  getToastMsg,
-  setCurrentOperation,
-  setToastMsg,
-} from "../../../store/reducers/stateCache";
-import { TabsRoutePath } from "../navigation/TabsMenu";
-import { OperationType, ToastMsgType } from "../../globals/types";
-import { Agent } from "../../../core/agent/agent";
-import { ScannerProps } from "./Scanner.types";
-import { KeriConnectionType } from "../../../core/agent/agent.types";
 import {
   getMultiSigGroupCache,
   setMultiSigGroupCache,
 } from "../../../store/reducers/identifiersCache";
 import { MultiSigGroup } from "../../../store/reducers/identifiersCache/identifiersCache.types";
-import { PageFooter } from "../PageFooter";
-import { CustomInput } from "../CustomInput";
-import { OptionModal } from "../OptionsModal";
-import { setPendingConnection } from "../../../store/reducers/walletConnectionsCache";
-import { CreateIdentifier } from "../CreateIdentifier";
 import { setBootUrl, setConnectUrl } from "../../../store/reducers/ssiAgent";
+import {
+  getCurrentOperation,
+  getToastMsg,
+  setCurrentOperation,
+  setToastMsg,
+} from "../../../store/reducers/stateCache";
+import { setPendingConnection } from "../../../store/reducers/walletConnectionsCache";
+import { OperationType, ToastMsgType } from "../../globals/types";
+import { CreateIdentifier } from "../CreateIdentifier";
+import { CustomInput } from "../CustomInput";
+import { TabsRoutePath } from "../navigation/TabsMenu";
+import { OptionModal } from "../OptionsModal";
+import { PageFooter } from "../PageFooter";
+import "./Scanner.scss";
+import { ScannerProps } from "./Scanner.types";
 
 const Scanner = forwardRef(
-  ({ setIsValueCaptured, handleReset }: ScannerProps, ref) => {
+  ({ routePath, setIsValueCaptured, handleReset }: ScannerProps, ref) => {
     const componentId = "scanner";
     const dispatch = useAppDispatch();
     const multiSigGroupCache = useAppSelector(getMultiSigGroupCache);
     const currentOperation = useAppSelector(getCurrentOperation);
     const currentToastMsg = useAppSelector(getToastMsg);
-    const currentRoute = useAppSelector(getCurrentRoute);
     const [createIdentifierModalIsOpen, setCreateIdentifierModalIsOpen] =
       useState(false);
     const [pasteModalIsOpen, setPasteModalIsOpen] = useState(false);
@@ -202,7 +200,7 @@ const Scanner = forwardRef(
 
     useEffect(() => {
       if (
-        ((currentRoute?.path === TabsRoutePath.SCAN ||
+        ((routePath === TabsRoutePath.SCAN ||
           [
             OperationType.SCAN_CONNECTION,
             OperationType.SCAN_WALLET_CONNECTION,
@@ -218,7 +216,7 @@ const Scanner = forwardRef(
       } else {
         stopScan();
       }
-    }, [currentOperation, currentRoute]);
+    }, [currentOperation, currentToastMsg, routePath]);
 
     const handlePrimaryButtonAction = () => {
       stopScan();

--- a/src/ui/components/Scanner/Scanner.types.ts
+++ b/src/ui/components/Scanner/Scanner.types.ts
@@ -1,4 +1,5 @@
 interface ScannerProps {
+  routePath?: string;
   setIsValueCaptured?: (value: boolean) => void;
   handleReset?: () => void;
 }

--- a/src/ui/pages/Scan/Scan.test.tsx
+++ b/src/ui/pages/Scan/Scan.test.tsx
@@ -9,7 +9,7 @@ import { OperationType } from "../../globals/types";
 import { Scan } from "./Scan";
 
 const startScan = jest.fn(
-  (args: any) =>
+  (args: unknown) =>
     new Promise((resolve) => {
       setTimeout(() => {
         resolve({
@@ -30,7 +30,7 @@ jest.mock("@capacitor-community/barcode-scanner", () => {
           granted: true,
         }),
       hideBackground: jest.fn(),
-      startScan: (args: any) => startScan(args),
+      startScan: (args: unknown) => startScan(args),
       stopScan: jest.fn(),
       showBackground: jest.fn(),
     },
@@ -50,7 +50,7 @@ jest.mock("../../../core/agent/agent", () => ({
     agent: {
       connections: {
         connectByOobiUrl: () => connectByOobiUrlMock(),
-        getMultisigLinkedContacts: (args: any) =>
+        getMultisigLinkedContacts: (args: unknown) =>
           getMultisigLinkedContactsMock(args),
       },
     },
@@ -61,8 +61,11 @@ const historyPushMock = jest.fn();
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useHistory: () => ({
-    push: (args: any) => {
+    push: (args: unknown) => {
       historyPushMock(args);
+    },
+    location: {
+      pathname: TabsRoutePath.SCAN,
     },
   }),
 }));

--- a/src/ui/pages/Scan/Scan.tsx
+++ b/src/ui/pages/Scan/Scan.tsx
@@ -1,7 +1,9 @@
+import { useIonViewWillEnter } from "@ionic/react";
 import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { useIonViewWillEnter } from "@ionic/react";
-import { TabLayout } from "../../components/layout/TabLayout";
+import { getNextRoute } from "../../../routes/nextRoute";
+import { DataProps } from "../../../routes/nextRoute/nextRoute.types";
+import { TabsRoutePath } from "../../../routes/paths";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
   getCurrentOperation,
@@ -9,13 +11,11 @@ import {
   getToastMsg,
   setCurrentRoute,
 } from "../../../store/reducers/stateCache";
-import { TabsRoutePath } from "../../../routes/paths";
-import { Scanner } from "../../components/Scanner";
-import "./Scan.scss";
-import { DataProps } from "../../../routes/nextRoute/nextRoute.types";
-import { getNextRoute } from "../../../routes/nextRoute";
 import { updateReduxState } from "../../../store/utils";
-import { OperationType, ToastMsgType } from "../../globals/types";
+import { TabLayout } from "../../components/layout/TabLayout";
+import { Scanner } from "../../components/Scanner";
+import { OperationType } from "../../globals/types";
+import "./Scan.scss";
 
 const Scan = () => {
   const pageId = "scan-tab";
@@ -65,7 +65,10 @@ const Scan = () => {
       pageId={pageId}
       header={false}
     >
-      <Scanner setIsValueCaptured={setIsValueCaptured} />
+      <Scanner
+        routePath={history.location.pathname}
+        setIsValueCaptured={setIsValueCaptured}
+      />
     </TabLayout>
   );
 };


### PR DESCRIPTION
## Description

Fix an issue about camera is still active in the background after scanning. 

Sometime, after we close `Share identifier` and nav to `Identifiers` tab, `useIonViewWillEnter` hook of  `Identifiers` tab not triggered and `routes` value on redux store not updated. 

It make active camera condition is `true` (`routePath === TabsRoutePath.SCAN`) and trigger `startScan` function.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1013](https://cardanofoundation.atlassian.net/browse/DTIS-1013)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

#### Android
##### _Before_

https://github.com/user-attachments/assets/517b6948-e99f-4eb5-b653-b849ff8c9ad0

##### _After_

https://github.com/user-attachments/assets/ee5897b1-6210-44d0-95ff-3639dc7a58da

#### Browser


[DTIS-1013]: https://cardanofoundation.atlassian.net/browse/DTIS-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ