### PR TITLE
feat: set encryption for db

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
+        classpath 'com.android.tools.build:gradle:8.1.3'
         classpath 'com.google.gms:google-services:4.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -13,7 +13,10 @@ const config: CapacitorConfig = {
   },
   plugins: {
     CapacitorSQLite: {
-      "iosDatabaseLocation": "Library/IDWalletDatabase"
+      iosDatabaseLocation: "Library/IDWalletDatabase",
+      iosIsEncryption: true,
+      iosKeychainPrefix: "db-encryption-bran",
+      androidIsEncryption: true,
     },
     SplashScreen: {
       launchShowDuration: 3000,

--- a/src/core/storage/secureStorage/secureStorage.ts
+++ b/src/core/storage/secureStorage/secureStorage.ts
@@ -8,6 +8,7 @@ enum KeyStoreKeys {
   APP_OP_PASSWORD = "app-operations-password",
   SIGNIFY_BRAN = "signify-bran",
   MEERKAT_SEED = "app-meerkat-seed",
+  DB_ENCRYPTION_BRAN = "db-encryption-bran",
 }
 
 class SecureStorage {

--- a/src/core/storage/sqliteStorage/sqliteSession.ts
+++ b/src/core/storage/sqliteStorage/sqliteSession.ts
@@ -57,6 +57,7 @@ class SqliteSession {
       if (!isSetSecret) {
         const newBran = (await Agent.agent.getBranAndMnemonic()).bran;
         await connection.setEncryptionSecret(newBran);
+        await SecureStorage.set(KeyStoreKeys.DB_ENCRYPTION_BRAN, newBran);
       }
     }
 

--- a/src/core/storage/sqliteStorage/sqliteSession.ts
+++ b/src/core/storage/sqliteStorage/sqliteSession.ts
@@ -56,8 +56,8 @@ class SqliteSession {
       const isSetSecret = (await connection.isSecretStored()).result;
       if (!isSetSecret) {
         const newBran = (await Agent.agent.getBranAndMnemonic()).bran;
-        await connection.setEncryptionSecret(newBran);
         await SecureStorage.set(KeyStoreKeys.DB_ENCRYPTION_BRAN, newBran);
+        await connection.setEncryptionSecret(newBran);
       }
     }
 

--- a/src/core/storage/sqliteStorage/sqliteSession.ts
+++ b/src/core/storage/sqliteStorage/sqliteSession.ts
@@ -4,6 +4,7 @@ import {
   SQLiteDBConnection,
 } from "@capacitor-community/sqlite";
 import { Capacitor } from "@capacitor/core";
+import { randomPasscode } from "signify-ts";
 import { versionCompare } from "./utils";
 import { MIGRATIONS } from "./migrations";
 import { MigrationType } from "./migrations/migrations.types";
@@ -55,7 +56,7 @@ class SqliteSession {
     if (isEncryption) {
       const isSetSecret = (await connection.isSecretStored()).result;
       if (!isSetSecret) {
-        const newBran = (await Agent.agent.getBranAndMnemonic()).bran;
+        const newBran = randomPasscode();
         await SecureStorage.set(KeyStoreKeys.DB_ENCRYPTION_BRAN, newBran);
         await connection.setEncryptionSecret(newBran);
       }

--- a/src/core/storage/sqliteStorage/sqliteSession.ts
+++ b/src/core/storage/sqliteStorage/sqliteSession.ts
@@ -3,9 +3,12 @@ import {
   SQLiteConnection,
   SQLiteDBConnection,
 } from "@capacitor-community/sqlite";
+import { Capacitor } from "@capacitor/core";
 import { versionCompare } from "./utils";
 import { MIGRATIONS } from "./migrations";
 import { MigrationType } from "./migrations/migrations.types";
+import { Agent } from "../../agent/agent";
+import { KeyStoreKeys, SecureStorage } from "../secureStorage";
 
 class SqliteSession {
   static readonly VERSION_DATABASE_KEY = "VERSION_DATABASE_KEY";
@@ -44,6 +47,19 @@ class SqliteSession {
 
   async open(storageName: string): Promise<void> {
     const connection = new SQLiteConnection(CapacitorSQLite);
+
+    const platform = Capacitor.getPlatform();
+    const isPlatformEncryption = platform !== "web";
+    const isEncryptInConfig = (await connection.isInConfigEncryption()).result;
+    const isEncryption = isPlatformEncryption && isEncryptInConfig;
+    if (isEncryption) {
+      const isSetSecret = (await connection.isSecretStored()).result;
+      if (!isSetSecret) {
+        const newBran = (await Agent.agent.getBranAndMnemonic()).bran;
+        await connection.setEncryptionSecret(newBran);
+      }
+    }
+
     const ret = await connection.checkConnectionsConsistency();
     const isConn = (await connection.isConnection(storageName, false)).result;
     if (ret.result && isConn) {
@@ -54,8 +70,8 @@ class SqliteSession {
     } else {
       this.sessionInstance = await connection.createConnection(
         storageName,
-        false,
-        "no-encryption",
+        true,
+        "secret",
         1,
         false
       );


### PR DESCRIPTION
## Description

This PR updates the `open` method from sqlite to enhance the security of database connections by integrating encryption for non-web platforms. It checks if encryption is enabled and whether a secret is already stored. If no secret is stored, it generates a new one using `Agent.agent.getBranAndMnemonic()` and securely stores it using `SecureStorage`. This approach ensures that sensitive data handled by the application is more secure across platforms.

The sqlite plugin stores the key provided for encryption independently to which we cannot access or check the value of the key, that is why we store thhis new key-value using our `SecureStorage` in order to have 100% control of the encryption key.

From xcode you can get the path where the sqlite database is stored from the console, example:
`/Users/<user>/Library/Developer/CoreSimulator/Devices/49038AB0-E8DC-4630-AA46-C9F840EE6A82/data/Containers/Data/Application/8BF7533E-D6C3-49A2-8EFB-94E240803E98/Library/IDWalletDatabase`

Once the path is obtained, the database can be loaded in a browser that will ask for the password/bran used in the encryption in order to decrypt it.
![Screenshot 2024-10-15 at 11 50 50](https://github.com/user-attachments/assets/b689403b-76b9-4dbf-ab0e-3c4f6168d172)

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1400](https://cardanofoundation.atlassian.net/jira/software/projects/DTIS/boards/36?selectedIssue=DTIS-1400)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated


[DTIS-1400]: https://cardanofoundation.atlassian.net/browse/DTIS-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ