### PR TITLE
fix(ui): Wrong screen footer after scanning group invitation

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1434,7 +1434,7 @@
       "notes": {
         "top": "Before proceeding, please make sure that everyone you want to include as a signer scans this QR code.",
         "middle": "After everyone has scanned your QR code, please be sure to scan everyone else's QR code as well.",
-        "bottom": "To continue with the initiation of the mult-sig you must have scanned at least one other QR code."
+        "bottom": "To continue with the initiation of the group identifier you must have scanned at least one other QR code."
       },
       "scanbutton": "Scan QR codes",
       "initiatebutton": "Initiate group",

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage1.test.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage1.test.tsx
@@ -300,10 +300,10 @@ describe("Identifier Stage 1", () => {
       );
 
       expect(
-        getByText(EN_TRANSLATIONS.createidentifier.receive.notes.top)
+        getByText(EN_TRANSLATIONS.createidentifier.share.notes.top)
       ).toBeInTheDocument();
       expect(
-        getByText(EN_TRANSLATIONS.createidentifier.receive.notes.middle)
+        getByText(EN_TRANSLATIONS.createidentifier.share.notes.middle)
       ).toBeInTheDocument();
 
       act(() => {

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage1.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage1.tsx
@@ -120,26 +120,28 @@ const IdentifierStage1 = ({
 
   return (
     <>
-      {resumeMultiSig?.signifyName.length || initiated ? (
-        <IdentifierStage1BodyResume
-          componentId={componentId}
-          handleDone={handleDone}
-          handleInitiateMultiSig={handleInitiateMultiSig}
-          oobi={oobi}
-          groupMetadata={groupMetadata}
-          handleScanButton={handleScanButton}
-          scannedConections={scannedConections}
-        />
-      ) : (
-        <IdentifierStage1BodyInit
-          componentId={componentId}
-          handleDone={handleDone}
-          oobi={oobi}
-          groupMetadata={groupMetadata}
-          handleScanButton={handleScanButton}
-          scannedConections={scannedConections}
-        />
-      )}
+      {resumeMultiSig?.signifyName.length ||
+      initiated ||
+      scannedConections?.length ? (
+          <IdentifierStage1BodyResume
+            componentId={componentId}
+            handleDone={handleDone}
+            handleInitiateMultiSig={handleInitiateMultiSig}
+            oobi={oobi}
+            groupMetadata={groupMetadata}
+            handleScanButton={handleScanButton}
+            scannedConections={scannedConections}
+          />
+        ) : (
+          <IdentifierStage1BodyInit
+            componentId={componentId}
+            handleDone={handleDone}
+            oobi={oobi}
+            groupMetadata={groupMetadata}
+            handleScanButton={handleScanButton}
+            scannedConections={scannedConections}
+          />
+        )}
       <Alert
         isOpen={alertIsOpen}
         setIsOpen={setAlertIsOpen}

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage1BodyInit.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage1BodyInit.tsx
@@ -15,7 +15,6 @@ const IdentifierStage1BodyInit = ({
   handleDone,
   oobi,
   handleScanButton,
-  groupMetadata,
 }: IdentifierStage1BodyProps) => {
   const dispatch = useAppDispatch();
   const copyToClipboard = () => {
@@ -39,11 +38,7 @@ const IdentifierStage1BodyInit = ({
         className="multisig-share-note"
         data-testid="multisig-share-note-top"
       >
-        {i18n.t(
-          groupMetadata?.groupInitiator
-            ? "createidentifier.share.notes.top"
-            : "createidentifier.receive.notes.top"
-        )}
+        {i18n.t("createidentifier.share.notes.top")}
       </p>
       <div
         className={`multisig-share-qr-code${oobi.length ? " reveal" : " blur"}`}
@@ -90,11 +85,7 @@ const IdentifierStage1BodyInit = ({
         className="multisig-share-note"
         data-testid="multisig-share-note-middle"
       >
-        {i18n.t(
-          groupMetadata?.groupInitiator
-            ? "createidentifier.share.notes.middle"
-            : "createidentifier.receive.notes.middle"
-        )}
+        {i18n.t("createidentifier.share.notes.middle")}
       </p>
       <div
         className="share-identifier-scan-button"

--- a/src/ui/components/layout/TabLayout/TabLayout.scss
+++ b/src/ui/components/layout/TabLayout/TabLayout.scss
@@ -1,6 +1,14 @@
 .tab-layout {
   padding-inline: 1.25rem;
 
+  &.hidden {
+    visibility: hidden;
+  }
+
+  &.visible {
+    visibility: visible;
+  }
+
   ion-toolbar,
   .toolbar-container,
   ion-grid,

--- a/src/ui/components/layout/TabLayout/TabLayout.tsx
+++ b/src/ui/components/layout/TabLayout/TabLayout.tsx
@@ -78,9 +78,9 @@ const TabLayout = ({
 
   return (
     <IonPage
-      className={`tab-layout ${pageId} ${!isActive ? " " + "ion-hide" : ""} ${
-        customClass ? " " + customClass : ""
-      }`}
+      className={`tab-layout ${pageId} ${
+        !isActive ? " " + "ion-hide hidden" : "visible"
+      } ${customClass ? " " + customClass : ""}`}
       data-testid={pageId}
       id={pageId}
     >

--- a/src/ui/pages/Credentials/Credentials.tsx
+++ b/src/ui/pages/Credentials/Credentials.tsx
@@ -6,7 +6,6 @@ import {
 } from "@ionic/react";
 import { addOutline, peopleOutline } from "ionicons/icons";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useHistory } from "react-router-dom";
 import { Agent } from "../../../core/agent/agent";
 import { i18n } from "../../../i18n";
 import { TabsRoutePath } from "../../../routes/paths";
@@ -87,11 +86,9 @@ const AdditionalButtons = ({
 const Credentials = () => {
   const pageId = "credentials-tab";
   const dispatch = useAppDispatch();
-  const history = useHistory();
   const credsCache = useAppSelector(getCredsCache);
   const archivedCreds = useAppSelector(getCredsArchivedCache);
   const favCredsCache = useAppSelector(getFavouritesCredsCache);
-  const [tabIsOpen, setTabIsOpen] = useState(false);
   const [archivedCredentialsIsOpen, setArchivedCredentialsIsOpen] =
     useState(false);
   const [showPlaceholder, setShowPlaceholder] = useState(true);
@@ -144,10 +141,6 @@ const Credentials = () => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.CREDENTIALS }));
   });
 
-  useEffect(() => {
-    setTabIsOpen(history.location.pathname === TabsRoutePath.CREDENTIALS);
-  }, [history.location.pathname]);
-
   const findTimeById = (id: string) => {
     const found = favCredsCache.find((item) => item.id === id);
     return found ? found.time : null;
@@ -194,7 +187,7 @@ const Credentials = () => {
       : navAnimation === "favourite"
         ? "favorite-credential-nav"
         : ""
-  } ${tabIsOpen ? "visible" : "hidden"}`;
+  }`;
 
   const handleArchivedCredentialsDisplayChange = (value: boolean) => {
     if (value === archivedCredentialsIsOpen) return;

--- a/src/ui/pages/Credentials/Credentials.tsx
+++ b/src/ui/pages/Credentials/Credentials.tsx
@@ -6,6 +6,7 @@ import {
 } from "@ionic/react";
 import { addOutline, peopleOutline } from "ionicons/icons";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useHistory } from "react-router-dom";
 import { Agent } from "../../../core/agent/agent";
 import { i18n } from "../../../i18n";
 import { TabsRoutePath } from "../../../routes/paths";
@@ -86,10 +87,11 @@ const AdditionalButtons = ({
 const Credentials = () => {
   const pageId = "credentials-tab";
   const dispatch = useAppDispatch();
+  const history = useHistory();
   const credsCache = useAppSelector(getCredsCache);
   const archivedCreds = useAppSelector(getCredsArchivedCache);
   const favCredsCache = useAppSelector(getFavouritesCredsCache);
-
+  const [tabIsOpen, setTabIsOpen] = useState(false);
   const [archivedCredentialsIsOpen, setArchivedCredentialsIsOpen] =
     useState(false);
   const [showPlaceholder, setShowPlaceholder] = useState(true);
@@ -142,6 +144,10 @@ const Credentials = () => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.CREDENTIALS }));
   });
 
+  useEffect(() => {
+    setTabIsOpen(history.location.pathname === TabsRoutePath.CREDENTIALS);
+  }, [history.location.pathname]);
+
   const findTimeById = (id: string) => {
     const found = favCredsCache.find((item) => item.id === id);
     return found ? found.time : null;
@@ -188,7 +194,7 @@ const Credentials = () => {
       : navAnimation === "favourite"
         ? "favorite-credential-nav"
         : ""
-  }`;
+  } ${tabIsOpen ? "visible" : "hidden"}`;
 
   const handleArchivedCredentialsDisplayChange = (value: boolean) => {
     if (value === archivedCredentialsIsOpen) return;

--- a/src/ui/pages/Identifiers/Identifiers.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.tsx
@@ -82,7 +82,6 @@ const Identifiers = () => {
   const multisignGroupCache = useAppSelector(getMultiSigGroupCache);
   const favouritesIdentifiers = useAppSelector(getFavouritesIdentifiersCache);
   const currentOperation = useAppSelector(getCurrentOperation);
-  const [tabIsOpen, setTabIsOpen] = useState(false);
   const [favIdentifiers, setFavIdentifiers] = useState<
     IdentifierShortDetails[]
   >([]);
@@ -145,8 +144,6 @@ const Identifiers = () => {
         dispatch(setCurrentOperation(OperationType.IDLE));
       }
     }
-
-    setTabIsOpen(history.location.pathname === TabsRoutePath.IDENTIFIERS);
   }, [
     currentOperation,
     dispatch,
@@ -215,7 +212,7 @@ const Identifiers = () => {
       : navAnimation === "favourite"
         ? "favorite-identifier-nav"
         : ""
-  } ${tabIsOpen ? "visible" : "hidden"}`;
+  }`;
   const handleCloseCreateIdentifier = () => {
     switch (currentOperation) {
     case OperationType.CREATE_IDENTIFIER_CONNECT_WALLET:

--- a/src/ui/pages/Identifiers/Identifiers.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.tsx
@@ -82,7 +82,7 @@ const Identifiers = () => {
   const multisignGroupCache = useAppSelector(getMultiSigGroupCache);
   const favouritesIdentifiers = useAppSelector(getFavouritesIdentifiersCache);
   const currentOperation = useAppSelector(getCurrentOperation);
-
+  const [tabIsOpen, setTabIsOpen] = useState(false);
   const [favIdentifiers, setFavIdentifiers] = useState<
     IdentifierShortDetails[]
   >([]);
@@ -102,13 +102,10 @@ const Identifiers = () => {
     useState<IdentifierShortDetails | null>(null);
   const [navAnimation, setNavAnimation] =
     useState<StartAnimationSource>("none");
-
   const [deletedPendingItem, setDeletePendingItem] =
     useState<IdentifierShortDetails | null>(null);
   const [openDeletePendingAlert, setOpenDeletePendingAlert] = useState(false);
-
   const favouriteContainerElement = useRef<HTMLDivElement>(null);
-
   const { showConnections, setShowConnections } = useToggleConnections(
     TabsRoutePath.IDENTIFIERS
   );
@@ -148,6 +145,8 @@ const Identifiers = () => {
         dispatch(setCurrentOperation(OperationType.IDLE));
       }
     }
+
+    setTabIsOpen(history.location.pathname === TabsRoutePath.IDENTIFIERS);
   }, [
     currentOperation,
     dispatch,
@@ -216,7 +215,7 @@ const Identifiers = () => {
       : navAnimation === "favourite"
         ? "favorite-identifier-nav"
         : ""
-  }`;
+  } ${tabIsOpen ? "visible" : "hidden"}`;
   const handleCloseCreateIdentifier = () => {
     switch (currentOperation) {
     case OperationType.CREATE_IDENTIFIER_CONNECT_WALLET:

--- a/src/ui/pages/Menu/Menu.tsx
+++ b/src/ui/pages/Menu/Menu.tsx
@@ -19,7 +19,6 @@ import {
 } from "ionicons/icons";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Browser } from "@capacitor/browser";
-import { useHistory } from "react-router-dom";
 import { TabLayout } from "../../components/layout/TabLayout";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
@@ -90,9 +89,7 @@ const MenuItem = ({
 
 const Menu = () => {
   const pageId = "menu-tab";
-  const history = useHistory();
   const dispatch = useAppDispatch();
-  const [tabIsOpen, setTabIsOpen] = useState(false);
   const currentOperation = useAppSelector(getCurrentOperation);
   const connectWalletRef = useRef<ConnectWalletOptionRef>(null);
   const profileRef = useRef<ProfileOptionRef>(null);
@@ -107,10 +104,6 @@ const Menu = () => {
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.MENU }));
   });
-
-  useEffect(() => {
-    setTabIsOpen(history.location.pathname === TabsRoutePath.MENU);
-  }, [history.location.pathname]);
 
   const backHardwareConfig = useMemo(
     () => ({
@@ -363,7 +356,6 @@ const Menu = () => {
         pageId={pageId}
         hardwareBackButtonConfig={backHardwareConfig}
         header={true}
-        customClass={tabIsOpen ? "visible" : "hidden"}
         title={`${i18n.t("menu.tab.header")}`}
         additionalButtons={<AdditionalButtons />}
       >

--- a/src/ui/pages/Menu/Menu.tsx
+++ b/src/ui/pages/Menu/Menu.tsx
@@ -19,6 +19,7 @@ import {
 } from "ionicons/icons";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Browser } from "@capacitor/browser";
+import { useHistory } from "react-router-dom";
 import { TabLayout } from "../../components/layout/TabLayout";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
@@ -89,7 +90,9 @@ const MenuItem = ({
 
 const Menu = () => {
   const pageId = "menu-tab";
+  const history = useHistory();
   const dispatch = useAppDispatch();
+  const [tabIsOpen, setTabIsOpen] = useState(false);
   const currentOperation = useAppSelector(getCurrentOperation);
   const connectWalletRef = useRef<ConnectWalletOptionRef>(null);
   const profileRef = useRef<ProfileOptionRef>(null);
@@ -104,6 +107,10 @@ const Menu = () => {
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.MENU }));
   });
+
+  useEffect(() => {
+    setTabIsOpen(history.location.pathname === TabsRoutePath.MENU);
+  }, [history.location.pathname]);
 
   const backHardwareConfig = useMemo(
     () => ({
@@ -356,6 +363,7 @@ const Menu = () => {
         pageId={pageId}
         hardwareBackButtonConfig={backHardwareConfig}
         header={true}
+        customClass={tabIsOpen ? "visible" : "hidden"}
         title={`${i18n.t("menu.tab.header")}`}
         additionalButtons={<AdditionalButtons />}
       >

--- a/src/ui/pages/Menu/components/Profile/Profile.test.tsx
+++ b/src/ui/pages/Menu/components/Profile/Profile.test.tsx
@@ -9,6 +9,7 @@ import { CustomInputProps } from "../../../../components/CustomInput/CustomInput
 import { Menu } from "../../Menu";
 import { SubMenuKey } from "../../Menu.types";
 import { PROFILE_LINK } from "../../../../globals/constants";
+import { TabsRoutePath } from "../../../../../routes/paths";
 
 jest.mock("../../../../../core/agent/agent", () => ({
   Agent: {
@@ -65,6 +66,15 @@ jest.mock("../../../../components/CustomInput", () => ({
       </>
     );
   },
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useHistory: () => ({
+    location: {
+      pathname: TabsRoutePath.MENU,
+    },
+  }),
 }));
 
 const browserMock = jest.fn(({ link }: { link: string }) =>

--- a/src/ui/pages/Notifications/Notifications.tsx
+++ b/src/ui/pages/Notifications/Notifications.tsx
@@ -23,7 +23,6 @@ import { EarlierNotification } from "./components";
 import { EarlierNotificationRef } from "./components/EarlierNotification.types";
 import { NotificationOptionsModal } from "./components/NotificationOptionsModal";
 import { showError } from "../../utils/error";
-import { ToastMsgType } from "../../globals/types";
 
 const Chip = ({ filter, label, isActive, onClick }: FilterChipProps) => (
   <span>
@@ -42,6 +41,7 @@ const Notifications = () => {
   const dispatch = useAppDispatch();
   const history = useHistory();
   const notifications = useAppSelector(getNotificationsCache);
+  const [tabIsOpen, setTabIsOpen] = useState(false);
   const [selectedFilter, setSelectedFilter] = useState(NotificationFilter.All);
   const earlierNotificationRef = useRef<EarlierNotificationRef>(null);
   const [selectedItem, setSelectedItem] = useState<KeriaNotification | null>(
@@ -85,6 +85,13 @@ const Notifications = () => {
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.NOTIFICATIONS }));
   });
+
+  useEffect(() => {
+    if (history.location.pathname !== TabsRoutePath.NOTIFICATIONS) {
+      earlierNotificationRef.current?.reset();
+    }
+    setTabIsOpen(history.location.pathname === TabsRoutePath.NOTIFICATIONS);
+  }, [history.location.pathname]);
 
   const maskAsReaded = async (notification: KeriaNotification) => {
     if (notification.read) return;
@@ -140,16 +147,12 @@ const Notifications = () => {
     setSelectedItem(item);
   };
 
-  useEffect(() => {
-    if (history.location.pathname !== TabsRoutePath.NOTIFICATIONS)
-      earlierNotificationRef.current?.reset();
-  }, [history.location.pathname]);
-
   return (
     <TabLayout
       pageId={pageId}
       header={true}
       title={`${i18n.t("notifications.tab.header")}`}
+      customClass={tabIsOpen ? "visible" : "hidden"}
     >
       <div className="notifications-tab-chips">
         {filterOptions.map((option) => (

--- a/src/ui/pages/Notifications/Notifications.tsx
+++ b/src/ui/pages/Notifications/Notifications.tsx
@@ -41,7 +41,6 @@ const Notifications = () => {
   const dispatch = useAppDispatch();
   const history = useHistory();
   const notifications = useAppSelector(getNotificationsCache);
-  const [tabIsOpen, setTabIsOpen] = useState(false);
   const [selectedFilter, setSelectedFilter] = useState(NotificationFilter.All);
   const earlierNotificationRef = useRef<EarlierNotificationRef>(null);
   const [selectedItem, setSelectedItem] = useState<KeriaNotification | null>(
@@ -85,13 +84,6 @@ const Notifications = () => {
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.NOTIFICATIONS }));
   });
-
-  useEffect(() => {
-    if (history.location.pathname !== TabsRoutePath.NOTIFICATIONS) {
-      earlierNotificationRef.current?.reset();
-    }
-    setTabIsOpen(history.location.pathname === TabsRoutePath.NOTIFICATIONS);
-  }, [history.location.pathname]);
 
   const maskAsReaded = async (notification: KeriaNotification) => {
     if (notification.read) return;
@@ -147,12 +139,16 @@ const Notifications = () => {
     setSelectedItem(item);
   };
 
+  useEffect(() => {
+    if (history.location.pathname !== TabsRoutePath.NOTIFICATIONS)
+      earlierNotificationRef.current?.reset();
+  }, [history.location.pathname]);
+
   return (
     <TabLayout
       pageId={pageId}
       header={true}
       title={`${i18n.t("notifications.tab.header")}`}
-      customClass={tabIsOpen ? "visible" : "hidden"}
     >
       <div className="notifications-tab-chips">
         {filterOptions.map((option) => (

--- a/src/ui/pages/Scan/Scan.tsx
+++ b/src/ui/pages/Scan/Scan.tsx
@@ -24,6 +24,7 @@ const Scan = () => {
   const history = useHistory();
   const dispatch = useAppDispatch();
   const stateCache = useAppSelector(getStateCache);
+  const [tabIsOpen, setTabIsOpen] = useState(false);
   const currentOperation = useAppSelector(getCurrentOperation);
   const currentToastMsg = useAppSelector(getToastMsg);
   const [isValueCaptured, setIsValueCaptured] = useState(false);
@@ -33,6 +34,10 @@ const Scan = () => {
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.SCAN }));
   });
+
+  useEffect(() => {
+    setTabIsOpen(history.location.pathname === TabsRoutePath.SCAN);
+  }, [history.location.pathname]);
 
   useEffect(() => {
     if (isValueCaptured) {
@@ -72,6 +77,7 @@ const Scan = () => {
     <TabLayout
       pageId={pageId}
       header={supportMultiCamera}
+      customClass={tabIsOpen ? "visible" : "hidden"}
       additionalButtons={
         <IonButton
           shape="round"

--- a/src/ui/pages/Scan/Scan.tsx
+++ b/src/ui/pages/Scan/Scan.tsx
@@ -24,7 +24,7 @@ const Scan = () => {
   const history = useHistory();
   const dispatch = useAppDispatch();
   const stateCache = useAppSelector(getStateCache);
-  const [tabIsOpen, setTabIsOpen] = useState(false);
+
   const currentOperation = useAppSelector(getCurrentOperation);
   const currentToastMsg = useAppSelector(getToastMsg);
   const [isValueCaptured, setIsValueCaptured] = useState(false);
@@ -34,10 +34,6 @@ const Scan = () => {
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.SCAN }));
   });
-
-  useEffect(() => {
-    setTabIsOpen(history.location.pathname === TabsRoutePath.SCAN);
-  }, [history.location.pathname]);
 
   useEffect(() => {
     if (isValueCaptured) {
@@ -77,7 +73,6 @@ const Scan = () => {
     <TabLayout
       pageId={pageId}
       header={supportMultiCamera}
-      customClass={tabIsOpen ? "visible" : "hidden"}
       additionalButtons={
         <IonButton
           shape="round"


### PR DESCRIPTION
## Description

Fixing a bug that should show the person we scanned when we are invited to a group id.

Also fixed the following bug:

![04092024104342](https://github.com/user-attachments/assets/8362c533-0ecb-4e57-b8df-2a09e107d9c7)


**NOTES:**

In the videos there is an issue with the notification not arriving on time on the emulators. I asked Fergal and this is a core issue currently being fixed in another PR.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1273**](https://cardanofoundation.atlassian.net/issues/DTIS-1273)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser

https://github.com/user-attachments/assets/93b3866d-6121-42ef-a19c-da703240a365


https://github.com/user-attachments/assets/f1f33478-2e1c-4c56-9242-6e418f8d2307


#### IOS / Android

https://github.com/user-attachments/assets/172299c3-303e-4ac8-a557-5c63a2ae6610

