### PR TITLE
fix(core): stop caching signer for cip-45

### DIFF
--- a/src/core/cardano/walletConnect/identityWalletConnect.ts
+++ b/src/core/cardano/walletConnect/identityWalletConnect.ts
@@ -26,8 +26,6 @@ class IdentityWalletConnect extends CardanoPeerConnect {
     payload: string
   ) => Promise<string | { error: PeerConnectionError }>;
 
-  signerCache: Map<string, Signer>;
-
   constructor(
     walletInfo: IWalletInfo,
     seed: string | null,
@@ -43,7 +41,6 @@ class IdentityWalletConnect extends CardanoPeerConnect {
       logLevel: "info",
     });
     this.selectedAid = selectedAid;
-    this.signerCache = new Map();
     this.eventService = eventService;
 
     this.getKeriIdentifier = async (): Promise<{
@@ -87,14 +84,9 @@ class IdentityWalletConnect extends CardanoPeerConnect {
         }
       }
       if (approved) {
-        if (this.signerCache.get(identifier) === undefined) {
-          this.signerCache.set(
-            identifier,
-            await Agent.agent.identifiers.getSigner(identifier)
-          );
-        }
-        return this.signerCache.get(identifier)!.sign(Buffer.from(payload))
-          .qb64;
+        return (await Agent.agent.identifiers.getSigner(identifier)).sign(
+          Buffer.from(payload)
+        ).qb64;
       } else {
         return { error: TxSignError.UserDeclined };
       }


### PR DESCRIPTION
We shouldn't be caching the signer like this because if we issue a key rotation while still connected, it will try to sign with the old keys.

We could clear the cache for that identifier if a key rotation occurs but honestly it's not worth the complexity.

@jorgenavben Can you test this against ballot?