### PR TITLE
feat(ui): Disable back button swipe where it's breaking things

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -31,9 +31,7 @@ import { LockPage } from "./pages/LockPage/LockPage";
 import { LoadingPage } from "./pages/LoadingPage/LoadingPage";
 import { SidePage } from "./pages/SidePage";
 
-setupIonicReact({
-  swipeBackEnabled: false,
-});
+setupIonicReact();
 
 const App = () => {
   const stateCache = useAppSelector(getStateCache);
@@ -54,7 +52,6 @@ const App = () => {
     if (isPreviewMode) {
       setupIonicReact({
         rippleEffect: false,
-        swipeBackEnabled: false,
         mode: "ios",
       });
       document?.querySelector("html")?.classList.add("smartphone-layout");

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -31,7 +31,9 @@ import { LockPage } from "./pages/LockPage/LockPage";
 import { LoadingPage } from "./pages/LoadingPage/LoadingPage";
 import { SidePage } from "./pages/SidePage";
 
-setupIonicReact();
+setupIonicReact({
+  swipeBackEnabled: false,
+});
 
 const App = () => {
   const stateCache = useAppSelector(getStateCache);
@@ -52,6 +54,7 @@ const App = () => {
     if (isPreviewMode) {
       setupIonicReact({
         rippleEffect: false,
+        swipeBackEnabled: false,
         mode: "ios",
       });
       document?.querySelector("html")?.classList.add("smartphone-layout");

--- a/src/ui/components/PageHeader/PageHeader.types.ts
+++ b/src/ui/components/PageHeader/PageHeader.types.ts
@@ -24,7 +24,7 @@ interface PageHeaderProps {
   hardwareBackButtonConfig?: {
     prevent: boolean;
     priority?: BackEventPriorityType;
-    handler?: (processNextHandler: () => void) => void;
+    handler?: (processNextHandler?: () => void) => void;
   };
 }
 

--- a/src/ui/components/layout/TabLayout/TabLayout.tsx
+++ b/src/ui/components/layout/TabLayout/TabLayout.tsx
@@ -83,6 +83,7 @@ const TabLayout = ({
         customClass ? " " + customClass : ""
       }`}
       data-testid={pageId}
+      id={pageId}
     >
       {header && (
         <IonHeader className="ion-no-border tab-header">

--- a/src/ui/hooks/swipeBackHook.ts
+++ b/src/ui/hooks/swipeBackHook.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { getPlatforms } from "@ionic/react";
+import { createSwipeBackGesture } from "../utils/swipeback";
+
+const useSwipeBack = (
+  getSwipeEl: () => HTMLElement | null,
+  canStartHandler: () => boolean,
+  onEndHandler: (shouldComplete: boolean, step: number, dur: number) => void,
+  onStartHandler?: () => void,
+  onMoveHandler?: (step: number) => void
+) => {
+  useEffect(() => {
+    const platforms = getPlatforms();
+    if (!platforms.includes("mobile") && !platforms.includes("ios")) return;
+
+    const swipeEl = getSwipeEl();
+
+    if (!swipeEl) return;
+
+    const swp = createSwipeBackGesture(
+      swipeEl,
+      canStartHandler,
+      onEndHandler,
+      onStartHandler,
+      onMoveHandler
+    );
+
+    swp.enable();
+
+    return () => {
+      swp.destroy();
+    };
+  }, [
+    canStartHandler,
+    onEndHandler,
+    onMoveHandler,
+    onStartHandler,
+    getSwipeEl,
+  ]);
+};
+
+export { useSwipeBack };

--- a/src/ui/hooks/useIonHardwareBackButton.ts
+++ b/src/ui/hooks/useIonHardwareBackButton.ts
@@ -19,7 +19,7 @@ const useIonHardwareBackButton = (
     return () => {
       document.removeEventListener("ionBackButton", handleBack);
     };
-  }, [prevent, handler]);
+  }, [prevent, handler, priority]);
 };
 
 export { useIonHardwareBackButton };

--- a/src/ui/pages/Connections/Connections.tsx
+++ b/src/ui/pages/Connections/Connections.tsx
@@ -10,7 +10,7 @@ import {
   IonRow,
   IonSearchbar,
 } from "@ionic/react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { addOutline } from "ionicons/icons";
 import { useHistory } from "react-router-dom";
 import { TabLayout } from "../../components/layout/TabLayout";
@@ -36,6 +36,7 @@ import { MoreOptions } from "../../components/ShareQR/MoreOptions";
 import { AlphabeticList } from "./components/AlphabeticList";
 import { AlphabetSelector } from "./components/AlphabetSelector";
 import { SideSlider } from "../../components/SideSlider";
+import { useSwipeBack } from "../../hooks/swipeBackHook";
 
 const Connections = ({
   showConnections,
@@ -56,14 +57,14 @@ const Connections = ({
   );
 
   useEffect(() => {
-    const openConnections = (history.location.state as Record<string, any>)
+    const openConnections = (history.location.state as Record<string, unknown>)
       ?.openConnections;
 
     if (openConnections) {
       setShowConnections(true);
       history.replace(history.location.pathname, {});
     }
-  }, [history.location.state]);
+  }, [history, history.location.state, setShowConnections]);
 
   useEffect(() => {
     setShowPlaceholder(Object.keys(connectionsCache).length === 0);
@@ -142,6 +143,16 @@ const Connections = ({
     }),
     [showConnections]
   );
+
+  const getConnectionsTab = useCallback(() => {
+    return document.getElementById(pageId);
+  }, []);
+
+  const canStart = useCallback(() => {
+    return showConnections;
+  }, [showConnections]);
+
+  useSwipeBack(getConnectionsTab, canStart, () => setShowConnections(false));
 
   return (
     <>

--- a/src/ui/utils/swipeback.ts
+++ b/src/ui/utils/swipeback.ts
@@ -1,0 +1,112 @@
+/**
+ * Source of swipe back action ionic-framework version: 7.5.x. Used to custom swipe back action on our app.
+ * github: https://github.com/ionic-team/ionic-framework/blob/7.5.x/core/src/utils/gesture/swipe-back.ts
+ */
+import { createGesture, Gesture, GestureDetail } from "@ionic/react";
+
+const clamp = (min: number, n: number, max: number) => {
+  return Math.max(min, Math.min(n, max));
+};
+
+const isRTL = (hostEl?: Pick<HTMLElement, "dir">) => {
+  if (hostEl) {
+    if (hostEl.dir !== "") {
+      return hostEl.dir.toLowerCase() === "rtl";
+    }
+  }
+  return document?.dir.toLowerCase() === "rtl";
+};
+
+const CANNOT_GET_DEFAULT_VIEW = "Cannot get default view of element";
+
+export const createSwipeBackGesture = (
+  el: HTMLElement,
+  canStartHandler: () => boolean,
+  onEndHandler: (shouldComplete: boolean, step: number, dur: number) => void,
+  onStartHandler?: () => void,
+  onMoveHandler?: (step: number) => void
+): Gesture => {
+  if (!el?.ownerDocument?.defaultView) {
+    throw new Error(CANNOT_GET_DEFAULT_VIEW);
+  }
+
+  const win = el.ownerDocument.defaultView;
+  let rtl = isRTL(el);
+
+  /**
+   * Determine if a gesture is near the edge
+   * of the screen. If true, then the swipe
+   * to go back gesture should proceed.
+   */
+  const isAtEdge = (detail: GestureDetail) => {
+    const threshold = 50;
+    const { startX } = detail;
+
+    if (rtl) {
+      return startX >= win.innerWidth - threshold;
+    }
+
+    return startX <= threshold;
+  };
+
+  const getDeltaX = (detail: GestureDetail) => {
+    return rtl ? -detail.deltaX : detail.deltaX;
+  };
+
+  const getVelocityX = (detail: GestureDetail) => {
+    return rtl ? -detail.velocityX : detail.velocityX;
+  };
+
+  const canStart = (detail: GestureDetail) => {
+    /**
+     * The user's locale can change mid-session,
+     * so we need to check text direction at
+     * the beginning of every gesture.
+     */
+    rtl = isRTL(el);
+
+    return isAtEdge(detail) && canStartHandler();
+  };
+
+  const onMove = (detail: GestureDetail) => {
+    // set the transition animation's progress
+    const delta = getDeltaX(detail);
+    const stepValue = delta / win.innerWidth;
+    onMoveHandler?.(stepValue);
+  };
+
+  const onEnd = (detail: GestureDetail) => {
+    // the swipe back gesture has ended
+    const delta = getDeltaX(detail);
+    const width = win.innerWidth;
+    const stepValue = delta / width;
+    const velocity = getVelocityX(detail);
+    const z = width / 2.0;
+    const shouldComplete = velocity >= 0 && (velocity > 0.2 || delta > z);
+
+    const missing = shouldComplete ? 1 - stepValue : stepValue;
+    const missingDistance = missing * width;
+    let realDur = 0;
+    if (missingDistance > 5) {
+      const dur = missingDistance / Math.abs(velocity);
+      realDur = Math.min(dur, 540);
+    }
+
+    onEndHandler(
+      shouldComplete,
+      stepValue <= 0 ? 0.01 : clamp(0, stepValue, 0.9999),
+      realDur
+    );
+  };
+
+  return createGesture({
+    el,
+    gestureName: "goback-swipe-custom",
+    gesturePriority: 101.5,
+    threshold: 10,
+    canStart,
+    onStart: onStartHandler,
+    onMove,
+    onEnd,
+  });
+};


### PR DESCRIPTION
## Description

Disable swipe back action on IOS to fix an issue about render blank page after swipe back.
I tested on android and swipe working well (same as hardware back button):

https://github.com/user-attachments/assets/9c434c4a-c8fe-40f5-8c06-b20df2bce731


## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-978](https://cardanofoundation.atlassian.net/browse/DTIS-978)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS
##### _Before_

https://github.com/user-attachments/assets/7a7b7f0a-6f4d-4e4a-956c-2c003a6efba2

##### _After_

https://github.com/user-attachments/assets/b2cfd0a7-fe19-40a2-9c26-8049592e83c9



[DTIS-978]: https://cardanofoundation.atlassian.net/browse/DTIS-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ