### PR TITLE
feat(ui): Help center contacts missing

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1053,7 +1053,8 @@
           },
           "help": {
             "title": "Need help?",
-            "detailtext": "If you need assistance, please refer to our Help Center or contact support."
+            "detailtext": "If you need assistance, please message us on our <0>{{discordSupportChannel}}</0>.",
+            "supportchannel": "Discord support channel"
           },
           "continuesetup": "Continue setup"
         }

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.scss
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.scss
@@ -1,5 +1,7 @@
 .notification-details-multi-sig-feedback {
   .page-header {
+    margin-top: 0.625rem;
+
     ion-toolbar {
       --background: transparent;
     }

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.tsx
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.tsx
@@ -1,6 +1,8 @@
 import { IonIcon, IonText } from "@ionic/react";
 import { alertCircleOutline } from "ionicons/icons";
 import { useState } from "react";
+import { Trans } from "react-i18next";
+import { Browser } from "@capacitor/browser";
 import { IdentifierShortDetails } from "../../../../../core/agent/services/identifier.types";
 import { i18n } from "../../../../../i18n";
 import { useAppSelector } from "../../../../../store/hooks";
@@ -13,6 +15,7 @@ import { PageFooter } from "../../../../components/PageFooter";
 import { PageHeader } from "../../../../components/PageHeader";
 import "./ErrorPage.scss";
 import { ErrorPageProps } from "./ErrorPage.types";
+import { DISCORD_LINK } from "../../../../globals/constants";
 
 const ErrorPage = ({
   pageId,
@@ -46,6 +49,19 @@ const ErrorPage = ({
   const handleCloseCreateIdentifier = () => {
     setCreateIdentifierModalIsOpen(false);
     onFinishSetup();
+  };
+
+  const HandleDiscordLink = () => {
+    return (
+      <u
+        data-testid="discord-link-browser-handler"
+        onClick={() => Browser.open({ url: DISCORD_LINK })}
+      >
+        {i18n.t(
+          "notifications.details.identifier.errorpage.help.supportchannel"
+        )}
+      </u>
+    );
   };
 
   return (
@@ -119,9 +135,12 @@ const ErrorPage = ({
             {i18n.t("notifications.details.identifier.errorpage.help.title")}
           </h2>
           <IonText className="detail-text">
-            {i18n.t(
-              "notifications.details.identifier.errorpage.help.detailtext"
-            )}
+            <Trans
+              i18nKey={i18n.t(
+                "notifications.details.identifier.errorpage.help.detailtext"
+              )}
+              components={[<HandleDiscordLink key="" />]}
+            />
           </IonText>
         </div>
       </ScrollablePageLayout>


### PR DESCRIPTION
## Description

Adding link to our Discord channel on the error page when a multi sig participant has forgotten to scan someone in their group.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1092**](https://cardanofoundation.atlassian.net/browse/DTIS-1092)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS


https://github.com/user-attachments/assets/91d4c9cf-ee5a-4af7-863c-cd1853f98680



#### Android


https://github.com/user-attachments/assets/6a6dca2a-3e5f-48c4-ae12-58fe5ba9f5a7



#### Browser


https://github.com/user-attachments/assets/8c13c999-9a67-479f-9822-74b36b750692

