### PR TITLE
feat(core): return members when retrieving group identifier

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -313,6 +313,8 @@ class Agent {
       if (!(error instanceof Error)) {
         throw error;
       }
+      /* eslint-disable no-console */
+      console.error(error);
       const status = error.message.split(" - ")[1];
       if (error.message === "Failed to fetch") {
         throw new Error(Agent.KERIA_CONNECT_FAILED_BAD_NETWORK);
@@ -320,7 +322,7 @@ class Agent {
       if (/404/gi.test(status)) {
         throw new Error(Agent.KERIA_NOT_BOOTED);
       }
-      throw error;
+      throw new Error(Agent.KERIA_BOOTED_ALREADY_BUT_CANNOT_CONNECT);
     });
   }
 

--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -54,16 +54,20 @@ const walletId = "idw";
 class Agent {
   static readonly KERIA_CONNECTION_BROKEN =
     "The app is not connected to KERIA at the moment";
-  static readonly KERIA_BOOT_FAILED_BAD_NETWORK = "Failed to boot due to network connectivity";
-  static readonly KERIA_CONNECT_FAILED_BAD_NETWORK = "Failed to connect due to network connectivity"
+  static readonly KERIA_BOOT_FAILED_BAD_NETWORK =
+    "Failed to boot due to network connectivity";
+  static readonly KERIA_CONNECT_FAILED_BAD_NETWORK =
+    "Failed to connect due to network connectivity";
   static readonly KERIA_BOOT_FAILED = "Failed to boot signify client";
-  static readonly KERIA_BOOTED_ALREADY_BUT_CANNOT_CONNECT = "KERIA agent is already booted but cannot connect";
+  static readonly KERIA_BOOTED_ALREADY_BUT_CANNOT_CONNECT =
+    "KERIA agent is already booted but cannot connect";
   static readonly KERIA_NOT_BOOTED =
     "Agent has not been booted for a given Signify passcode";
   static readonly INVALID_MNEMONIC = "Seed phrase is invalid";
   static readonly MISSING_DATA_ON_KERIA =
     "Attempted to fetch data by ID on KERIA, but was not found. May indicate stale data records in the local database.";
   static readonly BUFFER_ALLOC_SIZE = 3;
+
   private static instance: Agent;
   private agentServicesProps: AgentServicesProps = {
     eventEmitter: undefined as any,
@@ -88,11 +92,11 @@ class Agent {
   private identifierService!: IdentifierService;
   private multiSigService!: MultiSigService;
   private ipexCommunicationService!: IpexCommunicationService;
-
   private connectionService!: ConnectionService;
   private credentialService!: CredentialService;
   private keriaNotificationService!: KeriaNotificationService;
   private authService!: AuthService;
+
   static isOnline = false;
 
   get identifiers() {
@@ -316,8 +320,8 @@ class Agent {
 
     this.signifyClient = new SignifyClient(connectUrl, bran, Tier.low);
     this.agentServicesProps.signifyClient = this.signifyClient;
-    
-    await this.signifyClient.connect().catch(error => {
+
+    await this.signifyClient.connect().catch((error) => {
       if (!(error instanceof Error)) {
         throw error;
       }
@@ -358,7 +362,7 @@ class Agent {
       if (
         error instanceof Error &&
         error.message ===
-        `${SecureStorage.KEY_NOT_FOUND} ${KeyStoreKeys.APP_PASSCODE}`
+          `${SecureStorage.KEY_NOT_FOUND} ${KeyStoreKeys.APP_PASSCODE}`
       ) {
         await SecureStorage.set(
           KeyStoreKeys.APP_PASSCODE,
@@ -375,7 +379,7 @@ class Agent {
       if (
         error instanceof Error &&
         error.message ===
-        `${SecureStorage.KEY_NOT_FOUND} ${KeyStoreKeys.SIGNIFY_BRAN}`
+          `${SecureStorage.KEY_NOT_FOUND} ${KeyStoreKeys.SIGNIFY_BRAN}`
       ) {
         await SecureStorage.set(
           KeyStoreKeys.SIGNIFY_BRAN,
@@ -385,12 +389,15 @@ class Agent {
         throw error;
       }
     }
-    await this.basicStorage.save({
-      id: MiscRecordId.APP_ALREADY_INIT,
-      content: {
-        initialized: true,
-      },
-    });
+
+    await this.basicStorage.createOrUpdateBasicRecord(
+      new BasicRecord({
+        id: MiscRecordId.APP_ALREADY_INIT,
+        content: {
+          initialized: true,
+        },
+      })
+    );
 
     await this.basicStorage.createOrUpdateBasicRecord(
       new BasicRecord({

--- a/src/core/agent/services/credentialService.ts
+++ b/src/core/agent/services/credentialService.ts
@@ -107,10 +107,7 @@ class CredentialService extends AgentService {
   }
 
   async createMetadata(data: CredentialMetadataRecordProps) {
-    const metadataRecord = new CredentialMetadataRecord({
-      ...data,
-    });
-
+    const metadataRecord = new CredentialMetadataRecord(data);
     await this.credentialStorage.saveCredentialMetadataRecord(metadataRecord);
   }
 

--- a/src/core/agent/services/identifier.types.ts
+++ b/src/core/agent/services/identifier.types.ts
@@ -32,6 +32,7 @@ interface IdentifierDetails extends IdentifierShortDetails {
   bt: string;
   b: string[];
   di?: string;
+  members?: string[];
 }
 
 interface MultiSigIcpRequestDetails {

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -293,6 +293,7 @@ describe("Single sig service of agent", () => {
       multisigManageAid: keriMetadataRecord.multisigManageAid,
       ...identifierStateKeria.state,
       isPending: false,
+      members: undefined,
     });
   });
 

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -296,7 +296,7 @@ describe("Single sig service of agent", () => {
     });
   });
 
-  test.only("group identifier detailed view should contain the member identifiers", async () => {
+  test("group identifier detailed view should contain the member identifiers", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
     identifierStorage.getIdentifierMetadata = jest
       .fn()

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -7,10 +7,11 @@ import { IdentifierService } from "./identifierService";
 import { EventTypes } from "../event.types";
 import { OperationPendingRecordType } from "../records/operationPendingRecord.type";
 
-const identifiersListMock = jest.fn();
-const identifiersGetMock = jest.fn();
-const identifiersCreateMock = jest.fn();
-const identifiersRotateMock = jest.fn();
+const listIdentifiersMock = jest.fn();
+const getIdentifierMembersMock = jest.fn();
+const getIdentifiersMock = jest.fn();
+const createIdentifierMock = jest.fn();
+const rotateIdentifierMock = jest.fn();
 const saveOperationPendingMock = jest.fn();
 const mockSigner = {
   _code: "A",
@@ -38,13 +39,13 @@ const signifyClient = jest.mocked({
   connect: jest.fn(),
   boot: jest.fn(),
   identifiers: () => ({
-    list: identifiersListMock,
-    get: identifiersGetMock,
-    create: identifiersCreateMock,
+    list: listIdentifiersMock,
+    get: getIdentifiersMock,
+    create: createIdentifierMock,
     addEndRole: jest.fn().mockResolvedValue({ op: jest.fn() }),
     interact: jest.fn(),
-    rotate: identifiersRotateMock,
-    members: jest.fn(),
+    rotate: rotateIdentifierMock,
+    members: getIdentifierMembersMock,
   }),
   operations: () => ({
     get: operationGetMock,
@@ -166,6 +167,7 @@ const keriMetadataRecordProps = {
   theme: 0,
   groupMetadata,
 };
+
 const identifierMetadataRecord = new IdentifierMetadataRecord({
   ...keriMetadataRecordProps,
   theme: 0,
@@ -175,7 +177,7 @@ const keriMetadataRecord = new IdentifierMetadataRecord(
   keriMetadataRecordProps
 );
 
-const aidReturnedBySignify = {
+const identifierStateKeria = {
   prefix: keriMetadataRecord.id,
   state: {
     s: "s",
@@ -188,6 +190,34 @@ const aidReturnedBySignify = {
     b: "b",
     di: "di",
   },
+};
+
+const groupIdentifierStateKeria = {
+  ...identifierStateKeria,
+  group: {},
+};
+
+const identifierMembersState = {
+  signing: [
+    {
+      aid: "EGn8b8d9nUbmw3csQ7DO4mkfCz9HusIKL98xe1BFYOKb",
+      ends: {},
+    },
+    {
+      aid: "EH51ZBTNCY7acERZQ9u2PHMdswKMfW6KRHgKrYr0UMFg",
+      ends: {},
+    },
+  ],
+  rotation: [
+    {
+      aid: "EGn8b8d9nUbmw3csQ7DO4mkfCz9HusIKL98xe1BFYOKb",
+      ends: {},
+    },
+    {
+      aid: "EH51ZBTNCY7acERZQ9u2PHMdswKMfW6KRHgKrYr0UMFg",
+      ends: {},
+    },
+  ],
 };
 
 describe("Single sig service of agent", () => {
@@ -222,7 +252,7 @@ describe("Single sig service of agent", () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()
       .mockResolvedValue(keriMetadataRecord);
-    identifiersGetMock.mockRejectedValue(
+    getIdentifiersMock.mockRejectedValue(
       new Error("request - 404 - SignifyClient message")
     );
     await expect(
@@ -251,7 +281,7 @@ describe("Single sig service of agent", () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()
       .mockResolvedValue(keriMetadataRecord);
-    identifiersGetMock.mockResolvedValue(aidReturnedBySignify);
+    getIdentifiersMock.mockResolvedValue(identifierStateKeria);
     expect(
       await identifierService.getIdentifier(keriMetadataRecord.id)
     ).toStrictEqual({
@@ -261,8 +291,33 @@ describe("Single sig service of agent", () => {
       theme: 0,
       groupMetadata: keriMetadataRecord.groupMetadata,
       multisigManageAid: keriMetadataRecord.multisigManageAid,
-      ...aidReturnedBySignify.state,
+      ...identifierStateKeria.state,
       isPending: false,
+    });
+  });
+
+  test.only("group identifier detailed view should contain the member identifiers", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
+    identifierStorage.getIdentifierMetadata = jest
+      .fn()
+      .mockResolvedValue(keriMetadataRecord);
+    getIdentifiersMock.mockResolvedValue(groupIdentifierStateKeria);
+    getIdentifierMembersMock.mockResolvedValue(identifierMembersState);
+    expect(
+      await identifierService.getIdentifier(keriMetadataRecord.id)
+    ).toStrictEqual({
+      id: keriMetadataRecord.id,
+      displayName: keriMetadataRecordProps.displayName,
+      createdAtUTC: nowISO,
+      theme: 0,
+      groupMetadata: keriMetadataRecord.groupMetadata,
+      multisigManageAid: keriMetadataRecord.multisigManageAid,
+      ...identifierStateKeria.state,
+      isPending: false,
+      members: [
+        identifierMembersState.signing[0].aid,
+        identifierMembersState.signing[1].aid,
+      ],
     });
   });
 
@@ -270,7 +325,7 @@ describe("Single sig service of agent", () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     const aid = "newIdentifierAid";
     const displayName = "newDisplayName";
-    identifiersCreateMock.mockResolvedValue({
+    createIdentifierMock.mockResolvedValue({
       serder: {
         ked: {
           i: aid,
@@ -291,7 +346,7 @@ describe("Single sig service of agent", () => {
       signifyName: expect.any(String),
       isPending: false,
     });
-    expect(identifiersCreateMock).toBeCalled();
+    expect(createIdentifierMock).toBeCalled();
     expect(identifierStorage.createIdentifierMetadataRecord).toBeCalledTimes(1);
   });
 
@@ -300,7 +355,7 @@ describe("Single sig service of agent", () => {
     const aid = "newIdentifierAid";
     const displayName = "newDisplayName";
     eventEmitter.emit = jest.fn();
-    identifiersCreateMock.mockResolvedValue({
+    createIdentifierMock.mockResolvedValue({
       serder: {
         ked: {
           i: aid,
@@ -334,7 +389,7 @@ describe("Single sig service of agent", () => {
       signifyName: expect.any(String),
       isPending: true,
     });
-    expect(identifiersCreateMock).toBeCalled();
+    expect(createIdentifierMock).toBeCalled();
     expect(identifierStorage.createIdentifierMetadataRecord).toBeCalledTimes(1);
     expect(eventEmitter.emit).toHaveBeenCalledWith({
       type: EventTypes.OperationAdded,
@@ -350,7 +405,7 @@ describe("Single sig service of agent", () => {
   test("cannot create a keri identifier if theme is not valid", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     const displayName = "newDisplayName";
-    identifiersCreateMock.mockResolvedValue({
+    createIdentifierMock.mockResolvedValue({
       serder: {
         ked: {
           i: "i",
@@ -458,7 +513,7 @@ describe("Single sig service of agent", () => {
 
   test("Should call createIdentifierMetadataRecord when there are un-synced KERI identifiers", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
-    identifiersListMock.mockReturnValue({
+    listIdentifiersMock.mockReturnValue({
       aids: [
         {
           name: "12219bf2-613a-4d5f-8c5d-5d093e7035b3",
@@ -490,13 +545,13 @@ describe("Single sig service of agent", () => {
   test("should call signify.rotateIdentifier with correct params", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     const identifierId = "identifierId";
-    identifiersRotateMock.mockResolvedValue({
+    rotateIdentifierMock.mockResolvedValue({
       op: jest.fn().mockResolvedValue({
         done: true,
       }),
     });
     await identifierService.rotateIdentifier(identifierId);
-    expect(identifiersRotateMock).toHaveBeenCalledWith(identifierId);
+    expect(rotateIdentifierMock).toHaveBeenCalledWith(identifierId);
   });
 
   test("Should throw error if we failed to obtain key manager when call getSigner", async () => {
@@ -504,7 +559,7 @@ describe("Single sig service of agent", () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()
       .mockResolvedValue(keriMetadataRecord);
-    identifiersGetMock.mockResolvedValue(aidReturnedBySignify);
+    getIdentifiersMock.mockResolvedValue(identifierStateKeria);
     await expect(
       identifierService.getSigner(keriMetadataRecord.id)
     ).rejects.toThrowError(IdentifierService.FAILED_TO_OBTAIN_KEY_MANAGER);
@@ -515,7 +570,7 @@ describe("Single sig service of agent", () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()
       .mockResolvedValue(keriMetadataRecord);
-    identifiersGetMock.mockResolvedValue(aidReturnedBySignify);
+    getIdentifiersMock.mockResolvedValue(identifierStateKeria);
     signifyClient.manager = managerMock as any;
     expect(
       await identifierService.getSigner(keriMetadataRecord.id)

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -97,6 +97,13 @@ class IdentifierService extends AgentService {
         }
       });
 
+    let members;
+    if (aid.group) {
+      members = (
+        await this.props.signifyClient.identifiers().members(identifier)
+      ).signing.map((member: any) => member.aid);
+    }
+
     return {
       id: aid.prefix,
       displayName: metadata.displayName,
@@ -114,6 +121,7 @@ class IdentifierService extends AgentService {
       bt: aid.state.bt,
       b: aid.state.b,
       di: aid.state.di,
+      members,
     };
   }
 


### PR DESCRIPTION
## Description

Exposes the member identifiers for a group identifier when retrieving the details. The UI can use this along with the Redux caches to display the other connections for that identifier.

**Note:** It will also return the local member identifier related to this multi-sig, which will not be in the multisig connections cache - it can be skipped.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser - iOS/Android - no, no impact here on native.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated