### PR TITLE
perf(core): filter by isDeleted for credentials using tag query

### DIFF
--- a/src/core/agent/records/credentialStorage.ts
+++ b/src/core/agent/records/credentialStorage.ts
@@ -15,6 +15,7 @@ class CredentialStorage {
     const records = await this.storageService.findAllByQuery(
       {
         ...(isArchived !== undefined ? { isArchived } : {}),
+        isDeleted: false,
       },
       CredentialMetadataRecord
     );

--- a/src/core/agent/services/credentialService.ts
+++ b/src/core/agent/services/credentialService.ts
@@ -49,8 +49,6 @@ class CredentialService extends AgentService {
     const listMetadatas = await this.credentialStorage.getAllCredentialMetadata(
       isGetArchive
     );
-    // Only get credentials that are not deleted
-    // @TODO - foconnor: Should be filtering via SQL for the deleted ones.
     return listMetadatas.map((element: CredentialMetadataRecord) =>
       this.getCredentialShortDetails(element)
     );

--- a/src/core/agent/services/credentialService.ts
+++ b/src/core/agent/services/credentialService.ts
@@ -51,11 +51,9 @@ class CredentialService extends AgentService {
     );
     // Only get credentials that are not deleted
     // @TODO - foconnor: Should be filtering via SQL for the deleted ones.
-    return listMetadatas
-      .filter((item) => !item.isDeleted)
-      .map((element: CredentialMetadataRecord) =>
-        this.getCredentialShortDetails(element)
-      );
+    return listMetadatas.map((element: CredentialMetadataRecord) =>
+      this.getCredentialShortDetails(element)
+    );
   }
 
   private getCredentialShortDetails(


### PR DESCRIPTION
## Description

The filter for isDeleted in getCredentials should be removed in favour of filtering by isDeleted in getAllCredentialMetadata using the query tags in SQL

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1427)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
