### PR TITLE
fix(core): correct record type for connection notes

### DIFF
--- a/src/core/agent/records/connectionNoteRecord.ts
+++ b/src/core/agent/records/connectionNoteRecord.ts
@@ -14,7 +14,7 @@ class ConnectionNoteRecord extends BaseRecord {
   connectionId!: string;
   title!: string;
   message!: string;
-  static readonly type = "ConnectionRecord";
+  static readonly type = "ConnectionNoteRecord";
   readonly type = ConnectionNoteRecord.type;
 
   constructor(props: ConnectionNoteRecordStorageProps) {


### PR DESCRIPTION
These were being pulled when you fetch the list of connections as they had the same type (regression during refactoring).