### PR TITLE
fix(ui): fix scan issue after create multisig

### DIFF
--- a/src/ui/App.scss
+++ b/src/ui/App.scss
@@ -26,7 +26,7 @@ body {
         .app-spinner-container
       ):not(.input-pid-modal):not(.confirmation-toast):not(
         .alert-create-identifier
-      ):not(.create-identifier-modal) {
+      ):not(.create-stage-0) {
       display: none;
     }
 

--- a/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
+++ b/src/ui/components/CreateIdentifier/components/IdentifierStage0.tsx
@@ -37,6 +37,7 @@ import { TypeItem } from "./TypeItem";
 import { createThemeValue } from "../../../utils/theme";
 import { IADTypeInfoModal } from "./AIDTypeInfoModal";
 import { showError } from "../../../utils/error";
+import { combineClassNames } from "../../../utils/style";
 
 const IdentifierStage0 = ({
   state,
@@ -182,7 +183,10 @@ const IdentifierStage0 = ({
       <ScrollablePageLayout
         pageId={componentId + "-content"}
         activeStatus={isModalOpen}
-        customClass={keyboardIsOpen ? "keyboard-is-open" : ""}
+        customClass={combineClassNames(
+          "create-stage-0",
+          keyboardIsOpen ? "keyboard-is-open" : ""
+        )}
         header={
           <PageHeader
             closeButton={true}


### PR DESCRIPTION
## Description

Fix multisig scan issue. Reason because when full page scan open it will hide all element on app. I also fix create identifier modal not display when open full page scan.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1461](https://cardanofoundation.atlassian.net/browse/DTIS-1461)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
### Browser

https://github.com/user-attachments/assets/1b345e5d-e8ec-41bd-84d7-f6c7d6d0c85c



[DTIS-1461]: https://cardanofoundation.atlassian.net/browse/DTIS-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ