### PR TITLE
bugfix(ui): Sort notifications by chronological order

### DIFF
--- a/src/ui/pages/Notifications/Notifications.tsx
+++ b/src/ui/pages/Notifications/Notifications.tsx
@@ -40,7 +40,10 @@ const Notifications = () => {
   const pageId = "notifications-tab";
   const dispatch = useAppDispatch();
   const history = useHistory();
-  const notifications = useAppSelector(getNotificationsCache);
+  const notificationsCache = useAppSelector(getNotificationsCache);
+  const notifications = [...notificationsCache].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
   const [selectedFilter, setSelectedFilter] = useState(NotificationFilter.All);
   const earlierNotificationRef = useRef<EarlierNotificationRef>(null);
   const [selectedItem, setSelectedItem] = useState<KeriaNotification | null>(


### PR DESCRIPTION
## Description

For some reason, notifications aren't sorted from the newest to the oldest. Adding this small fix to make sure they are.

Since I am not adding anything new to the UI, I will only take screenshots on the browser.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1325**](https://cardanofoundation.atlassian.net/issues/DTIS-1325)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser
##### _Before_

![6e3c1de5-9d7f-49a7-9752-6ffabb11be25](https://github.com/user-attachments/assets/a3b5dc88-f2e2-4c14-9178-5e0792f770a3)


##### _After_

![19092024152011](https://github.com/user-attachments/assets/ee69f2c4-31ef-44e3-bd6c-c8b0d5baffcf)
