### PR TITLE
fix(ui): Recovery Phrase Verification Alphabetical Order

### DIFF
--- a/src/ui/pages/VerifySeedPhrase/VerifySeedPhrase.tsx
+++ b/src/ui/pages/VerifySeedPhrase/VerifySeedPhrase.tsx
@@ -1,7 +1,6 @@
 import { IonButton, IonIcon } from "@ionic/react";
 import { closeOutline } from "ionicons/icons";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useHistory } from "react-router-dom";
 import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
 import { i18n } from "../../../i18n";
 import { RoutePath } from "../../../routes";
@@ -25,7 +24,6 @@ import { showError } from "../../utils/error";
 
 const VerifySeedPhrase = () => {
   const pageId = "verify-seed-phrase";
-  const history = useHistory();
   const dispatch = useAppDispatch();
   const stateCache = useAppSelector(getStateCache);
   const seedPhraseStore = useAppSelector(getSeedPhraseCache);
@@ -40,21 +38,19 @@ const VerifySeedPhrase = () => {
     [seedPhraseStore.seedPhrase]
   );
 
-  const shuffleSeedPhrase = useCallback(() => {
+  const sortSeedPhrase = useCallback(() => {
     setSeedPhraseRemaining(
-      [...originalSeedPhrase].sort(() => Math.random() - 0.5)
+      [...originalSeedPhrase].sort((a, b) => a.localeCompare(b))
     );
   }, [originalSeedPhrase]);
 
   useEffect(() => {
-    if (history?.location.pathname === RoutePath.VERIFY_SEED_PHRASE) {
-      shuffleSeedPhrase();
-    }
-  }, [history?.location.pathname, shuffleSeedPhrase]);
+    sortSeedPhrase();
+  }, []);
 
   const handleClearSelected = () => {
     setSeedPhraseSelected([]);
-    shuffleSeedPhrase();
+    sortSeedPhrase();
     setClearAlertOpen(false);
   };
 
@@ -87,6 +83,7 @@ const VerifySeedPhrase = () => {
     }
     setSeedPhraseRemaining(seedPhraseRemaining.concat(words));
     setSeedPhraseSelected(newMatch);
+    sortSeedPhrase();
   };
 
   const storeIdentitySeedPhrase = async () => {


### PR DESCRIPTION
## Description

In this PR I am sorting the words in Verify Seed Phrase alphabetically, both when the page loads and also when the user clears the selections (that's when you click on the selected items and they go back to the list at the bottom of the page).

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [**DTIS-1453**](https://cardanofoundation.atlassian.net/issues/DTIS-1453)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---

#### Browser

https://github.com/user-attachments/assets/fe086bb4-2500-42fc-8c6c-83ee4a7149fb

