### PR TITLE
fix: remove newly joined group identifier from 

### DIFF
--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -185,6 +185,7 @@ interface AgentServicesProps {
 interface CreateIdentifierResult {
   signifyName: string;
   identifier: string;
+  multisigManageAid?: string;
   isPending?: boolean;
 }
 

--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -708,6 +708,7 @@ describe("Multisig sig service of agent", () => {
     ).toEqual({
       identifier: multisigIdentifier,
       isPending: true,
+      multisigManageAid: "id",
       signifyName: expect.any(String),
     });
 

--- a/src/core/agent/services/multiSigService.ts
+++ b/src/core/agent/services/multiSigService.ts
@@ -530,7 +530,12 @@ class MultiSigService extends AgentService {
       notificationId,
       notificationRoute
     );
-    return { identifier: multisigId, signifyName, isPending };
+    return {
+      identifier: multisigId,
+      multisigManageAid: identifier.id,
+      signifyName,
+      isPending,
+    };
   }
 
   @OnlineOnly

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/MultiSigRequest.tsx
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/MultiSigRequest.tsx
@@ -103,7 +103,7 @@ const MultiSigRequest = ({
         "Cannot accept a multi-sig inception event before details are loaded from core"
       );
     } else {
-      const { identifier, signifyName, isPending } =
+      const { identifier, multisigManageAid, signifyName, isPending } =
         (await Agent.agent.multiSigs.joinMultisig(
           notificationDetails.id,
           notificationDetails.a.r as NotificationRoute,
@@ -121,6 +121,7 @@ const MultiSigRequest = ({
           createdAtUTC: `${notificationDetails?.createdAt}`,
           theme: multisigIcpDetails.ourIdentifier.theme,
           isPending: !!isPending,
+          multisigManageAid,
           signifyName,
         };
         const filteredIdentifiersData = identifiersData.filter(


### PR DESCRIPTION
Small bug - Redux issue after just joining a group identifier. It was appearing in the list of individual identifiers.