### PR TITLE
fix(ui): Validate btn on SSI agent screen disabled if connect fails

### DIFF
--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -377,7 +377,7 @@ const CreateSSIAgent = () => {
             pageId={pageId}
             primaryButtonText={`${i18n.t("ssiagent.button.validate")}`}
             primaryButtonAction={() => handleValidate()}
-            primaryButtonDisabled={!validated}
+            primaryButtonDisabled={!validated || loading}
           />
         </div>
       </ScrollablePageLayout>

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -113,7 +113,7 @@ const CreateSSIAgent = () => {
     ssiAgent.connectUrl &&
     !isValidHttpUrl(ssiAgent.connectUrl);
 
-  const validated = validBootUrl && validConnectUrl && !hasMismatchError;
+  const validated = validBootUrl && validConnectUrl;
 
   const handleClearState = () => {
     dispatch(clearSSIAgent());


### PR DESCRIPTION
## Description

Enable validate button after connect fails 

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1221](https://cardanofoundation.atlassian.net/browse/DTIS-1221)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser

https://github.com/user-attachments/assets/d1956d09-2791-4b67-8b7e-56b265ee5acc

[DTIS-1221]: https://cardanofoundation.atlassian.net/browse/DTIS-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ