### PR TITLE
fix(ui): disconnect dapp before deleting dapp record

### DIFF
--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -138,6 +138,10 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
       setActionInfo({
         type: ActionType.None,
       });
+      if (connectedWallet) {
+        PeerConnection.peerConnection.disconnectDApp(connectedWallet?.id);
+        dispatch(setConnectedWallet(null));
+      }
       await Agent.agent.peerConnectionMetadataStorage.deletePeerConnectionMetadataRecord(
         data.id
       );


### PR DESCRIPTION
## Description

If the currently connected dApp is completely deleted, we shouldn’t be warned about breaking the connection.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1109)

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated