### PR TITLE
feat(ui): Avoid spacing strings from the core based on capitals or numbers

### DIFF
--- a/src/ui/components/ArchivedCredentials/ArchivedCredentials.test.tsx
+++ b/src/ui/components/ArchivedCredentials/ArchivedCredentials.test.tsx
@@ -93,8 +93,6 @@ describe("Archived and revoked credentials", () => {
     credsFixAcdc.forEach((cred) => {
       expect(getByTestId(`credential-name-${cred.id}`).innerHTML).toBe(
         cred.credentialType
-          .replace(/([A-Z][a-z])/g, " $1")
-          .replace(/(\d)/g, " $1")
       );
     });
 

--- a/src/ui/components/ArchivedCredentials/CredentialItem.tsx
+++ b/src/ui/components/ArchivedCredentials/CredentialItem.tsx
@@ -57,9 +57,7 @@ const CredentialItem = ({
               data-testid={`credential-name-${credential.id}`}
               className="credential-name"
             >
-              {credential.credentialType
-                .replace(/([A-Z][a-z])/g, " $1")
-                .replace(/(\d)/g, " $1")}
+              {credential.credentialType}
             </div>
             <div className="credential-expiration">
               {!isRevoked ? (

--- a/src/ui/components/SwitchCardView/CardList.tsx
+++ b/src/ui/components/SwitchCardView/CardList.tsx
@@ -25,9 +25,7 @@ const CardList = ({
 
           return {
             id: item.id,
-            title: identifier.displayName
-              .replace(/([A-Z][a-z])/g, " $1")
-              .replace(/(\d)/g, " $1"),
+            title: identifier.displayName,
             subtitle: formatShortDate(identifier.createdAtUTC),
             data: identifier,
             image: IDENTIFIER_BG_MAPPING[identifier.theme] as string,


### PR DESCRIPTION
## Description

Avoid spacing strings from the core based on capitals or numbers on multisign identifier and archived cred.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1235](https://cardanofoundation.atlassian.net/browse/DTIS-1235)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Multisig Identifier
##### Before
<img width="340" alt="Screenshot 2024-08-26 at 17 35 46" src="https://github.com/user-attachments/assets/649b47ba-6ccb-46a7-aaeb-b10515ed74d5">

##### After
<img width="340" alt="Screenshot 2024-08-26 at 16 34 53" src="https://github.com/user-attachments/assets/10701ecd-259e-4663-8bbe-852a3887051a">

#### Archived Credential
##### Before
<img width="340" alt="Screenshot 2024-08-26 at 17 35 51" src="https://github.com/user-attachments/assets/03692f9b-1055-4cc2-b792-4a8b59e52aac">

##### After
<img width="340" alt="Screenshot 2024-08-26 at 16 35 01" src="https://github.com/user-attachments/assets/8ab347ca-3461-4489-9835-31186f95f0a4">



[comment]: <> (Add screenshots)

[DTIS-1235]: https://cardanofoundation.atlassian.net/browse/DTIS-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ