### PR TITLE
chore(core): Updated CF's bittorrent tracker url

### DIFF
--- a/src/core/cardano/walletConnect/peerConnection.ts
+++ b/src/core/cardano/walletConnect/peerConnection.ts
@@ -31,7 +31,7 @@ class PeerConnection {
 
   private announce = [
     "wss://tracker.openwebtorrent.com",
-    "wss://dev.tracker.cf-identity-wallet.metadata.dev.cf-deployments.org",
+    "wss://dev.btt.cf-identity-wallet.metadata.dev.cf-deployments.org",
     "wss://tracker.files.fm:7073/announce",
     "ws://tracker.files.fm:7072/announce",
     "wss://tracker.openwebtorrent.com:443/announce",


### PR DESCRIPTION
## Description

@rcmorano has updated the CF's bittorrent tracker host and IP to reduce the discovery time for a new connection when using CIP-45 in Cardano Connect. In this PR I have updated the url that we were previously using with the new one. 

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1112)

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated