### PR TITLE
fixx(ui): SignRequest does not parse category id correctly

### DIFF
--- a/src/ui/components/CardDetails/CardDetailsAttributes/CardDetailsNestedAttributes.tsx
+++ b/src/ui/components/CardDetails/CardDetailsAttributes/CardDetailsNestedAttributes.tsx
@@ -17,9 +17,11 @@ const CardDetailsNestedAttributes = ({
   const { className, ...restItemProps } = itemProps || {};
   const key = attribute[0];
   const item = attribute[1] as any;
+  const dateRegex =
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,6}([+-]\d{2}:\d{2}|Z)$/;
 
   const cardDetailInfo = useMemo(() => {
-    if (item[10] === "T")
+    if (dateRegex.test(item))
       return `${formatShortDate(item)} - ${formatTimeToSec(item)}`;
 
     const isValuedType = typeof item === ("string" || "number");


### PR DESCRIPTION
## Description

The error was caused by a missing regex that was supposed to distinguish between attributes when receiving a normal string vs a date converted to string. 

The following date to string formats are accepted:

  "2024-01-22T16:03:44.643Z",
  "2024-09-18T14:53:15.497000+00:00",
  "2024-09-18T14:53:15.497-05:00",

I am only testing it on browser since I am not introducing any new UI elements to the existing design.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1362**](https://cardanofoundation.atlassian.net/browse/DTIS-1362)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Sign request

![24092024151548](https://github.com/user-attachments/assets/66e956b0-8364-4b23-8569-4c3464f08eea)


#### Identifier/Credential info

![24092024152256](https://github.com/user-attachments/assets/ad6348e8-90e4-4061-862e-66bf9148b257)
