### PR TITLE
fix(core): deleted identifiers should not be returned from get all

### DIFF
--- a/src/core/agent/records/identifierStorage.ts
+++ b/src/core/agent/records/identifierStorage.ts
@@ -27,6 +27,7 @@ class IdentifierStorage {
   async getAllIdentifierMetadata(): Promise<IdentifierMetadataRecord[]> {
     const records = await this.storageService.findAllByQuery(
       {
+        isDeleted: false,
         $not: {
           groupCreated: true,
         },


### PR DESCRIPTION
#723 introduced this because we always expected deleted identifiers to already be archived.