### PR TITLE
ci(gha): stop running PR pipelines for PRs to main

### DIFF
--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -7,6 +7,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
     types: [ opened, synchronize ]
+    branches-ignore: [ main ]
     paths:
     - 'Earthfile'
     - '.github/workflows/docker-builds.yaml'

--- a/.github/workflows/gh-verify-pr.yaml
+++ b/.github/workflows/gh-verify-pr.yaml
@@ -9,6 +9,7 @@ name: verify-pr
 on:
   pull_request:
     types: [ opened, synchronize ]
+    branches-ignore: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
We have PR workflows and workflows for pushes to develop and main.

For merges from develop to main - we don't need the PR workflow and can just use the push workflow.