### PR TITLE
fix(ui): Only one connection history item is shown in the UI

### DIFF
--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
@@ -724,7 +724,13 @@ describe("Checking the Connection Details Page when notes are available", () => 
     );
 
     await waitFor(() =>
-      expect(getByText("13/02/2024 - 10:16:08")).toBeVisible()
+      expect(
+        getByText(
+          `${formatShortDate(historyEvents[0].timestamp)} - ${formatTimeToSec(
+            historyEvents[0].timestamp
+          )}`
+        )
+      ).toBeVisible()
     );
 
     await waitFor(() =>
@@ -732,7 +738,13 @@ describe("Checking the Connection Details Page when notes are available", () => 
     );
 
     await waitFor(() =>
-      expect(getByText("14/02/2024 - 10:16:26")).toBeVisible()
+      expect(
+        getByText(
+          `${formatShortDate(historyEvents[1].timestamp)} - ${formatTimeToSec(
+            historyEvents[1].timestamp
+          )}`
+        )
+      ).toBeVisible()
     );
 
     await waitFor(() =>
@@ -740,7 +752,13 @@ describe("Checking the Connection Details Page when notes are available", () => 
     );
 
     await waitFor(() =>
-      expect(getByText("15/02/2024 - 10:16:08")).toBeVisible()
+      expect(
+        getByText(
+          `${formatShortDate(historyEvents[2].timestamp)} - ${formatTimeToSec(
+            historyEvents[2].timestamp
+          )}`
+        )
+      ).toBeVisible()
     );
 
     await waitFor(() =>
@@ -750,7 +768,13 @@ describe("Checking the Connection Details Page when notes are available", () => 
     );
 
     await waitFor(() =>
-      expect(getByText("16/02/2024 - 11:39:22")).toBeVisible()
+      expect(
+        getByText(
+          `${formatShortDate(historyEvents[3].timestamp)} - ${formatTimeToSec(
+            historyEvents[3].timestamp
+          )}`
+        )
+      ).toBeVisible()
     );
 
     await waitFor(() =>

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
@@ -652,22 +652,37 @@ describe("Checking the Connection Details Page when notes are available", () => 
 
     await waitFor(() => expect(getByText("Message")).toBeVisible());
   });
-});
 
-describe("Checking the Connection Details Page when different Credentials are issued", () => {
-  test("We can see the connection details for UniversityDegreeCredential", async () => {
-    const historyEvent = {
-      type: 0,
-      timestamp: "2024-02-13T10:16:08.756Z",
-      credentialType: "UniversityDegreeCredential",
-    };
+  test("Get multiple connection history items", async () => {
+    const historyEvents = [
+      {
+        type: 0,
+        timestamp: "2024-02-13T10:16:08.756Z",
+        credentialType: "UniversityDegreeCredential",
+      },
+      {
+        type: 0,
+        timestamp: "2024-02-14T10:16:26.919Z",
+        credentialType: "PermanentResidentCard",
+      },
+      {
+        type: 0,
+        timestamp: "2024-02-15T10:16:08.756Z",
+        credentialType: "AccessPassCredential",
+      },
+      {
+        type: 0,
+        timestamp: "2024-02-16T11:39:22.919Z",
+        credentialType: "Qualified vLEI Issuer Credential",
+      },
+    ];
     jest
       .spyOn(Agent.agent.connections, "getConnectionById")
       .mockResolvedValue(connectionsFix[0]);
 
     jest
       .spyOn(Agent.agent.connections, "getConnectionHistoryById")
-      .mockResolvedValue([historyEvent]);
+      .mockResolvedValue(historyEvents);
 
     const storeMocked = {
       ...mockStore(initialStateFull),
@@ -705,242 +720,28 @@ describe("Checking the Connection Details Page when different Credentials are is
     });
 
     await waitFor(() =>
-      expect(getByText("Connected with \"Cambridge University\"")).toBeVisible()
-    );
-
-    await waitFor(() => {
-      expect(getByTestId("connection-detail-date")).toBeVisible();
-      expect(getByTestId("connection-detail-date")).toHaveTextContent(
-        `${formatShortDate(
-          connectionsFix[0].connectionDate
-        )} - ${formatTimeToSec(connectionsFix[0].connectionDate)}`
-      );
-    });
-
-    await waitFor(() =>
       expect(getByText("Received \"University Degree Credential\"")).toBeVisible()
     );
 
     await waitFor(() =>
-      expect(getByTestId("connection-history-timestamp")).toHaveTextContent(
-        `${formatShortDate("2024-02-13T10:16:08.756Z")} - ${formatTimeToSec(
-          "2024-02-13T10:16:08.756Z"
-        )}`
-      )
+      expect(getByText("13/02/2024 - 10:16:08")).toBeVisible()
     );
-  });
-
-  test("We can see the connection details for AccessPassCredential", async () => {
-    jest
-      .spyOn(Agent.agent.connections, "getConnectionById")
-      .mockResolvedValue(connectionsFix[2]);
-
-    jest
-      .spyOn(Agent.agent.connections, "getConnectionHistoryById")
-      .mockResolvedValue([
-        {
-          type: 0,
-          timestamp: "2024-02-15T10:16:08.756Z",
-          credentialType: "AccessPassCredential",
-        },
-      ]);
-
-    const storeMocked = {
-      ...mockStore(initialStateFull),
-      dispatch: dispatchMock,
-    };
-    const { getByTestId, queryByTestId, getByText } = render(
-      <MemoryRouter initialEntries={[TabsRoutePath.CREDENTIALS]}>
-        <Provider store={storeMocked}>
-          <Route
-            path={TabsRoutePath.CREDENTIALS}
-            component={Creds}
-          />
-
-          <Route
-            path={RoutePath.CONNECTION_DETAILS}
-            component={ConnectionDetails}
-          />
-        </Provider>
-      </MemoryRouter>
-    );
-
-    act(() => {
-      fireEvent.click(getByTestId("connections-button"));
-    });
-
-    await waitFor(() => {
-      expect(queryByTestId("connection-item-0")).toBeNull();
-    });
-
-    expect(getByText(connectionsFix[2].label)).toBeVisible();
-
-    act(() => {
-      fireEvent.click(getByText(connectionsFix[2].label));
-    });
-
-    await waitFor(() =>
-      expect(getByText("Connected with \"Cardano Foundation\"")).toBeVisible()
-    );
-
-    await waitFor(() => {
-      expect(getByTestId("connection-detail-date")).toBeVisible();
-      expect(getByTestId("connection-detail-date")).toHaveTextContent(
-        `${formatShortDate(
-          connectionsFix[2].connectionDate
-        )} - ${formatTimeToSec(connectionsFix[2].connectionDate)}`
-      );
-    });
-
-    await waitFor(() =>
-      expect(getByText("Received \"Access Pass Credential\"")).toBeVisible()
-    );
-
-    await waitFor(() =>
-      expect(getByTestId("connection-history-timestamp")).toHaveTextContent(
-        `${formatShortDate("2024-02-15T10:16:08.756Z")} - ${formatTimeToSec(
-          "2024-02-15T10:16:08.756Z"
-        )}`
-      )
-    );
-  });
-
-  test("We can see the connection details for PermanentResidentCard", async () => {
-    jest
-      .spyOn(Agent.agent.connections, "getConnectionById")
-      .mockResolvedValue(connectionsFix[1]);
-
-    jest
-      .spyOn(Agent.agent.connections, "getConnectionHistoryById")
-      .mockResolvedValue([
-        {
-          type: 0,
-          timestamp: "2024-02-13T10:16:26.919Z",
-          credentialType: "PermanentResidentCard",
-        },
-      ]);
-
-    const storeMocked = {
-      ...mockStore(initialStateFull),
-      dispatch: dispatchMock,
-    };
-    const { getByTestId, queryByTestId, getByText } = render(
-      <MemoryRouter initialEntries={[TabsRoutePath.CREDENTIALS]}>
-        <Provider store={storeMocked}>
-          <Route
-            path={TabsRoutePath.CREDENTIALS}
-            component={Creds}
-          />
-
-          <Route
-            path={RoutePath.CONNECTION_DETAILS}
-            component={ConnectionDetails}
-          />
-        </Provider>
-      </MemoryRouter>
-    );
-
-    act(() => {
-      fireEvent.click(getByTestId("connections-button"));
-    });
-
-    await waitFor(() => {
-      expect(queryByTestId("connection-item-0")).toBeNull();
-    });
-
-    expect(getByText(connectionsFix[1].label)).toBeVisible();
-
-    act(() => {
-      fireEvent.click(getByText(connectionsFix[1].label));
-    });
-
-    await waitFor(() =>
-      expect(getByText("Connected with \"Passport Office\"")).toBeVisible()
-    );
-
-    await waitFor(() => {
-      expect(getByTestId("connection-detail-date")).toBeVisible();
-      expect(getByTestId("connection-detail-date")).toHaveTextContent(
-        `${formatShortDate(
-          connectionsFix[1].connectionDate
-        )} - ${formatTimeToSec(connectionsFix[1].connectionDate)}`
-      );
-    });
 
     await waitFor(() =>
       expect(getByText("Received \"Permanent Resident Card\"")).toBeVisible()
     );
 
     await waitFor(() =>
-      expect(getByTestId("connection-history-timestamp")).toHaveTextContent(
-        `${formatShortDate("2024-02-13T10:16:26.919Z")} - ${formatTimeToSec(
-          "2024-02-13T10:16:26.919Z"
-        )}`
-      )
+      expect(getByText("14/02/2024 - 10:16:26")).toBeVisible()
     );
-  });
-
-  test("We can see the connection details for Qualified vLEI Issuer", async () => {
-    jest
-      .spyOn(Agent.agent.connections, "getConnectionById")
-      .mockResolvedValue(connectionsFix[3]);
-
-    jest
-      .spyOn(Agent.agent.connections, "getConnectionHistoryById")
-      .mockResolvedValue([
-        {
-          type: 0,
-          timestamp: "2024-02-13T11:39:22.919Z",
-          credentialType: "Qualified vLEI Issuer Credential",
-        },
-      ]);
-
-    const storeMocked = {
-      ...mockStore(initialStateFull),
-      dispatch: dispatchMock,
-    };
-    const { getByTestId, queryByTestId, getByText } = render(
-      <MemoryRouter initialEntries={[TabsRoutePath.CREDENTIALS]}>
-        <Provider store={storeMocked}>
-          <Route
-            path={TabsRoutePath.CREDENTIALS}
-            component={Creds}
-          />
-
-          <Route
-            path={RoutePath.CONNECTION_DETAILS}
-            component={ConnectionDetails}
-          />
-        </Provider>
-      </MemoryRouter>
-    );
-
-    act(() => {
-      fireEvent.click(getByTestId("connections-button"));
-    });
-
-    await waitFor(() => {
-      expect(queryByTestId("connection-item-0")).toBeNull();
-    });
-
-    expect(getByText(connectionsFix[3].label)).toBeVisible();
-
-    act(() => {
-      fireEvent.click(getByText(connectionsFix[3].label));
-    });
 
     await waitFor(() =>
-      expect(getByText("Connected with \"John Smith\"")).toBeVisible()
+      expect(getByText("Received \"Access Pass Credential\"")).toBeVisible()
     );
 
-    await waitFor(() => {
-      expect(getByTestId("connection-detail-date")).toBeVisible();
-      expect(getByTestId("connection-detail-date")).toHaveTextContent(
-        `${formatShortDate(
-          connectionsFix[3].connectionDate
-        )} - ${formatTimeToSec(connectionsFix[3].connectionDate)}`
-      );
-    });
+    await waitFor(() =>
+      expect(getByText("15/02/2024 - 10:16:08")).toBeVisible()
+    );
 
     await waitFor(() =>
       expect(
@@ -949,11 +750,11 @@ describe("Checking the Connection Details Page when different Credentials are is
     );
 
     await waitFor(() =>
-      expect(getByTestId("connection-history-timestamp")).toHaveTextContent(
-        `${formatShortDate("2024-02-13T11:39:22.919Z")} - ${formatTimeToSec(
-          "2024-02-13T11:39:22.919Z"
-        )}`
-      )
+      expect(getByText("16/02/2024 - 11:39:22")).toBeVisible()
+    );
+
+    await waitFor(() =>
+      expect(getByText("Connected with \"Cambridge University\"")).toBeVisible()
     );
   });
 });

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.tsx
@@ -260,32 +260,36 @@ const ConnectionDetails = () => {
                 className="connection-details-history"
                 title={i18n.t("connections.details.history")}
               >
-                {connectionHistory?.length > 0 && (
-                  <div className="connection-details-history-event">
-                    <div className="connection-details-logo">
-                      <img
-                        src={Minicred}
-                        alt="credential-miniature"
-                        className="credential-miniature"
-                      />
-                    </div>
-                    <p className="connection-details-history-event-info">
-                      {i18next.t("connections.details.received", {
-                        credential: connectionHistory[0]?.credentialType
-                          ?.replace(/([A-Z][a-z])/g, " $1")
-                          .replace(/^ /, "")
-                          .replace(/(\d)/g, "$1"),
-                      })}
-                      <span data-testid="connection-history-timestamp">
-                        {` ${formatShortDate(
-                          connectionHistory[0]?.timestamp
-                        )} - ${formatTimeToSec(
-                          connectionHistory[0]?.timestamp
-                        )}`}
-                      </span>
-                    </p>
-                  </div>
-                )}
+                {connectionHistory?.length > 0 &&
+                  connectionHistory.map(
+                    (historyItem: ConnectionHistoryItem, index: number) => (
+                      <div
+                        className="connection-details-history-event"
+                        key={index}
+                      >
+                        <div className="connection-details-logo">
+                          <img
+                            src={Minicred}
+                            alt="credential-miniature"
+                            className="credential-miniature"
+                          />
+                        </div>
+                        <p className="connection-details-history-event-info">
+                          {i18next.t("connections.details.received", {
+                            credential: historyItem.credentialType
+                              ?.replace(/([A-Z][a-z])/g, " $1")
+                              .replace(/^ /, "")
+                              .replace(/(\d)/g, "$1"),
+                          })}
+                          <span data-testid="connection-history-timestamp">
+                            {` ${formatShortDate(
+                              historyItem.timestamp
+                            )} - ${formatTimeToSec(historyItem.timestamp)}`}
+                          </span>
+                        </p>
+                      </div>
+                    )
+                  )}
                 <div className="connection-details-history-event">
                   <div className="connection-details-logo">
                     <img


### PR DESCRIPTION
## Description

Fixing bug that will allow to map and display all history events in a connection page.

Only taking screenshot in the browser to show that it's working as I am not really adding anything new to the UI.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1150**](https://cardanofoundation.atlassian.net/browse/DTIS-1150)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser
![29072024164716](https://github.com/user-attachments/assets/c2b5e7d7-e0f4-4969-ba1b-698158b01a9a)
