### PR TITLE
fix(ui): Scanning a multi-sig QR code (after first scan) from the normal scanner causes an infinite spinner

### DIFF
--- a/src/ui/globals/types.ts
+++ b/src/ui/globals/types.ts
@@ -52,6 +52,7 @@ enum OperationType {
   SCAN_SSI_BOOT_URL = "scanSSIBootUrl",
   SCAN_SSI_CONNECT_URL = "scanSSIConnectUrl",
   OPEN_WALLET_CONNECTION_DETAIL = "openWalletConnection",
+  OPEN_MULTISIG_IDENTIFIER = "openMultisignIdentifier",
 }
 
 enum ToastMsgType {

--- a/src/ui/pages/Scan/Scan.test.tsx
+++ b/src/ui/pages/Scan/Scan.test.tsx
@@ -7,6 +7,7 @@ import { store } from "../../../store";
 import { connectionsFix } from "../../__fixtures__/connectionsFix";
 import { OperationType } from "../../globals/types";
 import { Scan } from "./Scan";
+import { setCurrentOperation } from "../../../store/reducers/stateCache";
 
 const startScan = jest.fn(
   (args: unknown) =>
@@ -195,6 +196,47 @@ describe("Scan Tab", () => {
           openConnections: true,
         },
       });
+    });
+  });
+
+  test("Nav to identifier after scan multisig", async () => {
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.SCAN, TabsRoutePath.IDENTIFIERS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: false,
+        },
+        currentOperation: OperationType.IDLE,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    connectByOobiUrlMock.mockImplementation(() => {
+      return {
+        type: KeriConnectionType.NORMAL,
+      };
+    });
+
+    getMultisigLinkedContactsMock.mockReturnValue([connectionsFix[0]]);
+
+    render(
+      <Provider store={storeMocked}>
+        <Scan />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(historyPushMock).toBeCalledWith(TabsRoutePath.IDENTIFIERS);
+      expect(dispatchMock).toBeCalledWith(
+        setCurrentOperation(OperationType.OPEN_MULTISIG_IDENTIFIER)
+      );
     });
   });
 });

--- a/src/ui/pages/Scan/Scan.tsx
+++ b/src/ui/pages/Scan/Scan.tsx
@@ -60,6 +60,10 @@ const Scan = () => {
     }
   }, [currentToastMsg, currentOperation, isValueCaptured]);
 
+  const handleAfterScan = () => {
+    history.push(TabsRoutePath.IDENTIFIERS);
+  };
+
   return (
     <TabLayout
       pageId={pageId}
@@ -68,6 +72,7 @@ const Scan = () => {
       <Scanner
         routePath={history.location.pathname}
         setIsValueCaptured={setIsValueCaptured}
+        handleReset={handleAfterScan}
       />
     </TabLayout>
   );


### PR DESCRIPTION
## Description

Nav to identifiers tab and open scanned multisig identifier.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1231](https://cardanofoundation.atlassian.net/browse/DTIS-1231)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser

https://github.com/user-attachments/assets/b4575658-5876-4dea-ad76-7d21c5fa8f99



[DTIS-1233]: https://cardanofoundation.atlassian.net/browse/DTIS-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DTIS-1231]: https://cardanofoundation.atlassian.net/browse/DTIS-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ