### PR TITLE
fix: remove button for multi sigs

### DIFF
--- a/src/ui/__fixtures__/filteredIdentifierFix.ts
+++ b/src/ui/__fixtures__/filteredIdentifierFix.ts
@@ -24,6 +24,7 @@ const filteredIdentifierFix: IdentifierShortDetails[] = [
     theme: 0,
     isPending: true,
     signifyName: "Test",
+    multisigManageAid: "123",
   },
 ];
 

--- a/src/ui/__fixtures__/identifierFix.ts
+++ b/src/ui/__fixtures__/identifierFix.ts
@@ -2,12 +2,58 @@ import { IdentifierDetails } from "../../core/agent/services/identifier.types";
 
 const identifierFix: IdentifierDetails[] = [
   {
-    signifyName: "Test",
     id: "ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb",
     displayName: "Professional ID",
     createdAtUTC: "2023-01-01T19:23:24Z",
-    isPending: false,
     theme: 0,
+    isPending: false,
+    signifyName: "Test",
+    s: "4", // Sequence number, only show if s > 0
+    dt: "2023-06-12T14:07:53.224866+00:00", // Last key rotation timestamp, if s > 0
+    kt: 2, // Keys signing threshold (only show if kt > 1)
+    k: [
+      // List of signing keys - array
+      "DCF6b0c5aVm_26_sCTgLB4An6oUxEM5pVDDLqxxXDxH-",
+    ],
+    nt: 3, // Next keys signing threshold, only show if nt > 1
+    n: [
+      // Next keys digests - array
+      "EIZ-n_hHHY5ERGTzvpXYBkB6_yBAM4RXcjQG3-JykFvF",
+    ],
+    bt: 1, // Backer threshold and backer keys below
+    b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"], // List of backers
+    di: "test", // Delegated identifier prefix, don't show if ""
+  },
+  {
+    id: "ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inx",
+    displayName: "Professional ID",
+    createdAtUTC: "2023-01-01T19:23:24Z",
+    theme: 1,
+    isPending: false,
+    signifyName: "Test",
+    s: "4", // Sequence number, only show if s > 0
+    dt: "2023-06-12T14:07:53.224866+00:00", // Last key rotation timestamp, if s > 0
+    kt: 2, // Keys signing threshold (only show if kt > 1)
+    k: [
+      // List of signing keys - array
+      "DCF6b0c5aVm_26_sCTgLB4An6oUxEM5pVDDLqxxXDxH-",
+    ],
+    nt: 3, // Next keys signing threshold, only show if nt > 1
+    n: [
+      // Next keys digests - array
+      "EIZ-n_hHHY5ERGTzvpXYBkB6_yBAM4RXcjQG3-JykFvF",
+    ],
+    bt: 1, // Backer threshold and backer keys below
+    b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"], // List of backers
+    di: "test", // Delegated identifier prefix, don't show if ""
+  },
+  {
+    id: "ECHG-cxboMQ78Hwlm2-w6OS3iU275bAKkqC1LjwICPyi",
+    displayName: "Test MS",
+    createdAtUTC: "2024-03-07T11:54:56.886Z",
+    theme: 0,
+    isPending: true,
+    signifyName: "Test",
     s: "4", // Sequence number, only show if s > 0
     dt: "2023-06-12T14:07:53.224866+00:00", // Last key rotation timestamp, if s > 0
     kt: 2, // Keys signing threshold (only show if kt > 1)

--- a/src/ui/components/CardSlider/CardSlider.test.tsx
+++ b/src/ui/components/CardSlider/CardSlider.test.tsx
@@ -64,7 +64,7 @@ describe("Card slider", () => {
       <Provider store={mockedStore}>
         <CardSlider
           cardType={CardType.IDENTIFIERS}
-          cardsData={identifierFix}
+          cardsData={[identifierFix[0]]}
           title="title"
           name="allidentifiers"
         />

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.test.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.test.tsx
@@ -69,10 +69,33 @@ describe("Identifier Options modal", () => {
     );
     await waitForIonicReact();
 
-    expect(getByTestId("view-json-identifier-options")).toBeVisible();
-    expect(getByTestId("edit-identifier-options")).toBeVisible();
-    expect(getByTestId("share-identifier-options")).toBeVisible();
-    expect(getByTestId("delete-identifier-options")).toBeVisible();
+    expect(getByTestId("view-json-identifier-option")).toBeVisible();
+    expect(getByTestId("edit-identifier-option")).toBeVisible();
+    expect(getByTestId("rotate-keys-option")).toBeVisible();
+    expect(getByTestId("share-identifier-option")).toBeVisible();
+    expect(getByTestId("delete-identifier-option")).toBeVisible();
+  });
+
+  test("should not display the rotate-keys-option inside the modal", async () => {
+    const setIdentifierOptionsIsOpen = jest.fn();
+    const setCardData = jest.fn();
+    const { queryByTestId } = render(
+      <Provider store={mockedStore}>
+        <IdentifierOptions
+          handleRotateKey={jest.fn()}
+          optionsIsOpen={true}
+          setOptionsIsOpen={setIdentifierOptionsIsOpen}
+          cardData={identifierFix[2]}
+          setCardData={setCardData}
+          handleDeleteIdentifier={async () => {
+            jest.fn();
+          }}
+        />
+      </Provider>
+    );
+    await waitForIonicReact();
+
+    await waitFor(() => expect(queryByTestId("rotate-keys-option")).toBe(null));
   });
 });
 
@@ -109,7 +132,7 @@ describe("Identifier Options function test", () => {
   test("Display JSON view", async () => {
     const setIdentifierOptionsIsOpen = jest.fn();
     const setCardData = jest.fn();
-    const { getByTestId, getByText } = render(
+    const { getByTestId } = render(
       <Provider store={mockedStore}>
         <IdentifierOptions
           handleRotateKey={jest.fn()}
@@ -125,10 +148,10 @@ describe("Identifier Options function test", () => {
     );
     await waitForIonicReact();
 
-    expect(getByTestId("view-json-identifier-options")).toBeVisible();
+    expect(getByTestId("view-json-identifier-option")).toBeVisible();
 
     act(() => {
-      fireEvent.click(getByTestId("view-json-identifier-options"));
+      fireEvent.click(getByTestId("view-json-identifier-option"));
     });
 
     await waitFor(() => {
@@ -170,10 +193,10 @@ describe("Identifier Options function test", () => {
     );
     await waitForIonicReact();
 
-    expect(getByTestId("edit-identifier-options")).toBeVisible();
+    expect(getByTestId("edit-identifier-option")).toBeVisible();
 
     act(() => {
-      fireEvent.click(getByTestId("edit-identifier-options"));
+      fireEvent.click(getByTestId("edit-identifier-option"));
     });
 
     await waitFor(() => {
@@ -208,7 +231,7 @@ describe("Identifier Options function test", () => {
     const setIdentifierOptionsIsOpen = jest.fn();
     const setCardData = jest.fn();
     const mockDelete = jest.fn();
-    const { getByTestId, getAllByText } = render(
+    const { getByTestId } = render(
       <Provider store={mockedStore}>
         <IdentifierOptions
           handleRotateKey={jest.fn()}
@@ -222,10 +245,10 @@ describe("Identifier Options function test", () => {
     );
     await waitForIonicReact();
 
-    expect(getByTestId("delete-identifier-options")).toBeVisible();
+    expect(getByTestId("delete-identifier-option")).toBeVisible();
 
     act(() => {
-      fireEvent.click(getByTestId("delete-identifier-options"));
+      fireEvent.click(getByTestId("delete-identifier-option"));
     });
 
     await waitFor(() => {

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
@@ -45,7 +45,6 @@ const IdentifierOptions = ({
   const [newDisplayName, setNewDisplayName] = useState(cardData.displayName);
   const [newSelectedTheme, setNewSelectedTheme] = useState(cardData.theme);
   const [viewIsOpen, setViewIsOpen] = useState(false);
-  const [keyboardIsOpen, setkeyboardIsOpen] = useState(false);
   const [isMultiSig, setIsMultiSig] = useState(false);
 
   useEffect(() => {
@@ -64,17 +63,6 @@ const IdentifierOptions = ({
   useEffect(() => {
     setNewDisplayName(cardData.displayName);
   }, [cardData.displayName]);
-
-  useEffect(() => {
-    if (Capacitor.isNativePlatform()) {
-      Keyboard.addListener("keyboardWillShow", () => {
-        setkeyboardIsOpen(true);
-      });
-      Keyboard.addListener("keyboardWillHide", () => {
-        setkeyboardIsOpen(false);
-      });
-    }
-  }, []);
 
   useEffect(() => {
     setNewSelectedTheme(cardData.theme);

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
@@ -30,7 +30,6 @@ import { OptionItem, OptionModal } from "../OptionsModal";
 import "./IdentifierOptions.scss";
 import { IdentifierOptionsProps } from "./IdentifierOptions.types";
 import { IdentifierJsonModal } from "./components";
-import { RotateKeyModal } from "../../pages/IdentifierDetails/components/RotateKeyModal/RotateKeyModal";
 
 const IdentifierOptions = ({
   optionsIsOpen,
@@ -47,6 +46,15 @@ const IdentifierOptions = ({
   const [newSelectedTheme, setNewSelectedTheme] = useState(cardData.theme);
   const [viewIsOpen, setViewIsOpen] = useState(false);
   const [keyboardIsOpen, setkeyboardIsOpen] = useState(false);
+  const identifiersData = useAppSelector(getIdentifiersCache);
+  const [isMultiSig, setIsMultiSig] = useState(false);
+
+  useEffect(() => {
+    const identifier = identifiersData.find((data) => data.id === cardData.id);
+    if (identifier && identifier.multisigManageAid) {
+      setIsMultiSig(true);
+    }
+  }, [identifiersData, cardData.id]);
 
   const verifyDisplayName =
     newDisplayName.length > 0 &&
@@ -148,38 +156,42 @@ const IdentifierOptions = ({
     dispatch(setCurrentOperation(OperationType.IDLE));
   };
 
-  const options: OptionItem[] = [
+  const optionsRotate: OptionItem[] = [
     {
       icon: codeSlashOutline,
       label: i18n.t("identifiers.details.options.view"),
       onClick: viewJson,
-      testId: "view-json-identifier-options",
+      testId: "view-json-identifier-option",
     },
     {
       icon: pencilOutline,
       label: i18n.t("identifiers.details.options.edit"),
       onClick: updateIdentifier,
-      testId: "edit-identifier-options",
+      testId: "edit-identifier-option",
     },
     {
       icon: refreshOutline,
       label: i18n.t("identifiers.details.options.rotatekeys"),
       onClick: rotateKey,
-      testId: "rotate-keys",
+      testId: "rotate-keys-option",
     },
     {
       icon: shareOutline,
       label: i18n.t("identifiers.details.options.share"),
       onClick: share,
-      testId: "share-identifier-options",
+      testId: "share-identifier-option",
     },
     {
       icon: trashOutline,
       label: i18n.t("identifiers.details.options.delete"),
       onClick: deleteIdentifier,
-      testId: "delete-identifier-options",
+      testId: "delete-identifier-option",
     },
   ];
+
+  const optionsNoRotate = optionsRotate.filter(
+    (option) => option.testId !== "rotate-keys-option"
+  );
 
   return (
     <>
@@ -190,7 +202,7 @@ const IdentifierOptions = ({
         header={{
           title: `${i18n.t("identifiers.details.options.title")}`,
         }}
-        items={options}
+        items={isMultiSig ? optionsNoRotate : optionsRotate}
       />
       <OptionModal
         modalIsOpen={editorOptionsIsOpen}

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
@@ -40,13 +40,12 @@ const IdentifierOptions = ({
   handleRotateKey,
 }: IdentifierOptionsProps) => {
   const dispatch = useAppDispatch();
-  const identifierData = useAppSelector(getIdentifiersCache);
+  const identifiersData = useAppSelector(getIdentifiersCache);
   const [editorOptionsIsOpen, setEditorIsOpen] = useState(false);
   const [newDisplayName, setNewDisplayName] = useState(cardData.displayName);
   const [newSelectedTheme, setNewSelectedTheme] = useState(cardData.theme);
   const [viewIsOpen, setViewIsOpen] = useState(false);
   const [keyboardIsOpen, setkeyboardIsOpen] = useState(false);
-  const identifiersData = useAppSelector(getIdentifiersCache);
   const [isMultiSig, setIsMultiSig] = useState(false);
 
   useEffect(() => {
@@ -94,7 +93,7 @@ const IdentifierOptions = ({
   const handleSubmit = async () => {
     setEditorIsOpen(false);
     setOptionsIsOpen(false);
-    const updatedIdentifiers = [...identifierData];
+    const updatedIdentifiers = [...identifiersData];
     const index = updatedIdentifiers.findIndex(
       (identifier) => identifier.id === cardData.id
     );

--- a/src/ui/pages/IdentifierDetails/IdentifierDetails.test.tsx
+++ b/src/ui/pages/IdentifierDetails/IdentifierDetails.test.tsx
@@ -191,7 +191,7 @@ describe("Cards Details page (not multi-sig)", () => {
     });
 
     await waitFor(() => {
-      expect(getByTestId("edit-identifier-options")).toBeInTheDocument();
+      expect(getByTestId("edit-identifier-option")).toBeInTheDocument();
     });
   });
 
@@ -261,7 +261,7 @@ describe("Cards Details page (not multi-sig)", () => {
     });
 
     await waitFor(() => {
-      expect(getByTestId("delete-identifier-options")).toBeInTheDocument();
+      expect(getByTestId("delete-identifier-option")).toBeInTheDocument();
     });
 
     act(() => {

--- a/src/ui/pages/IdentifierDetails/components/IdentifierContent.tsx
+++ b/src/ui/pages/IdentifierDetails/components/IdentifierContent.tsx
@@ -3,6 +3,7 @@ import {
   personCircleOutline,
   refreshOutline,
 } from "ionicons/icons";
+import { useEffect, useState } from "react";
 import { formatShortDate, formatTimeToSec } from "../../../utils/formatters";
 import { IdentifierContentProps } from "./IdentifierContent.types";
 import { i18n } from "../../../../i18n";
@@ -10,11 +11,23 @@ import { ConfigurationService } from "../../../../core/configuration";
 import { CardDetailsBlock } from "../../../components/CardDetails/CardDetailsBlock";
 import { CardDetailsItem } from "../../../components/CardDetails/CardDetailsItem";
 import { BackingMode } from "../../../../core/configuration/configurationService.types";
+import { useAppSelector } from "../../../../store/hooks";
+import { getIdentifiersCache } from "../../../../store/reducers/identifiersCache";
 
 const IdentifierContent = ({
   cardData,
   onOpenRotateKey,
 }: IdentifierContentProps) => {
+  const identifiersData = useAppSelector(getIdentifiersCache);
+  const [isMultiSig, setIsMultiSig] = useState(false);
+
+  useEffect(() => {
+    const identifier = identifiersData.find((data) => data.id === cardData.id);
+    if (identifier && identifier.multisigManageAid) {
+      setIsMultiSig(true);
+    }
+  }, [identifiersData, cardData.id]);
+
   return (
     <>
       {cardData.di !== "" && (
@@ -39,8 +52,8 @@ const IdentifierContent = ({
                 copyButton={true}
                 textIcon="identifiers.details.signingkeyslist.icon"
                 testId={`signing-key-${index}`}
-                actionButton={refreshOutline}
-                actionButtonClick={onOpenRotateKey}
+                actionButton={isMultiSig ? undefined : refreshOutline}
+                actionButtonClick={isMultiSig ? undefined : onOpenRotateKey}
               />
             );
           })}


### PR DESCRIPTION
## Description

In this PR we are not adding anything new to the UI, therefore I won't be testing it on all the emulators as usual. This is a  bugfix for hiding the button and the menu option for rotating the keys when the identifier is managed my a multi sig, since this requirement wasn't specified in the original Acceptance Criteria as discussed [here](https://cardanofoundation.slack.com/archives/C04DUEK6B25/p1720617663980479).

In the video below you can see how this button shows up when I open a single signer AID, while this will be hidden when opening a multi sig, both in the page and in the options modal.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1033**](https://cardanofoundation.atlassian.net/browse/DTIS-1033)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser

https://github.com/user-attachments/assets/2c2c3a04-6fe6-400b-aa33-0c084f9dab24

