### PR TITLE
fix(core): db transaction per migration

### DIFF
--- a/src/core/storage/sqliteStorage/migrations/index.ts
+++ b/src/core/storage/sqliteStorage/migrations/index.ts
@@ -1,14 +1,8 @@
-import { SQLiteDBConnection } from "@capacitor-community/sqlite";
+import { SqlMigration, TsMigration } from "./migrations.types";
 import { DATA_V001 } from "./v0.0.1-init_sql";
 import { DATA_V002 } from "./v0.0.2-credentialPrefix";
 
-export const MIGRATIONS: {
-  version: string;
-  sql?: string[];
-  migrationStatements?: (session: SQLiteDBConnection) => Promise<
-    {
-      statement: string;
-      values?: unknown[];
-    }[]
-  >;
-}[] = [DATA_V001, DATA_V002];
+type Migration = SqlMigration | TsMigration;
+const MIGRATIONS: Migration[] = [DATA_V001, DATA_V002];
+
+export { MIGRATIONS };

--- a/src/core/storage/sqliteStorage/migrations/migrations.types.ts
+++ b/src/core/storage/sqliteStorage/migrations/migrations.types.ts
@@ -1,0 +1,29 @@
+import { SQLiteDBConnection } from "@capacitor-community/sqlite";
+
+enum MigrationType {
+  SQL,
+  TS,
+}
+
+type BaseMigration = {
+  version: string;
+};
+
+type SqlMigration = BaseMigration & {
+  type: MigrationType.SQL;
+  sql: string[];
+};
+
+type TsMigration = BaseMigration & {
+  type: MigrationType.TS;
+  migrationStatements: (session: SQLiteDBConnection) => Promise<
+    {
+      statement: string;
+      values?: unknown[];
+    }[]
+  >;
+};
+
+export { MigrationType };
+
+export type { SqlMigration, TsMigration };

--- a/src/core/storage/sqliteStorage/migrations/v0.0.1-init_sql.ts
+++ b/src/core/storage/sqliteStorage/migrations/v0.0.1-init_sql.ts
@@ -1,4 +1,7 @@
-const DATA_V001 = {
+import { MigrationType, SqlMigration } from "./migrations.types";
+
+const DATA_V001: SqlMigration = {
+  type: MigrationType.SQL,
   version: "0.0.1",
   sql: [
     "CREATE TABLE IF NOT EXISTS kv (key text unique, value text)",

--- a/src/core/storage/sqliteStorage/migrations/v0.0.2-credentialPrefix.ts
+++ b/src/core/storage/sqliteStorage/migrations/v0.0.2-credentialPrefix.ts
@@ -4,8 +4,10 @@ import { resolveTagsFromDb } from "../utils";
 import { StorageRecord } from "../../storage.types";
 import { CredentialMetadataRecord } from "../../../agent/records";
 import { deserializeRecord } from "../../utils";
+import { MigrationType, TsMigration } from "./migrations.types";
 
-export const DATA_V002 = {
+export const DATA_V002: TsMigration = {
+  type: MigrationType.TS,
   version: "0.0.2",
   migrationStatements: (session: SQLiteDBConnection) =>
     credentialStatements(session),

--- a/src/core/storage/sqliteStorage/utils.ts
+++ b/src/core/storage/sqliteStorage/utils.ts
@@ -1,40 +1,5 @@
-import { SQLiteDBConnection } from "@capacitor-community/sqlite";
 import { BasicRecord } from "../../agent/records";
 import { Query } from "../storage.types";
-import { MIGRATIONS } from "./migrations";
-
-async function getMigrationsToApply(
-  session: SQLiteDBConnection,
-  currentVersion: string
-): Promise<{ statement: string; values?: unknown[] }[] | null> {
-  const versionArr: string[] = [];
-  MIGRATIONS.forEach((migration) => {
-    versionArr.push(migration.version);
-  });
-  versionArr.sort((a, b) => versionCompare(a, b));
-  const latestVersion = versionArr[versionArr.length - 1];
-  if (versionCompare(latestVersion, currentVersion) == 0) {
-    return null;
-  }
-
-  const migrationStatements: { statement: string; values?: unknown[] }[] = [];
-  for (const migration of MIGRATIONS) {
-    if (versionCompare(currentVersion, migration.version) == -1) {
-      if (migration?.sql) {
-        migration?.sql.forEach((sql) => {
-          migrationStatements.push({
-            statement: sql,
-          });
-        });
-      } else if (migration.migrationStatements) {
-        const statements = await migration.migrationStatements(session);
-        migrationStatements.push(...statements);
-      }
-    }
-  }
-
-  return migrationStatements;
-}
 
 function isValidPart(x: string): boolean {
   return /^\d+$/.test(x);
@@ -126,7 +91,6 @@ function convertDbQuery(params: Query<BasicRecord>): Record<string, unknown> {
 }
 
 export {
-  getMigrationsToApply,
   versionCompare,
   convertDbQuery,
   resolveTagsFromDb,


### PR DESCRIPTION
## Description

Recently we added a `0.0.2` migration which reads JSON blobs from the DB and updates them. This requires the tables to be in place.

Since we were migrating all outstanding migrations in one single transaction, this is a problem as the SQL statements to apply required tables to already be in place.

The simplest and most safe thing to do here is to have a single transaction per migration and write the new version each time.

Manual testing on the previous PR was against wallets which were already on `0.0.1` so the issue didn't surface. E2E tests when integrated will solve that though.

This PR also adds better typing to the migrations.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
