### PR TITLE
feat(ui): Add Credential ID to the Credential Details Page

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -876,6 +876,7 @@
       "title": "Title",
       "description": "Description",
       "revoked": "Revoked",
+      "id": "Credential ID",
       "attributes": {
         "label": "Attributes",
         "issuee": "Issuee",

--- a/src/ui/components/CredentialDetailModule/CredentialDetailModule.tsx
+++ b/src/ui/components/CredentialDetailModule/CredentialDetailModule.tsx
@@ -61,23 +61,19 @@ const CredentialDetailModule = ({
   const { isLightMode } = props;
   const selected = isLightMode ? props.selected : false;
   const setSelected = isLightMode ? props.setSelected : undefined;
-
   const dispatch = useAppDispatch();
   const credsCache = useAppSelector(getCredsCache);
   const favouritesCredsCache = useAppSelector(getFavouritesCredsCache);
   const notifications = useAppSelector(getNotificationsCache);
-
   const [optionsIsOpen, setOptionsIsOpen] = useState(false);
   const [alertDeleteArchiveIsOpen, setAlertDeleteArchiveIsOpen] =
     useState(false);
   const [alertRestoreIsOpen, setAlertRestoreIsOpen] = useState(false);
   const [verifyIsOpen, setVerifyIsOpen] = useState(false);
   const [cardData, setCardData] = useState<ACDCDetails>();
-
   const isArchived = credsCache.filter((item) => item.id === id).length === 0;
   const isRevoked = cardData?.status === CredentialStatus.REVOKED;
   const isInactiveCred = isArchived || isRevoked;
-
   const isFavourite = favouritesCredsCache?.some((fav) => fav.id === id);
   const [cloudError, setCloudError] = useState(false);
 

--- a/src/ui/components/CredentialDetailModule/components/CredentialContent.test.tsx
+++ b/src/ui/components/CredentialDetailModule/components/CredentialContent.test.tsx
@@ -18,6 +18,10 @@ describe("Creds content", () => {
     expect(
       getByText(EN_TRANSLATIONS.credentials.details.description)
     ).toBeVisible();
+    expect(getByText(EN_TRANSLATIONS.credentials.details.id)).toBeVisible();
+    expect(
+      getByText("EKfweht5lOkjaguB5dz42BMkfejhBFIF9-ghumzCJ6nv")
+    ).toBeVisible();
     expect(
       getByText(
         "A vLEI Credential issued by GLEIF to Qualified vLEI Issuers which allows the Qualified vLEI Issuers to issue, verify and revoke Legal Entity vLEI Credentials and Legal Entity Official Organizational Role vLEI Credentials"
@@ -29,7 +33,7 @@ describe("Creds content", () => {
     expect(
       getByText("EJWgO4hwKxNMxu2aUpmGFMozKt9Eq2Jz8n-xXR7CYtY_")
     ).toBeVisible();
-    // expect(getByText("22/01/2024 - 16:03:44")).toBeVisible();
+    expect(getByText("22/01/2024 - 16:03:44")).toBeVisible();
     expect(getByText("5493001KJTIIGC8Y1R17")).toBeVisible();
     expect(getByText("1.0.0")).toBeVisible();
     expect(
@@ -47,6 +51,6 @@ describe("Creds content", () => {
     expect(
       getByText(EN_TRANSLATIONS.credentials.details.status.issued)
     ).toBeVisible();
-    // expect(getByText("22/01/2024 - 16:05:44")).toBeVisible();
+    expect(getByText("22/01/2024 - 16:05:44")).toBeVisible();
   });
 });

--- a/src/ui/components/CredentialDetailModule/components/CredentialContent.tsx
+++ b/src/ui/components/CredentialDetailModule/components/CredentialContent.tsx
@@ -24,6 +24,14 @@ const CredentialContent = ({ cardData }: CredentialContentProps) => {
       >
         {cardData.s.description}
       </CardDetailsBlock>
+      <CardDetailsBlock title={i18n.t("credentials.details.id")}>
+        <CardDetailsItem
+          info={cardData.id}
+          copyButton={true}
+          icon={keyOutline}
+          testId="card-details-id"
+        />
+      </CardDetailsBlock>
       {cardData.a && (
         <CardDetailsBlock
           className="card-attribute-block"


### PR DESCRIPTION
## Description

Add Credential ID to the Credential Details Page allowing the user to know and use this value.

I won't be adding any new UI feature, just adding one more value to the already existing list, therefore I will only take a screenshot from the browser.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1354**](https://cardanofoundation.atlassian.net/issues/DTIS-1354)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser

![24092024122934](https://github.com/user-attachments/assets/5fdbc29d-efa8-432b-bbec-7e5217403b48)
