### PR TITLE
build(gha): hosted runners

### DIFF
--- a/.github/workflows/gh-vercel-branch-deploys.yaml
+++ b/.github/workflows/gh-vercel-branch-deploys.yaml
@@ -16,7 +16,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   deploy-branch:
-    runs-on: [arc-runner-set]
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/gh-vercel-pr-deploys.yaml
+++ b/.github/workflows/gh-vercel-pr-deploys.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   # This workflow contains a single job called "deploy-preview"
   deploy-preview:
-    runs-on: [arc-runner-set]
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Instead of `[arc-runner-set]` which is currently down.