### PR TITLE
fix(ui): Closing settings animation is sluggish but cardano connect is not

### DIFF
--- a/src/ui/components/SideSlider/SideSlider.scss
+++ b/src/ui/components/SideSlider/SideSlider.scss
@@ -5,12 +5,4 @@
   height: 100%;
   width: 100%;
   transform: translateX(100%);
-  transition-duration: 0.5s;
-  transition-property: transform;
-
-  &.open {
-    transform: translateX(0);
-    transition-duration: 0.5s;
-    transition-property: transform;
-  }
 }

--- a/src/ui/components/SideSlider/SideSlider.test.tsx
+++ b/src/ui/components/SideSlider/SideSlider.test.tsx
@@ -70,10 +70,6 @@ describe("Side Slider", () => {
       ).toBe(true);
     });
 
-    act(() => {
-      fireEvent.transitionEnd(getByTestId("side-slider"));
-    });
-
     await waitFor(() => {
       expect(openAnimation).toBeCalled();
     });
@@ -87,10 +83,6 @@ describe("Side Slider", () => {
         <div>Content</div>
       </SideSlider>
     );
-
-    act(() => {
-      fireEvent.transitionEnd(getByTestId("side-slider"));
-    });
 
     await waitFor(() => {
       expect(endAnimation).toBeCalled();

--- a/src/ui/components/SideSlider/SideSlider.tsx
+++ b/src/ui/components/SideSlider/SideSlider.tsx
@@ -14,7 +14,7 @@ const SideSlider = ({
   onOpenAnimationEnd,
   onCloseAnimationEnd,
 }: SideSliderProps) => {
-  const prevOpenState = useRef(isOpen);
+  const prevOpenState = useRef(false);
   const sliderEl = useRef<HTMLDivElement | null>(null);
 
   const slideAnimation = (baseEl: HTMLElement) => {

--- a/src/ui/components/SideSlider/SideSlider.tsx
+++ b/src/ui/components/SideSlider/SideSlider.tsx
@@ -14,6 +14,7 @@ const SideSlider = ({
   onOpenAnimationEnd,
   onCloseAnimationEnd,
 }: SideSliderProps) => {
+  const prevOpenState = useRef(isOpen);
   const sliderEl = useRef<HTMLDivElement | null>(null);
 
   const slideAnimation = (baseEl: HTMLElement) => {
@@ -51,7 +52,10 @@ const SideSlider = ({
   );
 
   useEffect(() => {
-    if (!sliderEl?.current || renderAsModal) return;
+    // NOTE: Because IonApp renders twice, it make leave animation run when page render. Need check isOpen state change to make sure animation run correctly.
+    if (!sliderEl?.current || renderAsModal || prevOpenState.current === isOpen)
+      return;
+    prevOpenState.current = isOpen;
 
     if (!isOpen) {
       leaveAnimation(sliderEl.current).play();
@@ -83,9 +87,6 @@ const SideSlider = ({
         zIndex,
       }}
       data-testid="side-slider"
-      onTransitionEnd={() => {
-        isOpen ? onOpenAnimationEnd?.() : onCloseAnimationEnd?.();
-      }}
       className={classes}
     >
       {children}

--- a/src/ui/components/SideSlider/SideSlider.types.ts
+++ b/src/ui/components/SideSlider/SideSlider.types.ts
@@ -10,6 +10,6 @@ interface SideSliderProps {
   onCloseAnimationEnd?: () => void;
 }
 
-export const ANIMATION_DURATION = 500;
+export const ANIMATION_DURATION = 300;
 
 export type { SideSliderProps };


### PR DESCRIPTION
## Description

Fix Closing settings animation is sluggish. Beside that, I also fixed cadarno connect open animation missing after close setting.

https://github.com/user-attachments/assets/9a7c45c9-2dd4-49d2-9ff7-ef738640e32b

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1198](https://cardanofoundation.atlassian.net/browse/DTIS-1198)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/d4c2c127-45e9-4a5e-b35e-185ce97a7798

#### Android

https://github.com/user-attachments/assets/e3ebc72c-080f-4347-93e0-a8bef0a4a5f1

#### Browser

https://github.com/user-attachments/assets/3b6ba284-91c4-47bd-b9b7-6dd7c7800f55



[DTIS-1198]: https://cardanofoundation.atlassian.net/browse/DTIS-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ