### PR TITLE
fix(ui): Credential animation cut off when credential received too fast

### DIFF
--- a/src/ui/components/ArchivedCredentials/ArchivedCredentials.tsx
+++ b/src/ui/components/ArchivedCredentials/ArchivedCredentials.tsx
@@ -44,6 +44,7 @@ import { ScrollablePageLayout } from "../layout/ScrollablePageLayout";
 import { PageHeader } from "../PageHeader";
 import { CredentialItem } from "./CredentialItem";
 import { TabsRoutePath } from "../navigation/TabsMenu";
+import { setCredsArchivedCache } from "../../../store/reducers/credsArchivedCache";
 
 const ArchivedCredentialsContainer = forwardRef<
   ArchivedCredentialsContainerRef,
@@ -135,6 +136,9 @@ const ArchivedCredentialsContainer = forwardRef<
       if (restoreSuccessCrendentials.length === 0) return;
 
       dispatch(setCredsCache([...credsCache, ...restoreSuccessCrendentials]));
+
+      const creds = await Agent.agent.credentials.getCredentials(true);
+      dispatch(setCredsArchivedCache(creds));
     } catch (e) {
       // TODO: Handle error
     }

--- a/src/ui/pages/CredentialDetails/CredentialDetails.tsx
+++ b/src/ui/pages/CredentialDetails/CredentialDetails.tsx
@@ -57,6 +57,7 @@ import { CredentialContent } from "./components/CredentialContent";
 import "./CredentialDetails.scss";
 import { CredHistory } from "./CredentialDetails.types";
 import { NotificationDetailCacheState } from "../../../store/reducers/notificationsCache/notificationCache.types";
+import { setCredsArchivedCache } from "../../../store/reducers/credsArchivedCache";
 
 const NAVIGATION_DELAY = 250;
 const CLEAR_ANIMATION = 1000;
@@ -89,6 +90,15 @@ const CredentialDetails = () => {
   const isArchived =
     credsCache.filter((item) => item.id === params.id).length === 0;
   const isFavourite = favouritesCredsCache?.some((fav) => fav.id === params.id);
+
+  const fetchArchivedCreds = useCallback(async () => {
+    try {
+      const creds = await Agent.agent.credentials.getCredentials(true);
+      dispatch(setCredsArchivedCache(creds));
+    } catch (e) {
+      // @TODO - duke: handle error
+    }
+  }, [dispatch]);
 
   const getCredDetails = useCallback(async () => {
     const cardDetails = await Agent.agent.credentials.getCredentialDetailsById(
@@ -158,6 +168,7 @@ const CredentialDetails = () => {
 
   const handleArchiveCredential = async () => {
     await Agent.agent.credentials.archiveCredential(params.id);
+    await fetchArchivedCreds();
     const creds = credsCache.filter((item) => item.id !== params.id);
     if (isFavourite) {
       handleSetFavourite(params.id);
@@ -171,6 +182,7 @@ const CredentialDetails = () => {
     // @TODO - sdisalvo: handle error
     await Agent.agent.credentials.deleteCredential(params.id);
     dispatch(setToastMsg(ToastMsgType.CREDENTIAL_DELETED));
+    await fetchArchivedCreds();
   };
 
   const handleRestoreCredential = async () => {
@@ -179,6 +191,7 @@ const CredentialDetails = () => {
     const creds = await Agent.agent.credentials.getCredentialShortDetailsById(
       params.id
     );
+    await fetchArchivedCreds();
     dispatch(setCredsCache([...credsCache, creds]));
 
     dispatch(setToastMsg(ToastMsgType.CREDENTIAL_RESTORED));

--- a/src/ui/pages/Credentials/Credentials.tsx
+++ b/src/ui/pages/Credentials/Credentials.tsx
@@ -4,34 +4,33 @@ import {
   IonLabel,
   useIonViewWillEnter,
 } from "@ionic/react";
-import { peopleOutline, addOutline } from "ionicons/icons";
+import { addOutline, peopleOutline } from "ionicons/icons";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { TabLayout } from "../../components/layout/TabLayout";
-import { i18n } from "../../../i18n";
-import "./Credentials.scss";
-import { CardsPlaceholder } from "../../components/CardsPlaceholder";
-import { CardsStack } from "../../components/CardsStack";
-import { useAppDispatch, useAppSelector } from "../../../store/hooks";
-import {
-  getToastMsg,
-  setCurrentOperation,
-  setCurrentRoute,
-} from "../../../store/reducers/stateCache";
-import { TabsRoutePath } from "../../../routes/paths";
-import { Connections } from "../Connections";
-import { CardType, OperationType, ToastMsgType } from "../../globals/types";
-import { ArchivedCredentials } from "../../components/ArchivedCredentials";
 import { Agent } from "../../../core/agent/agent";
-import {
-  getCredsCache,
-  getFavouritesCredsCache,
-} from "../../../store/reducers/credsCache";
-import { StartAnimationSource } from "../Identifiers/Identifiers.type";
-import { useOnlineStatusEffect, useToggleConnections } from "../../hooks";
+import { i18n } from "../../../i18n";
+import { TabsRoutePath } from "../../../routes/paths";
+import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
   getCredsArchivedCache,
   setCredsArchivedCache,
 } from "../../../store/reducers/credsArchivedCache";
+import {
+  getCredsCache,
+  getFavouritesCredsCache,
+} from "../../../store/reducers/credsCache";
+import {
+  setCurrentOperation,
+  setCurrentRoute,
+} from "../../../store/reducers/stateCache";
+import { ArchivedCredentials } from "../../components/ArchivedCredentials";
+import { CardsPlaceholder } from "../../components/CardsPlaceholder";
+import { CardsStack } from "../../components/CardsStack";
+import { TabLayout } from "../../components/layout/TabLayout";
+import { CardType, OperationType } from "../../globals/types";
+import { useOnlineStatusEffect, useToggleConnections } from "../../hooks";
+import { Connections } from "../Connections";
+import { StartAnimationSource } from "../Identifiers/Identifiers.type";
+import "./Credentials.scss";
 
 const CLEAR_STATE_DELAY = 1000;
 
@@ -80,7 +79,6 @@ const Creds = () => {
   const credsCache = useAppSelector(getCredsCache);
   const archivedCreds = useAppSelector(getCredsArchivedCache);
   const favCredsCache = useAppSelector(getFavouritesCredsCache);
-  const toastMsg = useAppSelector(getToastMsg);
 
   const [archivedCredentialsIsOpen, setArchivedCredentialsIsOpen] =
     useState(false);
@@ -93,30 +91,19 @@ const Creds = () => {
   );
 
   const fetchArchivedCreds = useCallback(async () => {
-    // @TODO - sdisalvo: handle error
-    const creds = await Agent.agent.credentials.getCredentials(true);
-    dispatch(setCredsArchivedCache(creds));
+    try {
+      const creds = await Agent.agent.credentials.getCredentials(true);
+      dispatch(setCredsArchivedCache(creds));
+    } catch (e) {
+      // @TODO - duke: handle error
+    }
   }, [dispatch]);
 
   useEffect(() => {
     setShowPlaceholder(credsCache.length === 0);
   }, [credsCache]);
 
-  const fetchDataUpdateCred = useCallback(() => {
-    const validToastMsgTypes = [
-      ToastMsgType.CREDENTIAL_ARCHIVED,
-      ToastMsgType.CREDENTIAL_RESTORED,
-      ToastMsgType.CREDENTIALS_RESTORED,
-      ToastMsgType.CREDENTIAL_DELETED,
-      ToastMsgType.CREDENTIALS_DELETED,
-    ];
-
-    if (toastMsg && validToastMsgTypes.includes(toastMsg)) {
-      fetchArchivedCreds();
-    }
-  }, [fetchArchivedCreds, toastMsg]);
-
-  useOnlineStatusEffect(fetchDataUpdateCred);
+  useOnlineStatusEffect(fetchArchivedCreds);
 
   const handleCreateCred = () => {
     dispatch(setCurrentOperation(OperationType.SCAN_CONNECTION));

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -57,8 +57,8 @@ const ReceiveCredential = ({
   const handleAccept = async () => {
     setInitiateAnimation(true);
     await Agent.agent.ipexCommunications.acceptAcdc(notificationDetails.id);
-    handleNotificationUpdate();
     setTimeout(() => {
+      handleNotificationUpdate();
       handleBack();
     }, ANIMATION_DELAY);
   };

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCrendential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCrendential.test.tsx
@@ -12,6 +12,7 @@ import { notificationsFix } from "../../../../__fixtures__/notificationsFix";
 import { ReceiveCredential } from "./ReceiveCredential";
 
 mockIonicReact();
+jest.useFakeTimers();
 
 const deleteNotificationMock = jest.fn((id: string) => Promise.resolve(id));
 const acceptAcdcMock = jest.fn((id: string) => Promise.resolve(id));
@@ -128,10 +129,17 @@ describe("Credential request", () => {
       expect(acceptAcdcMock).toBeCalledWith(notificationsFix[0].id);
     });
 
-    const newNotification = notificationsFix.filter(
-      (notification) => notification.id !== notificationsFix[0].id
-    );
+    await act(async () => {
+      jest.runAllTimers();
+      const newNotification = notificationsFix.filter(
+        (notification) => notification.id !== notificationsFix[0].id
+      );
 
-    expect(dispatchMock).lastCalledWith(setNotificationsCache(newNotification));
-  });
+      await waitFor(() => {
+        expect(dispatchMock).lastCalledWith(
+          setNotificationsCache(newNotification)
+        );
+      });
+    });
+  }, 10000);
 });


### PR DESCRIPTION
## Description

Fix credential animation cut off when credential received too fast

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1168](https://cardanofoundation.atlassian.net/browse/DTIS-1168)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Cred animation

https://github.com/user-attachments/assets/02664ac4-e6ce-41b1-8cff-230b86ea9bd8

#### Remove Fetch Archived Cred By Toast Message

https://github.com/user-attachments/assets/6b5da1a2-af47-4446-810f-d07471a4bee3



[DTIS-1168]: https://cardanofoundation.atlassian.net/browse/DTIS-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ