### PR TITLE
fix: offline mode bugs

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -217,15 +217,9 @@ class Agent {
       await signifyReady();
       const bran = await this.getBran();
       this.signifyClient = new SignifyClient(keriaConnectUrl, bran, Tier.low);
-      await this.signifyClient.connect();
-      Agent.isOnline = true;
       this.agentServicesProps.signifyClient = this.signifyClient;
-      this.agentServicesProps.eventService.emit<KeriaStatusChangedEvent>({
-        type: KeriaStatusEventTypes.KeriaStatusChanged,
-        payload: {
-          isOnline: Agent.isOnline,
-        },
-      });
+      await this.signifyClient.connect();
+      this.markAgentStatus(true);
     }
   }
 
@@ -239,6 +233,7 @@ class Agent {
         Tier.low,
         agentUrls.bootUrl
       );
+      this.agentServicesProps.signifyClient = this.signifyClient;
       const bootResult = await this.signifyClient.boot().catch((e) => {
         /* eslint-disable no-console */
         console.error(e);
@@ -266,7 +261,7 @@ class Agent {
         throw new Error(Agent.KERIA_BOOTED_ALREADY_BUT_CANNOT_CONNECT);
       }
       await this.saveAgentUrls(agentUrls);
-      this.markAgentOnline();
+      this.markAgentStatus(true);
     }
   }
 
@@ -286,6 +281,7 @@ class Agent {
       bran = branBuffer.toString("utf-8");
 
       this.signifyClient = new SignifyClient(connectUrl, bran, Tier.low);
+      this.agentServicesProps.signifyClient = this.signifyClient;
 
       await this.signifyClient.connect();
     } catch (error) {
@@ -306,16 +302,15 @@ class Agent {
       bootUrl: "",
     });
 
-    this.markAgentOnline();
+    this.markAgentStatus(true);
   }
 
-  private markAgentOnline() {
+  markAgentStatus(online: boolean) {
     Agent.isOnline = true;
-    this.agentServicesProps.signifyClient = this.signifyClient;
     this.agentServicesProps.eventService.emit<KeriaStatusChangedEvent>({
       type: KeriaStatusEventTypes.KeriaStatusChanged,
       payload: {
-        isOnline: Agent.isOnline,
+        isOnline: online,
       },
     });
   }

--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -5,6 +5,7 @@ import {
 } from "./services/credentialService.types";
 import { EventService } from "./services/eventService";
 import { ConnectionHistoryType } from "./services/connection.types";
+import { OperationPendingRecordType } from "./records/operationPendingRecord.type";
 
 enum ConnectionStatus {
   CONFIRMED = "confirmed",
@@ -231,6 +232,14 @@ interface BranAndMnemonic {
   mnemonic: string;
 }
 
+type OperationCallback = ({
+  oid,
+  opType,
+}: {
+  oid: string;
+  opType: OperationPendingRecordType;
+}) => void;
+
 export {
   ConnectionStatus,
   MiscRecordId,
@@ -263,4 +272,5 @@ export type {
   IpexMessage,
   NotificationRpy,
   AuthorizationRequestExn,
+  OperationCallback,
 };

--- a/src/core/agent/services/signifyNotificationService.test.ts
+++ b/src/core/agent/services/signifyNotificationService.test.ts
@@ -1,6 +1,7 @@
 import { Agent } from "../agent";
 import { ExchangeRoute, NotificationRoute } from "../agent.types";
 import { IpexMessageStorage } from "../records";
+import { OperationPendingRecord } from "../records/operationPendingRecord";
 import { ConnectionHistoryType } from "./connection.types";
 import { CredentialStatus } from "./credentialService.types";
 import { EventService } from "./eventService";
@@ -816,10 +817,6 @@ describe("Signify notification service of agent", () => {
 describe("Long running operation tracker", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    // We mock the setTimeout here so we can exit the while(true) loop
-    jest.spyOn(global, "setTimeout").mockImplementation(() => {
-      throw new Error("Force Exit");
-    });
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
     const operationMock = {
       metadata: {
@@ -836,23 +833,20 @@ describe("Long running operation tracker", () => {
 
   test("Should handle long operations with type group", async () => {
     const callback = jest.fn();
-    operationPendingGetAllMock.mockResolvedValueOnce([
-      {
-        type: "OperationPendingRecord",
-        id: "group.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "group",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "group.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "group",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
     identifierStorage.getIdentifierMetadata.mockResolvedValueOnce({
       signifyName: "signifyName",
     });
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(Agent.agent.multiSigs.endRoleAuthorization).toBeCalledWith(
       "signifyName"
     );
@@ -874,20 +868,17 @@ describe("Long running operation tracker", () => {
       },
     };
     operationsGetMock.mockResolvedValue(operationMock);
-    operationPendingGetAllMock.mockResolvedValueOnce([
-      {
-        type: "OperationPendingRecord",
-        id: "witness.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "witness",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "witness.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "witness",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(identifierStorage.updateIdentifierMetadata).toBeCalledWith(
       "AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
       {
@@ -918,20 +909,17 @@ describe("Long running operation tracker", () => {
       createdAt: new Date(),
     };
     connectionStorage.findById.mockResolvedValueOnce(connectionMock);
-    operationPendingGetAllMock.mockResolvedValueOnce([
-      {
-        type: "OperationPendingRecord",
-        id: "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "oobi",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "oobi",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(connectionStorage.update).toBeCalledWith({
       id: connectionMock.id,
       pending: false,
@@ -943,15 +931,6 @@ describe("Long running operation tracker", () => {
 
   test("Should handle long operations with type exchange.receivecredential", async () => {
     const callback = jest.fn();
-    operationPendingGetAllMock.mockResolvedValueOnce([
-      {
-        type: "OperationPendingRecord",
-        id: "exchange.receivecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "exchange.receivecredential",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
     const credentialIdMock = "credentialId";
     signifyClient
       .exchanges()
@@ -971,11 +950,17 @@ describe("Long running operation tracker", () => {
           },
         },
       });
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "exchange.receivecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "exchange.receivecredential",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(Agent.agent.ipexCommunications.markAcdc).toBeCalledWith(
       credentialIdMock,
       CredentialStatus.CONFIRMED
@@ -986,15 +971,6 @@ describe("Long running operation tracker", () => {
   test("Should handle long operations with type exchange.revokecredential", async () => {
     const callback = jest.fn();
     const credentialIdMock = "credentialId";
-    operationPendingGetAllMock.mockResolvedValue([
-      {
-        type: "OperationPendingRecord",
-        id: "exchange.revokecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "exchange.revokecredential",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
     getCredentialMock.mockResolvedValue({
       id: "id",
       schema: {
@@ -1026,11 +1002,17 @@ describe("Long running operation tracker", () => {
         },
       })
       .mockResolvedValueOnce(grantExchange);
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "exchange.revokecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "exchange.revokecredential",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(Agent.agent.ipexCommunications.markAcdc).toBeCalledWith(
       credentialIdMock,
       CredentialStatus.REVOKED
@@ -1045,15 +1027,6 @@ describe("Long running operation tracker", () => {
   test("Should not markAcdc if the credentialMetadata's status is revoked", async () => {
     const callback = jest.fn();
     const credentialIdMock = "credentialId";
-    operationPendingGetAllMock.mockResolvedValue([
-      {
-        type: "OperationPendingRecord",
-        id: "exchange.revokecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "exchange.revokecredential",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
     getCredentialMock.mockResolvedValue({
       id: "id",
       schema: {
@@ -1085,11 +1058,17 @@ describe("Long running operation tracker", () => {
           },
         },
       });
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "exchange.revokecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "exchange.revokecredential",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(Agent.agent.ipexCommunications.markAcdc).not.toBeCalled();
     expect(
       Agent.agent.ipexCommunications.createLinkedIpexMessageRecord
@@ -1101,15 +1080,6 @@ describe("Long running operation tracker", () => {
   test("Should not markAcdc if the credential.status.s status is not 1", async () => {
     const callback = jest.fn();
     const credentialIdMock = "credentialId";
-    operationPendingGetAllMock.mockResolvedValue([
-      {
-        type: "OperationPendingRecord",
-        id: "exchange.revokecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "exchange.revokecredential",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
     getCredentialMock.mockResolvedValue({
       id: "id",
       schema: {
@@ -1140,11 +1110,17 @@ describe("Long running operation tracker", () => {
           },
         },
       });
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "exchange.revokecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "exchange.revokecredential",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(Agent.agent.ipexCommunications.markAcdc).not.toBeCalled();
     expect(
       Agent.agent.ipexCommunications.createLinkedIpexMessageRecord
@@ -1167,15 +1143,6 @@ describe("Long running operation tracker", () => {
       },
     };
     operationsGetMock.mockResolvedValue(operationMock);
-    operationPendingGetAllMock.mockResolvedValueOnce([
-      {
-        type: "OperationPendingRecord",
-        id: "exchange.receivecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-        createdAt: new Date("2024-08-01T10:36:17.814Z"),
-        recordType: "exchange.receivecredential",
-        updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-      },
-    ]);
     const credentialIdMock = "credentialId";
     signifyClient.exchanges().get.mockResolvedValueOnce({
       exn: {
@@ -1187,17 +1154,27 @@ describe("Long running operation tracker", () => {
         },
       },
     });
-    try {
-      await signifyNotificationService.pollLongOperationsWithCb(callback);
-    } catch (error) {
-      expect((error as Error).message).toBe("Force Exit");
-    }
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "exchange.receivecredential.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "exchange.receivecredential",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    await signifyNotificationService.processOperation(
+      operationRecord,
+      callback
+    );
     expect(operationsGetMock).toBeCalledTimes(1);
     expect(Agent.agent.ipexCommunications.markAcdc).toBeCalledTimes(0);
     expect(operationPendingStorage.deleteById).toBeCalledTimes(1);
   });
 
   test("Should call setTimeout listening for pending operations if Keria is offline", async () => {
+    // We mock the setTimeout here so we can exit the while(true) loop
+    jest.spyOn(global, "setTimeout").mockImplementation(() => {
+      throw new Error("Force Exit");
+    });
     const callback = jest.fn();
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(false);
     operationPendingGetAllMock.mockResolvedValueOnce([

--- a/src/core/agent/services/signifyNotificationService.test.ts
+++ b/src/core/agent/services/signifyNotificationService.test.ts
@@ -849,7 +849,7 @@ describe("Long running operation tracker", () => {
       signifyName: "signifyName",
     });
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -884,7 +884,7 @@ describe("Long running operation tracker", () => {
       },
     ]);
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -928,7 +928,7 @@ describe("Long running operation tracker", () => {
       },
     ]);
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -972,7 +972,7 @@ describe("Long running operation tracker", () => {
         },
       });
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -1027,7 +1027,7 @@ describe("Long running operation tracker", () => {
       })
       .mockResolvedValueOnce(grantExchange);
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -1086,7 +1086,7 @@ describe("Long running operation tracker", () => {
         },
       });
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -1141,7 +1141,7 @@ describe("Long running operation tracker", () => {
         },
       });
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -1188,7 +1188,7 @@ describe("Long running operation tracker", () => {
       },
     });
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }
@@ -1210,7 +1210,7 @@ describe("Long running operation tracker", () => {
       },
     ]);
     try {
-      await signifyNotificationService.onSignifyOperationStateChanged(callback);
+      await signifyNotificationService.pollLongOperationsWithCb(callback);
     } catch (error) {
       expect((error as Error).message).toBe("Force Exit");
     }

--- a/src/core/agent/services/signifyNotificationService.ts
+++ b/src/core/agent/services/signifyNotificationService.ts
@@ -57,9 +57,7 @@ class SignifyNotificationService extends AgentService {
     this.credentialStorage = credentialStorage;
   }
 
-  async onNotificationStateChanged(
-    callback: (event: KeriaNotification) => void
-  ) {
+  async pollNotificationsWithCb(callback: (event: KeriaNotification) => void) {
     let notificationQuery = {
       nextIndex: 0,
       lastNotificationId: "",
@@ -72,9 +70,10 @@ class SignifyNotificationService extends AgentService {
         id: MiscRecordId.KERIA_NOTIFICATION_MARKER,
         content: notificationQuery,
       });
-    } else
+    } else {
       notificationQuery =
         notificationQueryRecord.content as unknown as KeriaNotificationMarker;
+    }
     // eslint-disable-next-line no-constant-condition
     while (true) {
       if (!this.loggedIn) {
@@ -103,6 +102,7 @@ class SignifyNotificationService extends AgentService {
         // Possible that bootAndConnect is called from @OnlineOnly in between loops,
         // so check if its gone down to avoid having 2 bootAndConnect loops
         if (Agent.agent.getKeriaOnlineStatus()) {
+          Agent.agent.markAgentStatus(false);
           // This will hang the loop until the connection is secured again
           await Agent.agent.connect();
         }
@@ -505,7 +505,7 @@ class SignifyNotificationService extends AgentService {
     return notificationRecord;
   }
 
-  async onSignifyOperationStateChanged(
+  async pollLongOperationsWithCb(
     callback: ({
       oid,
       opType,
@@ -535,6 +535,7 @@ class SignifyNotificationService extends AgentService {
             // Possible that bootAndConnect is called from @OnlineOnly in between loops,
             // so check if its gone down to avoid having 2 bootAndConnect loops
             if (Agent.agent.getKeriaOnlineStatus()) {
+              Agent.agent.markAgentStatus(false);
               // This will hang the loop until the connection is secured again
               await Agent.agent.connect();
             }

--- a/src/core/agent/services/utils.ts
+++ b/src/core/agent/services/utils.ts
@@ -52,6 +52,7 @@ export const OnlineOnly = (
         /Failed to fetch/gi.test(errorMessage) ||
         /Load failed/gi.test(errorMessage)
       ) {
+        Agent.agent.markAgentStatus(false);
         Agent.agent.connect(1000);
         throw new Error(Agent.KERIA_CONNECTION_BROKEN);
       } else {

--- a/src/store/reducers/stateCache/stateCache.ts
+++ b/src/store/reducers/stateCache/stateCache.ts
@@ -12,7 +12,7 @@ import { LoginAttempts } from "../../../core/agent/services/auth.types";
 
 const initialState: StateCacheProps = {
   initialized: false,
-  isOnline: true,
+  isOnline: false,
   routes: [],
   authentication: {
     loggedIn: false,

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -54,8 +54,8 @@ jest.mock("../core/agent/agent", () => ({
         pickupMessagesFromMediator: jest.fn(),
       },
       signifyNotifications: {
-        onNotificationStateChanged: jest.fn(),
-        onSignifyOperationStateChanged: jest.fn(),
+        pollNotificationsWithCb: jest.fn(),
+        pollLongOperationsWithCb: jest.fn(),
         getAllNotifications: jest.fn(),
         stopNotification: jest.fn(),
         startNotification: jest.fn(),

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -99,8 +99,8 @@ jest.mock("../../../core/agent/agent", () => ({
         pickupMessagesFromMediator: jest.fn(),
       },
       signifyNotifications: {
-        onNotificationStateChanged: jest.fn(),
-        onSignifyOperationStateChanged: jest.fn(),
+        pollNotificationsWithCb: jest.fn(),
+        pollLongOperationsWithCb: jest.fn(),
         getAllNotifications: jest.fn(),
       },
       getKeriaOnlineStatus: jest.fn(),

--- a/src/ui/hooks/useOnlineStatusEffect.ts
+++ b/src/ui/hooks/useOnlineStatusEffect.ts
@@ -2,14 +2,12 @@ import { useEffect } from "react";
 import { useAppSelector } from "../../store/hooks";
 import { getIsOnline } from "../../store/reducers/stateCache";
 
-const useOnlineStatusEffect = (
-  callback: (onlineStatus: boolean) => void | never
-) => {
+const useOnlineStatusEffect = (callback: () => void | never) => {
   const isOnline = useAppSelector(getIsOnline);
 
   useEffect(() => {
     if (!isOnline) return;
-    callback(isOnline);
+    callback();
   }, [isOnline, callback]);
 };
 


### PR DESCRIPTION
App was "online" in Redux by default, so if KERIA is down on start-up, it always thought it was online.

Now also only change online status in one place based on updates from core event bus/service.

Stop re-initialising signifyClient agent service props and don't set offline in recursive calls of `agent.connect`. (both of these were causing timing issues and causing it to flicker from online to offline and back continuously).