### PR TITLE
fix(ui): prevent connect wallet when we only have multisig identifiers

### DIFF
--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -242,7 +242,7 @@ describe("Wallet connect: empty history", () => {
     });
   });
 
-  test("Connect wallet modal: alert identifier missing when create new connect if we only have multi-sig identifiers", async () => {
+  test("Connect wallet modal: alert identifier missing when create new connect if we only have multi-sig or group identifiers", async () => {
     const initialState = {
       stateCache: {
         routes: [TabsRoutePath.IDENTIFIERS],
@@ -266,6 +266,15 @@ describe("Wallet connect: empty history", () => {
             theme: 0,
             isPending: false,
             multisigManageAid: "EBze49sDYvxxtq5eFbX2TKbK7g4SPS7DJVdoTRIyybxN",
+          },
+          {
+            displayName: "ms",
+            id: "EFn1HAaIyISfu_pwLA8DFgeKxr0pLzBccb4eXHSPVQ6L",
+            signifyName: "52e200ea-5cbc-4632-a8bb-59cb586caad7",
+            createdAtUTC: "2024-07-25T13:33:20.323Z",
+            theme: 0,
+            isPending: false,
+            groupMetadata: {},
           },
         ],
       },

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -1,10 +1,4 @@
-import {
-  act,
-  fireEvent,
-  getByTestId,
-  render,
-  waitFor,
-} from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { MemoryRouter } from "react-router-dom";
@@ -207,6 +201,73 @@ describe("Wallet connect: empty history", () => {
       },
       identifiersCache: {
         identifiers: [],
+      },
+      biometricsCache: {
+        enabled: false,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <Provider store={storeMocked}>
+          <ConnectWallet />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText(EN_TRANSLATIONS.menu.tab.items.connectwallet.connectbtn)
+      ).toBeVisible();
+    });
+
+    act(() => {
+      fireEvent.click(
+        getByText(EN_TRANSLATIONS.menu.tab.items.connectwallet.connectbtn)
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        getByText(
+          EN_TRANSLATIONS.menu.tab.items.connectwallet.connectionhistory
+            .missingidentifieralert.message
+        )
+      ).toBeVisible();
+    });
+  });
+
+  test("Connect wallet modal: alert identifier missing when create new connect if we only have multi-sig identifiers", async () => {
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.IDENTIFIERS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: true,
+        },
+      },
+      walletConnectionsCache: {
+        walletConnections: [],
+      },
+      identifiersCache: {
+        identifiers: [
+          {
+            displayName: "ms",
+            id: "EFn1HAaIyISfu_pwLA8DFgeKxr0pLzBccb4eXHSPVQ6L",
+            signifyName: "52e200ea-5cbc-4632-a8bb-59cb586caad7",
+            createdAtUTC: "2024-07-25T13:33:20.323Z",
+            theme: 0,
+            isPending: false,
+            multisigManageAid: "EBze49sDYvxxtq5eFbX2TKbK7g4SPS7DJVdoTRIyybxN",
+          },
+        ],
       },
       biometricsCache: {
         enabled: false,

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -4,7 +4,6 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { useHistory } from "react-router-dom";
@@ -53,7 +52,9 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
 
     const toastMsg = useAppSelector(getToastMsg);
     const pendingConnection = useAppSelector(getPendingConnection);
-    const identifierCache = useAppSelector(getIdentifiersCache);
+    const identifierCache = useAppSelector(getIdentifiersCache).filter(
+      (identifier) => !identifier.multisigManageAid
+    );
     const connections = useAppSelector(getWalletConnectionsCache);
     const connectedWallet = useAppSelector(getConnectedWallet);
     const currentOperation = useAppSelector(getCurrentOperation);

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -52,8 +52,8 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
 
     const toastMsg = useAppSelector(getToastMsg);
     const pendingConnection = useAppSelector(getPendingConnection);
-    const identifierCache = useAppSelector(getIdentifiersCache).filter(
-      (identifier) => !identifier.multisigManageAid
+    const defaultIdentifierCache = useAppSelector(getIdentifiersCache).filter(
+      (identifier) => !identifier.multisigManageAid && !identifier.groupMetadata
     );
     const connections = useAppSelector(getWalletConnectionsCache);
     const connectedWallet = useAppSelector(getConnectedWallet);
@@ -163,7 +163,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
     };
 
     const toggleConnected = () => {
-      if (identifierCache.length === 0) {
+      if (defaultIdentifierCache.length === 0) {
         setOpenIdentifierMissingAlert(true);
         return;
       }
@@ -193,7 +193,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
     };
 
     const handleScanQR = () => {
-      if (identifierCache.length === 0) {
+      if (defaultIdentifierCache.length === 0) {
         setOpenIdentifierMissingAlert(true);
         return;
       }


### PR DESCRIPTION
## Description

There is a dialog we show if we have no identifiers at all, but it should be shown if we don’t have any default identifiers since this is all we can use to vote.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1108)

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated