### PR TITLE
docs(readme): update cred server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 # SSI Services
 - [KERIA Cloud Agent](https://github.com/cardano-foundation/keria)
 - [Signify-TS Edge Client](https://github.com/cardano-foundation/signify-ts)
-- [Verifiable Credential Testing Tool](https://identity-wallet-credential-issuance-web-interface.vercel.app/)
+- [Verifiable Credential Testing Tool](https://dev.credentials-ui.cf-keripy.metadata.dev.cf-deployments.org/)
 - [KERI on Cardano](https://github.com/cardano-foundation/cardano-backer)
 
 # Preview in your Browser


### PR DESCRIPTION
URL for deployments against the default KERIA URL for Vercel and mobile deployments.

Soon, these will all move to our K8s setup.