### PR TITLE
fix(core): mark multisig/icp as read on KERIA once actioned

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -112,8 +112,8 @@ class Agent {
       this.multiSigService = new MultiSigService(
         this.agentServicesProps,
         this.identifierStorage,
-        this.notificationStorage,
-        this.operationPendingStorage
+        this.operationPendingStorage,
+        this.signifyNotifications
       );
     }
     return this.multiSigService;

--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -10,15 +10,21 @@ import { MultiSigService } from "./multiSigService";
 import { IdentifierStorage } from "../records";
 import { ConfigurationService } from "../../configuration";
 
-const notificationStorage = jest.mocked({
-  open: jest.fn(),
-  save: jest.fn(),
-  delete: jest.fn(),
-  deleteById: jest.fn(),
-  update: jest.fn(),
-  findById: jest.fn(),
-  findAllByQuery: jest.fn(),
-  getAll: jest.fn(),
+const signifyNotificationService = jest.mocked({
+  pollNotificationsWithCb: jest.fn(),
+  startNotification: jest.fn(),
+  stopNotification: jest.fn(),
+  deleteNotificationRecordById: jest.fn(),
+  processNotification: jest.fn(),
+  createNotificationRecord: jest.fn(),
+  readNotification: jest.fn(),
+  unreadNotification: jest.fn(),
+  getAllNotifications: jest.fn(),
+  markNotification: jest.fn(),
+  findNotificationsByMultisigId: jest.fn(),
+  pollLongOperationsWithCb: jest.fn(),
+  processOperation: jest.fn(),
+  addPendingOperationToQueue: jest.fn(),
 });
 
 const identifiersListMock = jest.fn();
@@ -128,8 +134,8 @@ const agentServicesProps = {
 const multiSigService = new MultiSigService(
   agentServicesProps,
   identifierStorage as any,
-  notificationStorage as any,
-  operationPendingStorage as any
+  operationPendingStorage as any,
+  signifyNotificationService as any
 );
 
 let mockResolveOobi = jest.fn();
@@ -620,11 +626,6 @@ describe("Multisig sig service of agent", () => {
   test("can join the multisig inception", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
     const multisigIdentifier = "newMultisigIdentifierAid";
-    notificationStorage.findById = jest.fn().mockResolvedValue({
-      content: {
-        d: "d",
-      },
-    });
     groupGetRequestMock = jest.fn().mockResolvedValue([
       {
         exn: {
@@ -1198,11 +1199,6 @@ describe("Multisig sig service of agent", () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()
       .mockResolvedValue(metadata);
-    notificationStorage.findById = jest.fn().mockResolvedValue({
-      content: {
-        d: "d",
-      },
-    });
     groupGetRequestMock = jest.fn().mockResolvedValue([
       {
         exn: {
@@ -1245,11 +1241,6 @@ describe("Multisig sig service of agent", () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()
       .mockResolvedValue(metadata);
-    notificationStorage.findById = jest.fn().mockResolvedValue({
-      content: {
-        d: "d",
-      },
-    });
     groupGetRequestMock = jest.fn().mockResolvedValue([
       {
         exn: {

--- a/src/core/agent/services/multiSigService.ts
+++ b/src/core/agent/services/multiSigService.ts
@@ -27,7 +27,6 @@ import {
   IdentifierMetadataRecord,
   IdentifierMetadataRecordProps,
   IdentifierStorage,
-  NotificationStorage,
   OperationPendingStorage,
 } from "../records";
 import { AgentService } from "./agentService";
@@ -41,6 +40,7 @@ import {
 import { OnlineOnly, waitAndGetDoneOp } from "./utils";
 import { OperationPendingRecordType } from "../records/operationPendingRecord.type";
 import { ConfigurationService } from "../../configuration";
+import { SignifyNotificationService } from "./signifyNotificationService";
 
 class MultiSigService extends AgentService {
   static readonly INVALID_THRESHOLD = "Invalid threshold";
@@ -69,19 +69,19 @@ class MultiSigService extends AgentService {
     "We do not control any member AID of the multi-sig";
 
   protected readonly identifierStorage: IdentifierStorage;
-  protected readonly notificationStorage!: NotificationStorage;
   protected readonly operationPendingStorage: OperationPendingStorage;
+  protected readonly signifyNotifications: SignifyNotificationService;
 
   constructor(
     agentServiceProps: AgentServicesProps,
     identifierStorage: IdentifierStorage,
-    notificationStorage: NotificationStorage,
-    operationPendingStorage: OperationPendingStorage
+    operationPendingStorage: OperationPendingStorage,
+    signifyNotificationService: SignifyNotificationService
   ) {
     super(agentServiceProps);
     this.identifierStorage = identifierStorage;
-    this.notificationStorage = notificationStorage;
     this.operationPendingStorage = operationPendingStorage;
+    this.signifyNotifications = signifyNotificationService;
   }
 
   @OnlineOnly
@@ -162,9 +162,7 @@ class MultiSigService extends AgentService {
         id: op.name,
         recordType: OperationPendingRecordType.Group,
       });
-      Agent.agent.signifyNotifications.addPendingOperationToQueue(
-        pendingOperation
-      );
+      this.signifyNotifications.addPendingOperationToQueue(pendingOperation);
     } else {
       // Trigger the end role authorization if the operation is done
       await this.endRoleAuthorization(signifyName);
@@ -352,7 +350,7 @@ class MultiSigService extends AgentService {
       aid,
       multiSig.signifyName
     );
-    await Agent.agent.signifyNotifications.deleteNotificationRecordById(
+    await this.signifyNotifications.deleteNotificationRecordById(
       notification.id,
       notification.a.r as NotificationRoute
     );
@@ -456,7 +454,7 @@ class MultiSigService extends AgentService {
     // @TODO - foconnor: getMultisigDetails already has much of this done so this method signature could be adjusted.
     const hasJoined = await this.hasJoinedMultisig(notificationSaid);
     if (hasJoined) {
-      await Agent.agent.signifyNotifications.deleteNotificationRecordById(
+      await this.signifyNotifications.deleteNotificationRecordById(
         notificationId,
         notificationRoute
       );
@@ -499,7 +497,6 @@ class MultiSigService extends AgentService {
       .get(identifier?.signifyName);
     const signifyName = uuidv4();
     const res = await this.joinMultisigKeri(exn, aid, signifyName);
-    await this.notificationStorage.deleteById(notificationId);
     const op = res.op;
     const multisigId = op.name.split(".")[1];
     const isPending = !op.done;
@@ -524,14 +521,15 @@ class MultiSigService extends AgentService {
         id: op.name,
         recordType: OperationPendingRecordType.Group,
       });
-      Agent.agent.signifyNotifications.addPendingOperationToQueue(
-        pendingOperation
-      );
+      this.signifyNotifications.addPendingOperationToQueue(pendingOperation);
     } else {
       // Trigger the end role authorization if the operation is done
       await this.endRoleAuthorization(signifyName);
     }
-
+    await this.signifyNotifications.deleteNotificationRecordById(
+      notificationId,
+      notificationRoute
+    );
     return { identifier: multisigId, signifyName, isPending };
   }
 


### PR DESCRIPTION
We were just deleting the notification record and not marking it as read on KERIA. So if the DB was lost and wallet recovered, the notification was re-appearing.

Also moved it to the bottom of the function. We should only delete the notification once it has successfully been actioned completely in case it fails halfway through.