### PR TITLE
feat(ui): Credential request improvements

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1044,7 +1044,9 @@
             "description": "Below is a list of all '{{requestCred}}' credentials, ordered by the name of the issuer",
             "title": "Choose credential",
             "active": "Active",
+            "noactive": "There are no active '{{requestCred}}' credentials.",
             "revoked": "Revoked",
+            "norevoked": "There are no revoked '{{requestCred}}' credentials.",
             "disclaimer": "The below credentials are revoked and may not be accepted by the verifier."
           }
         },

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1042,7 +1042,10 @@
           },
           "choosecredential": {
             "description": "Below is a list of all '{{requestCred}}' credentials, ordered by the name of the issuer",
-            "title": "Choose credential"
+            "title": "Choose credential",
+            "active": "Active",
+            "revoked": "Revoked",
+            "disclaimer": "The below credentials are revoked and may not be accepted by the verifier."
           }
         },
         "receive": {

--- a/src/ui/__fixtures__/credRequestFix.ts
+++ b/src/ui/__fixtures__/credRequestFix.ts
@@ -9,7 +9,7 @@ const credRequestFix = {
       connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
       acdc: {
         v: "ACDC10JSON000191_",
-        d: "ENj6MvfV1AdbBtkI-0BTLcTMPYtl1PDu1AXVHN4hMzVa",
+        d: "EKfweht5lOkjaguB5dz42BMkfejhBFIF9-ghumzCJ6nv",
         i: "EKtDv2h7MNqyhI5iODKtjEQAYWG-tjV5mDzEMf6MW6V0",
         ri: "EANnrMjnnwmII_zt11VA3Y2O4hLqdXRxS1PI18zopFVT",
         s: "EBIFDhtSE0cM4nbTnaMqiV1vUIlcnbsqBMeVMmeGmXOu",

--- a/src/ui/components/CardList/CardList.scss
+++ b/src/ui/components/CardList/CardList.scss
@@ -63,7 +63,7 @@
         line-height: 1rem;
         font-weight: 400;
         color: var(--ion-color-primary);
-        margin: 0 0 1rem 0;
+        margin: 0.2rem 0 1rem 0;
       }
     }
   }

--- a/src/ui/components/layout/ScrollablePageLayout/ScrollablePageLayout.scss
+++ b/src/ui/components/layout/ScrollablePageLayout/ScrollablePageLayout.scss
@@ -10,11 +10,11 @@
 
     > * {
       flex: 0 1 auto;
-      margin: 0 auto 1.56rem;
+      margin: 0 auto 1.5rem;
     }
 
     > h2 {
-      margin: 1rem 0 0.94rem;
+      margin: 0.75rem 0 1.75rem;
     }
   }
 
@@ -23,11 +23,11 @@
 
     .scrollable-page-content {
       > * {
-        margin: 0 auto 1.248rem;
+        margin: 0 auto 1.2rem;
       }
 
       > h2 {
-        margin: 0.5rem 0 0.94rem;
+        margin: 0.6rem 0 1.4rem;
       }
     }
   }

--- a/src/ui/pages/Menu/components/Settings/components/RecoverySeedPhrase/RecoverySeedPhrase.scss
+++ b/src/ui/pages/Menu/components/Settings/components/RecoverySeedPhrase/RecoverySeedPhrase.scss
@@ -15,7 +15,7 @@
 
     .card-details-info-block-inner {
       background: rgba(var(--ion-color-dark-grey-rgb), 0.5);
-      padding: 1rem 1.25rem;
+      padding: 1.25rem;
       display: flex;
       flex-direction: row;
       margin-bottom: 1.5rem;
@@ -28,10 +28,6 @@
           color: var(--ion-color-secondary);
         }
       }
-    }
-
-    .card-details-info-block-inner {
-      padding: 1.25rem;
     }
 
     .tips {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.scss
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.scss
@@ -8,8 +8,6 @@
   .title {
     font-size: 1rem;
     line-height: 1.115rem;
-    margin-top: 0.75rem;
-    margin-bottom: 1.75rem;
     font-weight: 500;
     text-align: center;
   }
@@ -34,6 +32,25 @@
 
   .card-item {
     --background-activated: transparent;
+  }
+
+  .card-details-info-block-inner {
+    background: rgba(var(--ion-color-dark-grey-rgb), 0.5);
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 1.5rem;
+
+    .disclaimer-icon {
+      width: 1.5rem;
+      height: 1.5rem;
+
+      ion-icon {
+        color: var(--ion-color-secondary);
+        width: 1.5rem;
+        height: 1.5rem;
+      }
+    }
   }
 
   .credential-request-footer {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.test.tsx
@@ -4,8 +4,8 @@ import { Provider } from "react-redux";
 import { createMemoryHistory } from "history";
 import configureStore from "redux-mock-store";
 import { IonReactMemoryRouter } from "@ionic/react-router";
-import { act } from "react-dom/test-utils";
 import { SecureStorage } from "@aparajita/capacitor-secure-storage";
+import { act } from "react";
 import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
 import { TabsRoutePath } from "../../../../../routes/paths";
 import { connectionsForNotifications } from "../../../../__fixtures__/connectionsFix";
@@ -17,7 +17,11 @@ import { ACDC } from "./CredentialRequest.types";
 import { credRequestFix } from "../../../../__fixtures__/credRequestFix";
 import { KeyStoreKeys } from "../../../../../core/storage";
 import { passcodeFiller } from "../../../../utils/passcodeFiller";
-import { credsFixAcdc } from "../../../../__fixtures__/credsFix";
+import {
+  credsFixAcdc,
+  revokedCredFixs,
+} from "../../../../__fixtures__/credsFix";
+import { CredentialStatus } from "../../../../../core/agent/services/credentialService.types";
 
 mockIonicReact();
 
@@ -47,6 +51,8 @@ const offerAcdcFromApplyMock = jest.fn(
     })
 );
 
+const combineMock = jest.fn(() => credsFixAcdc);
+
 jest.mock("../../../../../core/agent/agent", () => ({
   Agent: {
     agent: {
@@ -62,6 +68,7 @@ jest.mock("../../../../../core/agent/agent", () => ({
         getCredentialDetailsById: jest.fn(() =>
           Promise.resolve(credsFixAcdc[0])
         ),
+        getCredsCache: () => combineMock(),
       },
     },
   },
@@ -98,7 +105,10 @@ const initialState = {
 };
 
 describe("Credential request - choose request", () => {
-  test("Render", async () => {
+  beforeEach(() => {
+    combineMock.mockReturnValue(credsFixAcdc);
+  });
+  test("Render full active credentials & empty revoked tab", async () => {
     const storeMocked = {
       ...mockStore(initialState),
       dispatch: dispatchMock,
@@ -149,6 +159,7 @@ describe("Credential request - choose request", () => {
         )} - ${formatTimeToSec(credRequestFix.credentials[0].acdc.a.dt)}`
       )
     ).toBeVisible();
+
     expect(
       getByText(
         `${formatShortDate(
@@ -156,6 +167,23 @@ describe("Credential request - choose request", () => {
         )} - ${formatTimeToSec(credRequestFix.credentials[1].acdc.a.dt)}`
       )
     ).toBeVisible();
+
+    const segment = getByTestId("choose-credential-segment");
+
+    act(() => {
+      ionFireEvent.ionChange(segment, "revoked");
+    });
+
+    await waitFor(() =>
+      expect(
+        getByText(
+          EN_TRANSLATIONS.notifications.details.credential.request.choosecredential.norevoked.replace(
+            "{{requestCred}}",
+            credRequestFix.schema.name
+          )
+        )
+      ).toBeVisible()
+    );
   });
 
   test("Show detail", async () => {
@@ -352,6 +380,9 @@ describe("Credential request - choose request", () => {
           passcodeIsSet: true,
         },
       },
+      credsCache: {
+        creds: [],
+      },
       connectionsCache: {
         connections: connectionsForNotifications,
       },
@@ -439,6 +470,74 @@ describe("Credential request - choose request", () => {
     expect(offerAcdcFromApplyMock).toBeCalledWith(
       notificationsFix[4],
       credRequestFix.credentials[0].acdc
+    );
+  });
+});
+
+describe("Credential request - choose request", () => {
+  const updatedCredsFixAcdc = [
+    {
+      ...credsFixAcdc[0],
+      status: CredentialStatus.REVOKED,
+    },
+    ...credsFixAcdc.slice(1),
+  ];
+
+  beforeEach(() => {
+    combineMock.mockReturnValue(updatedCredsFixAcdc);
+  });
+  test.skip("Render empty active credentials & full revoked tab", async () => {
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const history = createMemoryHistory();
+
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <IonReactMemoryRouter history={history}>
+          <ChooseCredential
+            pageId="multi-sign"
+            activeStatus
+            onBack={jest.fn()}
+            onClose={jest.fn()}
+            notificationDetails={notificationsFix[4]}
+            credentialRequest={credRequestFix}
+            reloadData={jest.fn}
+          />
+        </IonReactMemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText(
+          EN_TRANSLATIONS.notifications.details.credential.request
+            .choosecredential.title
+        )
+      ).toBeVisible();
+    });
+
+    expect(
+      getByText(
+        EN_TRANSLATIONS.notifications.details.credential.request.choosecredential.noactive.replace(
+          "{{requestCred}}",
+          credRequestFix.schema.name
+        )
+      )
+    ).toBeVisible();
+
+    const segment = getByTestId("choose-credential-segment");
+
+    act(() => {
+      ionFireEvent.ionChange(segment, "revoked");
+    });
+
+    await waitFor(() =>
+      expect(
+        getByTestId("card-item-" + credRequestFix.credentials[0].acdc.d)
+      ).toBeVisible()
     );
   });
 });

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.test.tsx
@@ -51,8 +51,6 @@ const offerAcdcFromApplyMock = jest.fn(
     })
 );
 
-const combineMock = jest.fn(() => credsFixAcdc);
-
 jest.mock("../../../../../core/agent/agent", () => ({
   Agent: {
     agent: {
@@ -68,7 +66,6 @@ jest.mock("../../../../../core/agent/agent", () => ({
         getCredentialDetailsById: jest.fn(() =>
           Promise.resolve(credsFixAcdc[0])
         ),
-        getCredsCache: () => combineMock(),
       },
     },
   },
@@ -105,9 +102,6 @@ const initialState = {
 };
 
 describe("Credential request - choose request", () => {
-  beforeEach(() => {
-    combineMock.mockReturnValue(credsFixAcdc);
-  });
   test("Render full active credentials & empty revoked tab", async () => {
     const storeMocked = {
       ...mockStore(initialState),
@@ -475,21 +469,45 @@ describe("Credential request - choose request", () => {
 });
 
 describe("Credential request - choose request", () => {
-  const updatedCredsFixAcdc = [
-    {
-      ...credsFixAcdc[0],
-      status: CredentialStatus.REVOKED,
-    },
-    ...credsFixAcdc.slice(1),
-  ];
+  const credsCacheMock = credsFixAcdc.map((item) => ({
+    ...item,
+    status: CredentialStatus.REVOKED,
+  }));
 
-  beforeEach(() => {
-    combineMock.mockReturnValue(updatedCredsFixAcdc);
-  });
-  test.skip("Render empty active credentials & full revoked tab", async () => {
+  const initialState = {
+    stateCache: {
+      routes: [TabsRoutePath.NOTIFICATIONS],
+      authentication: {
+        loggedIn: true,
+        time: Date.now(),
+        passcodeIsSet: true,
+      },
+    },
+    credsCache: {
+      creds: credsCacheMock,
+    },
+    connectionsCache: {
+      connections: connectionsForNotifications,
+    },
+    notificationsCache: {
+      notifications: notificationsFix,
+    },
+  };
+
+  test("Render empty active credentials & full revoked tab", async () => {
     const storeMocked = {
       ...mockStore(initialState),
       dispatch: dispatchMock,
+    };
+
+    const credMock = {
+      ...credRequestFix,
+      credentials: [
+        {
+          ...credRequestFix.credentials[0],
+          status: CredentialStatus.REVOKED,
+        },
+      ],
     };
 
     const history = createMemoryHistory();
@@ -503,7 +521,7 @@ describe("Credential request - choose request", () => {
             onBack={jest.fn()}
             onClose={jest.fn()}
             notificationDetails={notificationsFix[4]}
-            credentialRequest={credRequestFix}
+            credentialRequest={credMock}
             reloadData={jest.fn}
           />
         </IonReactMemoryRouter>

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.tsx
@@ -79,7 +79,7 @@ const ChooseCredential = ({
   const [viewCredDetail, setViewCredDetail] =
     useState<RequestCredential | null>(null);
 
-  const displayIdentifiers = credentialRequest.credentials.map(
+  const mappedCredentials = credentialRequest.credentials.map(
     (cred): CardItem<RequestCredential> => {
       const connection = connections?.[cred.connectionId]?.label || "";
 
@@ -94,6 +94,18 @@ const ChooseCredential = ({
       };
     }
   );
+
+  const sortedCredentials = mappedCredentials.sort(function (a, b) {
+    if (a.title < b.title) {
+      return -1;
+    }
+    if (a.title > b.title) {
+      return 1;
+    }
+    const dateA = new Date(a.data.acdc.a.dt).getTime();
+    const dateB = new Date(b.data.acdc.a.dt).getTime();
+    return dateA - dateB;
+  });
 
   const handleSelectCred = useCallback((data: RequestCredential) => {
     setSelectedCred((selectedCred) =>
@@ -193,7 +205,7 @@ const ChooseCredential = ({
           )}
         </h2>
         <CardList
-          data={displayIdentifiers}
+          data={sortedCredentials}
           onCardClick={(data, e) => {
             e.stopPropagation();
             handleSelectCred(data);

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.tsx
@@ -268,6 +268,30 @@ const ChooseCredential = ({
             </div>
           </CardDetailsBlock>
         )}
+        {segmentValue === "active" && activeCredentials.length === 0 && (
+          <h2 className="title">
+            <i>
+              {i18n.t(
+                "notifications.details.credential.request.choosecredential.noactive",
+                {
+                  requestCred: credentialRequest.schema.name,
+                }
+              )}
+            </i>
+          </h2>
+        )}
+        {segmentValue === "revoked" && revokedCredentials.length === 0 && (
+          <h2 className="title">
+            <i>
+              {i18n.t(
+                "notifications.details.credential.request.choosecredential.norevoked",
+                {
+                  requestCred: credentialRequest.schema.name,
+                }
+              )}
+            </i>
+          </h2>
+        )}
         <CardList
           data={
             segmentValue === "active" ? activeCredentials : revokedCredentials

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
@@ -118,7 +118,7 @@ describe("Credential request", () => {
       <Provider store={storeMocked}>
         <IonReactMemoryRouter history={history}>
           <CredentialRequest
-            pageId="multi-sign"
+            pageId="notification-details"
             activeStatus
             handleBack={jest.fn()}
             notificationDetails={notificationsFix[4]}
@@ -141,7 +141,7 @@ describe("Credential request", () => {
     });
 
     act(() => {
-      fireEvent.click(getByTestId("primary-button-multi-sign"));
+      fireEvent.click(getByTestId("primary-button-notification-details"));
     });
 
     await waitFor(() => {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
@@ -1,15 +1,17 @@
 import { IonReactMemoryRouter } from "@ionic/react-router";
 import { mockIonicReact } from "@ionic/react-test-utils";
-import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
+import { act } from "react";
 import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
 import { TabsRoutePath } from "../../../../../routes/paths";
 import { connectionsForNotifications } from "../../../../__fixtures__/connectionsFix";
 import { notificationsFix } from "../../../../__fixtures__/notificationsFix";
 import { CredentialRequest } from "./CredentialRequest";
 import { credRequestFix } from "../../../../__fixtures__/credRequestFix";
+import { credsFixAcdc } from "../../../../__fixtures__/credsFix";
 
 mockIonicReact();
 
@@ -41,6 +43,8 @@ const initialState = {
   connectionsCache: {
     connections: connectionsForNotifications,
   },
+  credsCache: { creds: credsFixAcdc, favourites: [] },
+  credsArchivedCache: { creds: [] },
   notificationsCache: {
     notifications: notificationsFix,
   },


### PR DESCRIPTION
## Description

Adding tabs to let the user choose between providing an active or a revoked credential when asked to provide one.

We are still showing the alert when the user receives a request but they don't have any suitable credential, but we are now also adding a dedicated message inside each tab in case they have one which falls into one category and not in the other. Some demo of this have been added below the videos for iOS and Android and tested in the browser.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1327**](https://cardanofoundation.atlassian.net/issues/DTIS-1327)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS


https://github.com/user-attachments/assets/ec309b99-004e-4c8b-826f-fc7b9fc56d73


https://github.com/user-attachments/assets/66394a92-130a-4a67-9677-41d15e24d8c2


https://github.com/user-attachments/assets/9dc90520-1cde-4c54-bf57-b19342517b65



#### Android


https://github.com/user-attachments/assets/bf64475d-893d-4953-a52b-272d2c240d6a


https://github.com/user-attachments/assets/e60ddf5b-629f-4b18-a517-de7d74c33ded


https://github.com/user-attachments/assets/1d684bcb-dd96-4a11-89d8-9da144d2c634

#### Browser

##### No suitable credentials available (at all, this is the old alert)


https://github.com/user-attachments/assets/a81a51d1-fe67-4af1-bca4-aabfd620641a


##### Only active or only revoked available (to show the placeholder message when the list is empty)


https://github.com/user-attachments/assets/752f064a-1462-469e-86e0-19017a9b403e

