### PR TITLE
feat(core): limit get matching creds by identifier

### DIFF
--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -651,6 +651,7 @@ describe("Ipex communication service of agent", () => {
           s: "schemaSaid",
         },
         i: "i",
+        rp: "id",
         e: {},
       },
     };
@@ -698,7 +699,7 @@ describe("Ipex communication service of agent", () => {
     expect(credentialListMock).toBeCalledWith({
       filter: expect.objectContaining({
         "-s": { $eq: mockExchange.exn.a.s },
-        "-a-i": mockExchange.exn.a.i,
+        "-a-i": mockExchange.exn.rp,
       }),
     });
   });

--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -640,7 +640,7 @@ describe("Ipex communication service of agent", () => {
   test("can get matching credential for apply", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     const notiId = "notiId";
-    getExchangeMock = jest.fn().mockResolvedValue({
+    const mockExchange = {
       exn: {
         a: {
           i: "uuid",
@@ -653,7 +653,8 @@ describe("Ipex communication service of agent", () => {
         i: "i",
         e: {},
       },
-    });
+    };
+    getExchangeMock = jest.fn().mockResolvedValue(mockExchange);
     const noti = {
       id: notiId,
       createdAt: new Date("2024-04-29T11:01:04.903Z").toISOString(),
@@ -693,6 +694,12 @@ describe("Ipex communication service of agent", () => {
         fullName: "Mr. John Lucas Smith",
         licenseNumber: "SMITH01192OP",
       },
+    });
+    expect(credentialListMock).toBeCalledWith({
+      filter: expect.objectContaining({
+        "-s": { $eq: mockExchange.exn.a.s },
+        "-a-i": mockExchange.exn.a.i,
+      }),
     });
   });
 

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -208,6 +208,7 @@ class IpexCommunicationService extends AgentService {
     const msg = await this.props.signifyClient.exchanges().get(msgSaid);
     const schemaSaid = msg.exn.a.s;
     const attributes = msg.exn.a.a;
+    const recipient = msg.exn.a.i;
     const schemaKeri = await this.props.signifyClient
       .schemas()
       .get(schemaSaid)
@@ -225,6 +226,7 @@ class IpexCommunicationService extends AgentService {
 
     const filter = {
       "-s": { $eq: schemaSaid },
+      "-a-i": recipient,
       ...(Object.keys(attributes).length > 0
         ? {
           ...Object.fromEntries(

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -208,7 +208,7 @@ class IpexCommunicationService extends AgentService {
     const msg = await this.props.signifyClient.exchanges().get(msgSaid);
     const schemaSaid = msg.exn.a.s;
     const attributes = msg.exn.a.a;
-    const recipient = msg.exn.a.i;
+    const recipient = msg.exn.rp;
     const schemaKeri = await this.props.signifyClient
       .schemas()
       .get(schemaSaid)


### PR DESCRIPTION
## Description

Limit get matching creds to credentials held by the recipient of the apply message

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1232)

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated