### PR TITLE
feat(ui): Disallow screenshots on recovery phase, hide app contents when in app switcher

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':aparajita-capacitor-biometric-auth')
     implementation project(':aparajita-capacitor-secure-storage')
     implementation project(':capacitor-community-barcode-scanner')
+    implementation project(':capacitor-community-privacy-screen')
     implementation project(':capacitor-community-sqlite')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -11,6 +11,9 @@ project(':aparajita-capacitor-secure-storage').projectDir = new File('../node_mo
 include ':capacitor-community-barcode-scanner'
 project(':capacitor-community-barcode-scanner').projectDir = new File('../node_modules/@capacitor-community/barcode-scanner/android')
 
+include ':capacitor-community-privacy-screen'
+project(':capacitor-community-privacy-screen').projectDir = new File('../node_modules/@capacitor-community/privacy-screen/android')
+
 include ':capacitor-community-sqlite'
 project(':capacitor-community-sqlite').projectDir = new File('../node_modules/@capacitor-community/sqlite/android')
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -21,6 +21,10 @@ const config: CapacitorConfig = {
       launchFadeOutDuration: 1000,
       backgroundColor: "#92FFC0"
     },
+    PrivacyScreen: {
+      enable: false,
+      imageName: "Splashscreen",
+    }
   }
 };
 

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -14,6 +14,7 @@ def capacitor_pods
   pod 'AparajitaCapacitorBiometricAuth', :path => '../../node_modules/@aparajita/capacitor-biometric-auth'
   pod 'AparajitaCapacitorSecureStorage', :path => '../../node_modules/@aparajita/capacitor-secure-storage'
   pod 'CapacitorCommunityBarcodeScanner', :path => '../../node_modules/@capacitor-community/barcode-scanner'
+  pod 'CapacitorCommunityPrivacyScreen', :path => '../../node_modules/@capacitor-community/privacy-screen'
   pod 'CapacitorCommunitySqlite', :path => '../../node_modules/@capacitor-community/sqlite'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -14,6 +14,8 @@ PODS:
     - Capacitor
   - CapacitorCommunityBarcodeScanner (4.0.1):
     - Capacitor
+  - CapacitorCommunityPrivacyScreen (4.2.4):
+    - Capacitor
   - CapacitorCommunitySqlite (5.7.1):
     - Capacitor
     - SQLCipher
@@ -49,6 +51,7 @@ DEPENDENCIES:
   - "CapacitorBrowser (from `../../node_modules/@capacitor/browser`)"
   - "CapacitorClipboard (from `../../node_modules/@capacitor/clipboard`)"
   - "CapacitorCommunityBarcodeScanner (from `../../node_modules/@capacitor-community/barcode-scanner`)"
+  - "CapacitorCommunityPrivacyScreen (from `../../node_modules/@capacitor-community/privacy-screen`)"
   - "CapacitorCommunitySqlite (from `../../node_modules/@capacitor-community/sqlite`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
@@ -80,6 +83,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/clipboard"
   CapacitorCommunityBarcodeScanner:
     :path: "../../node_modules/@capacitor-community/barcode-scanner"
+  CapacitorCommunityPrivacyScreen:
+    :path: "../../node_modules/@capacitor-community/privacy-screen"
   CapacitorCommunitySqlite:
     :path: "../../node_modules/@capacitor-community/sqlite"
   CapacitorCordova:
@@ -107,6 +112,7 @@ SPEC CHECKSUMS:
   CapacitorBrowser: 53c2279785c2f67059439445647c8ad90150e1ae
   CapacitorClipboard: 45e5e25f2271f98712985d422776cdc5a779cca1
   CapacitorCommunityBarcodeScanner: 7feb206489c8555a8ca0c74c57ddf49ead774eb8
+  CapacitorCommunityPrivacyScreen: c41be3be02d46881131a4d66ac2aeb48f287f41f
   CapacitorCommunitySqlite: 6e2754dde799d618a8e75e409ccc67ec9c189460
   CapacitorCordova: a6e87fccc0307dee7aec1560ec9398485f2b0ce7
   CapacitorKeyboard: aec619a578235c6ce279075009a2689c2cf5c42c
@@ -120,6 +126,6 @@ SPEC CHECKSUMS:
   SQLCipher: f2e96b3822e3006b379181a0e4fd145f6de29b56
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: d5b050af5bcdbe71a0d8afcc492444499451cd91
+PODFILE CHECKSUM: 27d4918c25a2a97ee52a92d9ba0fd28a9469539c
 
 COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aparajita/capacitor-biometric-auth": "^8.0.0",
         "@aparajita/capacitor-secure-storage": "^5.0.0",
         "@capacitor-community/barcode-scanner": "^4.0.1",
+        "@capacitor-community/privacy-screen": "^4.2.4",
         "@capacitor-community/sqlite": "^5.5.0",
         "@capacitor/android": "^5.0.0",
         "@capacitor/app": "^5.0.7",
@@ -4063,6 +4064,14 @@
         "@zxing/browser": "^0.1.3",
         "@zxing/library": "^0.20.0"
       },
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
+    },
+    "node_modules/@capacitor-community/privacy-screen": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/privacy-screen/-/privacy-screen-4.2.4.tgz",
+      "integrity": "sha512-vpPASpwjJZpK6O7rt7+bP3F2Roxi/QvkaehLgtCxksTvUdKd2NFdaXzB70vRJYb1wp8s/af/zjUyuZpA1j2/1A==",
       "peerDependencies": {
         "@capacitor/core": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@aparajita/capacitor-biometric-auth": "^8.0.0",
     "@aparajita/capacitor-secure-storage": "^5.0.0",
     "@capacitor-community/barcode-scanner": "^4.0.1",
+    "@capacitor-community/privacy-screen": "^4.2.4",
     "@capacitor-community/sqlite": "^5.5.0",
     "@capacitor/android": "^5.0.0",
     "@capacitor/app": "^5.0.7",

--- a/src/ui/components/SeedPhraseModule/SeedPhraseModule.tsx
+++ b/src/ui/components/SeedPhraseModule/SeedPhraseModule.tsx
@@ -8,6 +8,7 @@ import {
   SeedPhraseModuleProps,
   SeedPhraseModuleRef,
 } from "./SeedPhraseModule.types";
+import { usePrivacyScreen } from "../../hooks/privacyScreenHook";
 
 const SeedPhraseModule = forwardRef<SeedPhraseModuleRef, SeedPhraseModuleProps>(
   (
@@ -31,6 +32,7 @@ const SeedPhraseModule = forwardRef<SeedPhraseModuleRef, SeedPhraseModuleProps>(
     ref
   ) => {
     const seedInputs = useRef<(HTMLElement | null)[]>([]);
+    usePrivacyScreen();
 
     useImperativeHandle(ref, () => ({
       focusInputByIndex: (index) => {

--- a/src/ui/hooks/privacyScreenHook.ts
+++ b/src/ui/hooks/privacyScreenHook.ts
@@ -1,0 +1,23 @@
+import { PrivacyScreen } from "@capacitor-community/privacy-screen";
+import { Capacitor } from "@capacitor/core";
+import { useEffect, useRef } from "react";
+
+const usePrivacyScreen = () => {
+  const unmount = useRef(false);
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+
+    setTimeout(() => {
+      if (unmount.current) return;
+      PrivacyScreen.enable();
+    }, 250);
+
+    return () => {
+      unmount.current = true;
+      PrivacyScreen.disable();
+    };
+  }, []);
+};
+
+export { usePrivacyScreen };


### PR DESCRIPTION
## Description

Disallow screenshots on recovery phase, hide app contents when in app switcher

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1202](https://cardanofoundation.atlassian.net/browse/DTIS-1202)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Android
It seem this plugin is not working on emulator. Therefore, I tried to test on my android phone. (So sorry if video so shaky, I need use another phone to record it)

##### Onboarding Seed Phrase (Generate seed phrase, Verify seed phrase and recovery seed phrase)

https://github.com/user-attachments/assets/2784f72c-a2be-452d-8ed1-1caf658c83b8

##### Forgot passcode

https://github.com/user-attachments/assets/f7e93a4b-74b3-4bdb-96cf-201a5f24ba7e

##### Forgot password

https://github.com/user-attachments/assets/38298ed5-8d6e-424b-bf7c-acf7b44fadb4

##### Recovery phrase

https://github.com/user-attachments/assets/22f68150-4f6a-4cc9-bf0f-60951b4d28a1





[DTIS-1202]: https://cardanofoundation.atlassian.net/browse/DTIS-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ