### PR TITLE
fix(ui): Disconnect wallet firing twice 

### DIFF
--- a/src/core/cardano/walletConnect/peerConnection.ts
+++ b/src/core/cardano/walletConnect/peerConnection.ts
@@ -65,12 +65,13 @@ class PeerConnection {
   onPeerDisconnectedStateChanged(
     callback: (event: PeerDisconnectedEvent) => void
   ) {
-    this.eventService.on(
-      PeerConnectionEventTypes.PeerDisconnected,
-      async (event: PeerDisconnectedEvent) => {
-        callback(event);
-      }
-    );
+    this.eventService.on(PeerConnectionEventTypes.PeerDisconnected, callback);
+  }
+
+  offPeerDisconnectedStateChanged(
+    callback: (event: PeerDisconnectedEvent) => void
+  ) {
+    this.eventService.off(PeerConnectionEventTypes.PeerDisconnected, callback);
   }
 
   onPeerConnectionBrokenStateChanged(

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -251,19 +251,26 @@ const AppWrapper = (props: { children: ReactNode }) => {
   }, [authentication.loggedIn, initAppSuccess]);
 
   useEffect(() => {
-    PeerConnection.peerConnection.onPeerDisconnectedStateChanged(
-      async (event) => {
-        if (!connectedWallet) {
-          return;
-        }
-        return peerDisconnectedChangeHandler(
-          event,
-          connectedWallet.id,
-          dispatch
-        );
+    if (!connectedWallet?.id) {
+      return;
+    }
+
+    const eventHandler = async (event: PeerDisconnectedEvent) => {
+      if (!connectedWallet?.id) {
+        return;
       }
-    );
-  }, [connectedWallet, dispatch]);
+
+      peerDisconnectedChangeHandler(event, connectedWallet.id, dispatch);
+    };
+
+    PeerConnection.peerConnection.onPeerDisconnectedStateChanged(eventHandler);
+
+    return () => {
+      PeerConnection.peerConnection.offPeerDisconnectedStateChanged(
+        eventHandler
+      );
+    };
+  }, [connectedWallet?.id, dispatch]);
 
   const checkKeyStore = async (key: string) => {
     try {

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -256,10 +256,6 @@ const AppWrapper = (props: { children: ReactNode }) => {
     }
 
     const eventHandler = async (event: PeerDisconnectedEvent) => {
-      if (!connectedWallet?.id) {
-        return;
-      }
-
       peerDisconnectedChangeHandler(event, connectedWallet.id, dispatch);
     };
 

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -153,7 +153,6 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
     const disconnectWallet = () => {
       if (!connectedWallet) return;
       PeerConnection.peerConnection.disconnectDApp(connectedWallet?.id);
-      dispatch(setConnectedWallet(null));
     };
 
     const toggleConnected = () => {
@@ -246,7 +245,12 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
           data: connectedWallet,
         });
       }
-    }, [connectedWallet, toastMsgs, pendingConnection]);
+    }, [
+      connectedWallet,
+      toastMsgs,
+      pendingConnection,
+      openConfirmConnectModal,
+    ]);
 
     useEffect(() => {
       if (!pendingConnection) return;
@@ -260,7 +264,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
           handleOpenConfirmConnectModal(pendingConnection);
         }, ANIMATION_DURATION);
       }
-    }, [currentOperation, pendingConnection]);
+    }, [currentOperation, dispatch, pendingConnection]);
 
     return (
       <>


### PR DESCRIPTION
## Description

Disconnect cardano wallet firing twice

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1342](https://cardanofoundation.atlassian.net/browse/DTIS-1342)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser
##### Before

https://github.com/user-attachments/assets/8511f429-1f01-48a2-9742-fccbb5d27bfa


##### After

https://github.com/user-attachments/assets/7be41f05-7c0e-4954-847c-3de5c7df92b1



[DTIS-1342]: https://cardanofoundation.atlassian.net/browse/DTIS-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ