### PR TITLE
fix(ui): prevent unable to connect toast to show with every conection

### DIFF
--- a/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
+++ b/src/ui/pages/SidePage/components/WalletConnect/WalletConnectStageTwo.tsx
@@ -67,14 +67,23 @@ const WalletConnectStageTwo = ({
           (connection) => connection.id === pendingDAppMeerkat
         );
         if (existingConnection) {
-          existingConnection.selectedAid = selectedIdentifier.id;
-          dispatch(setWalletConnectionsCache([...existingConnections]));
+          const updatedConnections = [];
+          for (const connection of existingConnections) {
+            if (connection.id === existingConnection.id) {
+              updatedConnections.push({
+                ...existingConnection,
+                selectedAid: selectedIdentifier.id,
+              });
+            } else {
+              updatedConnections.push(connection);
+            }
+          }
+          dispatch(setWalletConnectionsCache(updatedConnections));
         } else {
-          // Insert a new connection if needed
           dispatch(
             setWalletConnectionsCache([
-              { id: pendingDAppMeerkat, selectedAid: selectedIdentifier.id },
               ...existingConnections,
+              { id: pendingDAppMeerkat, selectedAid: selectedIdentifier.id },
             ])
           );
         }
@@ -85,6 +94,8 @@ const WalletConnectStageTwo = ({
       }
       onClose();
     } catch (e) {
+      /* eslint-disable no-console */
+      console.error(e);
       dispatch(setToastMsg(ToastMsgType.UNABLE_CONNECT_WALLET));
     }
   };


### PR DESCRIPTION
## Description

Every time that a new connection was stablished using Cardano Connect a toast with the text `unable to connect` was showing up even if the connection was successfully stablished a few seconds later. This PR prevents this from happening. 

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue:

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)