### PR TITLE
fix: keep notification until operation of ipex/offer done and get identifierType for offer credential

### DIFF
--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -675,6 +675,7 @@ describe("Ipex communication service of agent", () => {
         fullName: "Mr. John Lucas Smith",
         licenseNumber: "SMITH01192OP",
       },
+      identifierId: "uuid",
     });
     expect(credentialListMock).toBeCalledWith({
       filter: expect.objectContaining({

--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -675,7 +675,7 @@ describe("Ipex communication service of agent", () => {
         fullName: "Mr. John Lucas Smith",
         licenseNumber: "SMITH01192OP",
       },
-      identifierId: "uuid",
+      identifier: "uuid",
     });
     expect(credentialListMock).toBeCalledWith({
       filter: expect.objectContaining({

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -460,7 +460,7 @@ class IpexCommunicationService extends AgentService {
         };
       }),
       attributes: attributes,
-      identifierId: msg.exn.a.i,
+      identifier: msg.exn.a.i,
     };
   }
 

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -460,6 +460,7 @@ class IpexCommunicationService extends AgentService {
         };
       }),
       attributes: attributes,
+      identifierId: msg.exn.a.i,
     };
   }
 

--- a/src/core/agent/services/ipexCommunicationService.types.ts
+++ b/src/core/agent/services/ipexCommunicationService.types.ts
@@ -8,6 +8,7 @@ interface CredentialsMatchingApply {
     acdc: any;
   }[];
   attributes: Record<string, unknown>;
+  identifierId: string;
 }
 
 export type { CredentialsMatchingApply };

--- a/src/core/agent/services/ipexCommunicationService.types.ts
+++ b/src/core/agent/services/ipexCommunicationService.types.ts
@@ -8,7 +8,7 @@ interface CredentialsMatchingApply {
     acdc: any;
   }[];
   attributes: Record<string, unknown>;
-  identifierId: string;
+  identifier: string;
 }
 
 export type { CredentialsMatchingApply };

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -2010,7 +2010,7 @@ describe("Long running operation tracker", () => {
       {
         type: "NotificationRecord",
         id: "id",
-        createdAt: new Date(),
+        createdAt: new Date("2024-08-01T10:36:17.814Z"),
         a: {
           r: NotificationRoute.ExnIpexApply,
           d: "EIDUavcmyHBseNZAdAHR3SF8QMfX1kSJ3Ct0OqS0-HCW",
@@ -2027,6 +2027,23 @@ describe("Long running operation tracker", () => {
 
     await keriaNotificationService.processOperation(operationRecord);
     expect(notificationStorage.deleteById).toBeCalledWith("id");
+    expect(eventEmitter.emit).toBeCalledTimes(1);
+    expect(eventEmitter.emit).toHaveBeenCalledWith({
+      type: EventTypes.NotificationRemoved,
+      payload: {
+        keriaNotif: {
+          a: {
+            d: "EIDUavcmyHBseNZAdAHR3SF8QMfX1kSJ3Ct0OqS0-HCW",
+            r: NotificationRoute.ExnIpexApply,
+          },
+          connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
+          createdAt: "2024-08-01T10:36:17.814Z",
+          id: "id",
+          multisigId: undefined,
+          read: true,
+        },
+      },
+    });
     expect(operationPendingStorage.deleteById).toBeCalledTimes(1);
   });
 

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -1008,6 +1008,20 @@ class KeriaNotificationService extends AgentService {
                 notification.id,
                   notification.a.r as NotificationRoute
               );
+
+              this.props.eventEmitter.emit<NotificationRemovedEvent>({
+                type: EventTypes.NotificationRemoved,
+                payload: {
+                  keriaNotif: {
+                    id: notification.id,
+                    createdAt: notification.createdAt.toISOString(),
+                    a: notification.a,
+                    multisigId: notification.multisigId,
+                    connectionId: notification.connectionId,
+                    read: notification.read,
+                  },
+                },
+              });
             }
           }
         }

--- a/src/ui/__fixtures__/credRequestFix.ts
+++ b/src/ui/__fixtures__/credRequestFix.ts
@@ -41,6 +41,7 @@ const credRequestFix = {
   attributes: {
     attendeeName: "hmlax",
   },
+  identifier: "id",
 };
 
 export { credRequestFix };

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential.tsx
@@ -157,14 +157,6 @@ const ChooseCredential = ({
     setViewCredDetail(null);
   };
 
-  const handleNotificationUpdate = async () => {
-    const updatedNotifications = notifications.filter(
-      (notification) => notification.id !== notificationDetails.id
-    );
-
-    dispatch(setNotificationsCache(updatedNotifications));
-  };
-
   const handleRequestCredential = async () => {
     try {
       if (!selectedCred) {
@@ -176,7 +168,6 @@ const ChooseCredential = ({
         notificationDetails.id,
         selectedCred.acdc
       );
-      handleNotificationUpdate();
       dispatch(setToastMsg(ToastMsgType.SHARE_CRED_SUCCESS));
       onClose();
     } catch (e) {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
@@ -12,6 +12,7 @@ import { notificationsFix } from "../../../../__fixtures__/notificationsFix";
 import { CredentialRequest } from "./CredentialRequest";
 import { credRequestFix } from "../../../../__fixtures__/credRequestFix";
 import { credsFixAcdc } from "../../../../__fixtures__/credsFix";
+import { filteredIdentifierFix } from "../../../../__fixtures__/filteredIdentifierFix";
 
 mockIonicReact();
 
@@ -47,6 +48,9 @@ const initialState = {
   credsArchivedCache: { creds: [] },
   notificationsCache: {
     notifications: notificationsFix,
+  },
+  identifiersCache: {
+    identifiers: filteredIdentifierFix,
   },
 };
 

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
@@ -10,7 +10,9 @@ import { ChooseCredential } from "./ChooseCredential";
 import "./CredentialRequest.scss";
 import { CredentialRequestInformation } from "./CredentialRequestInformation";
 import { showError } from "../../../../utils/error";
-import { useAppDispatch } from "../../../../../store/hooks";
+import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
+import { getIdentifiersCache } from "../../../../../store/reducers/identifiersCache";
+import { IdentifierType } from "../../../../../core/agent/services/identifier.types";
 
 const CredentialRequest = ({
   pageId,
@@ -22,6 +24,7 @@ const CredentialRequest = ({
   const [requestStage, setRequestStage] = useState(0);
   const [credentialRequest, setCredentialRequest] =
     useState<CredentialsMatchingApply | null>();
+  const identifiersData = useAppSelector(getIdentifiersCache);
 
   const [isOpenAlert, setIsOpenAlert] = useState(false);
 
@@ -30,6 +33,16 @@ const CredentialRequest = ({
       const request = await Agent.agent.ipexCommunications.getIpexApplyDetails(
         notificationDetails
       );
+
+      const identifier = identifiersData.find(
+        (identifier) => identifier.id === request.identifierId
+      );
+
+      // @TODO: identifierType is not needed to render the component so this could be optimised. If it's needed, it should be fetched in the core for simplicity.
+      const identifierType =
+        identifier?.multisigManageAid || identifier?.multisigManageAid
+          ? IdentifierType.Group
+          : IdentifierType.Individual;
 
       setCredentialRequest(request);
     } catch (e) {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
@@ -35,10 +35,9 @@ const CredentialRequest = ({
       );
 
       const identifier = identifiersData.find(
-        (identifier) => identifier.id === request.identifierId
+        (identifier) => identifier.id === request.identifier
       );
 
-      // @TODO: identifierType is not needed to render the component so this could be optimised. If it's needed, it should be fetched in the core for simplicity.
       const identifierType =
         identifier?.multisigManageAid || identifier?.multisigManageAid
           ? IdentifierType.Group

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.types.ts
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.types.ts
@@ -6,7 +6,7 @@ interface CredentialRequestProps {
   pageId: string;
   activeStatus: boolean;
   notificationDetails: KeriaNotification;
-  credentialRequest: Omit<CredentialsMatchingApply, "identifierId">;
+  credentialRequest: CredentialsMatchingApply;
   onAccept: () => void;
   onBack: () => void;
 }
@@ -14,7 +14,7 @@ interface CredentialRequestProps {
 interface ChooseCredentialProps {
   pageId: string;
   activeStatus: boolean;
-  credentialRequest: Omit<CredentialsMatchingApply, "identifierId">;
+  credentialRequest: CredentialsMatchingApply;
   notificationDetails: KeriaNotification;
   reloadData: () => void;
   onBack: () => void;

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.types.ts
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.types.ts
@@ -6,7 +6,7 @@ interface CredentialRequestProps {
   pageId: string;
   activeStatus: boolean;
   notificationDetails: KeriaNotification;
-  credentialRequest: CredentialsMatchingApply;
+  credentialRequest: Omit<CredentialsMatchingApply, "identifierId">;
   onAccept: () => void;
   onBack: () => void;
 }
@@ -14,7 +14,7 @@ interface CredentialRequestProps {
 interface ChooseCredentialProps {
   pageId: string;
   activeStatus: boolean;
-  credentialRequest: CredentialsMatchingApply;
+  credentialRequest: Omit<CredentialsMatchingApply, "identifierId">;
   notificationDetails: KeriaNotification;
   reloadData: () => void;
   onBack: () => void;


### PR DESCRIPTION
## Description

Keep the notification until the operation of ipex/offer is done and get identifierType for offer credential

## Checklist before requesting a review

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated