### PR TITLE
feat(ui): display pending credential in UI automatically for multi-sig

### DIFF
--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -117,7 +117,7 @@ interface AcdcStateChangedEvent extends BaseEventEmitter {
   payload:
     | {
         status: CredentialStatus.PENDING;
-        credentialId: string;
+        credential: CredentialShortDetails;
       }
     | {
         status: CredentialStatus.CONFIRMED;

--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -114,19 +114,10 @@ interface ConnectionStateChangedEvent extends BaseEventEmitter {
 
 interface AcdcStateChangedEvent extends BaseEventEmitter {
   type: typeof AcdcEventTypes.AcdcStateChanged;
-  payload:
-    | {
-        status: CredentialStatus.PENDING;
-        credential: CredentialShortDetails;
-      }
-    | {
-        status: CredentialStatus.CONFIRMED;
-        credential: CredentialShortDetails;
-      }
-    | {
-        status: CredentialStatus.REVOKED;
-        credential: CredentialShortDetails;
-      };
+  payload: {
+    status: CredentialStatus;
+    credential: CredentialShortDetails;
+  };
 }
 
 interface KeriaStatusChangedEvent extends BaseEventEmitter {

--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -6,6 +6,7 @@ import { ConfigurationService } from "../../configuration";
 import { OperationPendingRecordType } from "../records/operationPendingRecord.type";
 import { ConnectionHistoryType } from "./connection.types";
 import { CredentialStatus } from "./credentialService.types";
+import { AcdcEventTypes } from "../agent.types";
 
 const notificationStorage = jest.mocked({
   open: jest.fn(),
@@ -320,10 +321,11 @@ describe("Ipex communication service of agent", () => {
     credentialStorage.getCredentialMetadata = jest.fn().mockResolvedValue({
       id: "id",
     });
+    eventService.emit = jest.fn();
 
     await ipexCommunicationService.acceptAcdc(id);
 
-    expect(credentialStorage.saveCredentialMetadataRecord).toBeCalledWith({
+    const credentialMock = {
       connectionId: "EC9bQGHShmp2Juayqp0C5XcheBiHyc1p54pZ_Op-B95x",
       credentialType: "title",
       id: "EAe_JgQ636ic-k34aUQMjDFPp6Zd350gEsQA6HePBU5W",
@@ -331,6 +333,16 @@ describe("Ipex communication service of agent", () => {
       issuanceDate: "2024-07-30T04:19:55.348Z",
       schema: "EBIFDhtSE0cM4nbTnaMqiV1vUIlcnbsqBMeVMmeGmXOu",
       status: "pending",
+    };
+    expect(credentialStorage.saveCredentialMetadataRecord).toBeCalledWith(
+      credentialMock
+    );
+    expect(eventService.emit).toHaveBeenCalledWith({
+      type: AcdcEventTypes.AcdcStateChanged,
+      payload: {
+        credential: credentialMock,
+        status: CredentialStatus.PENDING,
+      },
     });
     expect(operationPendingStorage.save).toBeCalledWith({
       id: "opName",
@@ -1011,6 +1023,8 @@ describe("Ipex communication service of agent", () => {
       exnSaid: "exnSaid",
     });
 
+    eventService.emit = jest.fn();
+
     await ipexCommunicationService.acceptAcdc("id");
 
     expect(notificationStorage.update).toBeCalledWith({
@@ -1027,7 +1041,8 @@ describe("Ipex communication service of agent", () => {
       },
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
     });
-    expect(credentialStorage.saveCredentialMetadataRecord).toBeCalledWith({
+
+    const credentialMock = {
       connectionId: "EC9bQGHShmp2Juayqp0C5XcheBiHyc1p54pZ_Op-B95x",
       credentialType: "title",
       id: "EAe_JgQ636ic-k34aUQMjDFPp6Zd350gEsQA6HePBU5W",
@@ -1035,6 +1050,17 @@ describe("Ipex communication service of agent", () => {
       issuanceDate: "2024-07-30T04:19:55.348Z",
       schema: "EBIFDhtSE0cM4nbTnaMqiV1vUIlcnbsqBMeVMmeGmXOu",
       status: "pending",
+    };
+    expect(credentialStorage.saveCredentialMetadataRecord).toBeCalledWith(
+      credentialMock
+    );
+
+    expect(eventService.emit).toHaveBeenCalledWith({
+      type: AcdcEventTypes.AcdcStateChanged,
+      payload: {
+        credential: credentialMock,
+        status: CredentialStatus.PENDING,
+      },
     });
     expect(operationPendingStorage.save).toBeCalledWith({
       id: "opName",

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -118,7 +118,7 @@ class IpexCommunicationService extends AgentService {
     allSchemaSaids.push(schemaSaid);
 
     const schema = await this.props.signifyClient.schemas().get(schemaSaid);
-    await this.saveAcdcMetadataRecord(
+    const credential = await this.saveAcdcMetadataRecord(
       grantExn.exn.e.acdc.d,
       grantExn.exn.e.acdc.a.dt,
       schema.title,
@@ -129,7 +129,7 @@ class IpexCommunicationService extends AgentService {
     this.props.eventService.emit<AcdcStateChangedEvent>({
       type: AcdcEventTypes.AcdcStateChanged,
       payload: {
-        credentialId,
+        credential,
         status: CredentialStatus.PENDING,
       },
     });
@@ -304,7 +304,7 @@ class IpexCommunicationService extends AgentService {
     schemaTitle: string,
     connectionId: string,
     schema: string
-  ): Promise<void> {
+  ): Promise<CredentialMetadataRecordProps> {
     const credentialDetails: CredentialMetadataRecordProps = {
       id: credentialId,
       isArchived: false,
@@ -317,6 +317,7 @@ class IpexCommunicationService extends AgentService {
     await this.credentialStorage.saveCredentialMetadataRecord(
       credentialDetails
     );
+    return credentialDetails;
   }
 
   private async admitIpex(
@@ -443,7 +444,7 @@ class IpexCommunicationService extends AgentService {
       );
 
     if (!credentialPending) {
-      await this.saveAcdcMetadataRecord(
+      const credential = await this.saveAcdcMetadataRecord(
         previousExnGrantMsg.exn.e.acdc.d,
         previousExnGrantMsg.exn.e.acdc.a.dt,
         schema.title,
@@ -454,7 +455,7 @@ class IpexCommunicationService extends AgentService {
       this.props.eventService.emit<AcdcStateChangedEvent>({
         type: AcdcEventTypes.AcdcStateChanged,
         payload: {
-          credentialId,
+          credential,
           status: CredentialStatus.PENDING,
         },
       });

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -96,7 +96,6 @@ class IpexCommunicationService extends AgentService {
       .exchanges()
       .get(grantNoteRecord.a.d as string);
 
-    const credentialId = grantExn.exn.e.acdc.d;
     const connectionId = grantExn.exn.i;
 
     const holder = await this.identifierStorage.getIdentifierMetadata(

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -243,11 +243,12 @@ describe("AppWrapper handler", () => {
 
   describe("Credential state changed handler", () => {
     test("handles credential state pending", async () => {
+      const credentialMock = {} as CredentialShortDetails;
       const credentialStateChangedEventMock = {
         type: AcdcEventTypes.AcdcStateChanged,
         payload: {
           status: CredentialStatus.PENDING,
-          credentialId: "credentialId",
+          credential: credentialMock,
         },
       } as AcdcStateChangedEvent;
       await acdcChangeHandler(credentialStateChangedEventMock, dispatch);

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -109,6 +109,7 @@ const acdcChangeHandler = async (
 ) => {
   if (event.payload.status === CredentialStatus.PENDING) {
     dispatch(setToastMsg(ToastMsgType.CREDENTIAL_REQUEST_PENDING));
+    dispatch(updateOrAddCredsCache(event.payload.credential));
   } else if (event.payload.status === CredentialStatus.REVOKED) {
     dispatch(updateOrAddCredsCache(event.payload.credential));
   } else {


### PR DESCRIPTION
## Description

Display pending credential in UI automatically for multi-sig

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1269)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
