### PR TITLE
fix(ui): remove delay from the receive credential animation

### DIFF
--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -42,7 +42,6 @@ const ReceiveCredential = ({
   const [initiateAnimation, setInitiateAnimation] = useState(false);
   const connection =
     connectionsCache?.[notificationDetails.connectionId]?.label;
-  const ANIMATION_DELAY = 2000;
 
   useIonHardwareBackButton(
     BackEventPriorityType.Page,
@@ -66,7 +65,7 @@ const ReceiveCredential = ({
       setTimeout(() => {
         handleNotificationUpdate();
         handleBack();
-      }, ANIMATION_DELAY);
+      });
     } catch (e) {
       setInitiateAnimation(false);
       showError("Unable to accept acdc", e, dispatch);


### PR DESCRIPTION
## Description

Making the receive credential animation quicker because at the moment it seems like we are stuck at the end of the animation.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1356**](https://cardanofoundation.atlassian.net/browse/DTIS-1356)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser

##### _Before_


https://github.com/user-attachments/assets/9ccdc2ea-c271-41b9-bc61-907b3db19f60


##### _After_


https://github.com/user-attachments/assets/bc5e6056-eeb6-4dd1-9464-ba20816a4b5d

