### PR TITLE
feat: only mark linkedGroupRequests as read on KERIA once original notification deleted

### DIFF
--- a/src/core/__fixtures__/agent/keriaNotificationFixture.ts
+++ b/src/core/__fixtures__/agent/keriaNotificationFixture.ts
@@ -336,17 +336,6 @@ const notificationIpexApplyProp = {
   },
 };
 
-const notificationIpexOfferProp = {
-  i: "string",
-  dt: "string",
-  r: false,
-  a: {
-    r: NotificationRoute.ExnIpexOffer,
-    d: "string",
-    m: "",
-  },
-};
-
 export {
   credentialMetadataMock,
   grantForIssuanceExnMessage,
@@ -363,5 +352,4 @@ export {
   notificationIpexGrantProp,
   notificationIpexAgreeProp,
   notificationIpexApplyProp,
-  notificationIpexOfferProp,
 };

--- a/src/core/__fixtures__/agent/keriaNotificationFixture.ts
+++ b/src/core/__fixtures__/agent/keriaNotificationFixture.ts
@@ -336,6 +336,17 @@ const notificationIpexApplyProp = {
   },
 };
 
+const notificationIpexOfferProp = {
+  i: "string",
+  dt: "string",
+  r: false,
+  a: {
+    r: NotificationRoute.ExnIpexOffer,
+    d: "string",
+    m: "",
+  },
+};
+
 export {
   credentialMetadataMock,
   grantForIssuanceExnMessage,
@@ -352,4 +363,5 @@ export {
   notificationIpexGrantProp,
   notificationIpexAgreeProp,
   notificationIpexApplyProp,
+  notificationIpexOfferProp,
 };

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -28,7 +28,6 @@ import {
   grantForIssuanceExnMessage,
   applyForPresentingExnMessage,
   agreeForPresentingExnMessage,
-  notificationIpexOfferProp,
 } from "../../__fixtures__/agent/keriaNotificationFixture";
 
 const identifiersListMock = jest.fn();

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -28,6 +28,7 @@ import {
   grantForIssuanceExnMessage,
   applyForPresentingExnMessage,
   agreeForPresentingExnMessage,
+  notificationIpexOfferProp,
 } from "../../__fixtures__/agent/keriaNotificationFixture";
 
 const identifiersListMock = jest.fn();
@@ -647,6 +648,19 @@ describe("Signify notification service of agent", () => {
     expect(markNotificationMock).toBeCalledTimes(1);
   });
 
+  test("Should skip if notification route is /ipex/offer and the identifier is missing ", async () => {
+    exchangesGetMock.mockResolvedValueOnce({ exn: { a: { i: "i" } } });
+    identifierStorage.getIdentifierMetadata.mockRejectedValueOnce(
+      new Error(IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING)
+    );
+
+    await keriaNotificationService.processNotification(
+      notificationIpexOfferProp
+    );
+
+    expect(markNotificationMock).toBeCalledWith(notificationIpexOfferProp.i);
+  });
+
   test("Original grant is linked to first received /multisig/exn admit message, and no notification record is created", async () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()
@@ -704,7 +718,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: new Date(),
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -787,7 +801,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: dt,
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -870,7 +884,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: dt,
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -930,7 +944,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: new Date("2024-04-29T11:01:04.903Z"),
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -1012,7 +1026,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: dt,
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -1094,7 +1108,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: dt,
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -1154,7 +1168,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: new Date("2024-04-29T11:01:04.903Z"),
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -1236,7 +1250,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: dt,
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -1319,7 +1333,7 @@ describe("Signify notification service of agent", () => {
       connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
       updatedAt: dt,
     });
-    expect(markNotificationMock).toBeCalledTimes(1);
+    expect(markNotificationMock).not.toBeCalled();
     expect(notificationStorage.save).toBeCalledTimes(0);
   });
 
@@ -1965,6 +1979,7 @@ describe("Long running operation tracker", () => {
       },
     });
     expect(operationPendingStorage.deleteById).toBeCalledTimes(1);
+    expect(markNotificationMock).toBeCalledWith("id");
   });
 
   test("Should delete original apply notification when multi-sig offer operation completes", async () => {
@@ -2045,6 +2060,7 @@ describe("Long running operation tracker", () => {
       },
     });
     expect(operationPendingStorage.deleteById).toBeCalledTimes(1);
+    expect(markNotificationMock).toBeCalledWith("id");
   });
 
   test("Should delete original agree notification when multi-sig grant operation completes", async () => {
@@ -2108,6 +2124,7 @@ describe("Long running operation tracker", () => {
     await keriaNotificationService.processOperation(operationRecord);
     expect(notificationStorage.deleteById).toBeCalledWith("id");
     expect(operationPendingStorage.deleteById).toBeCalledTimes(1);
+    expect(markNotificationMock).toBeCalledWith("id");
   });
 
   test("Should handle long operations with type exchange.revokecredential", async () => {

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -648,19 +648,6 @@ describe("Signify notification service of agent", () => {
     expect(markNotificationMock).toBeCalledTimes(1);
   });
 
-  test("Should skip if notification route is /ipex/offer and the identifier is missing ", async () => {
-    exchangesGetMock.mockResolvedValueOnce({ exn: { a: { i: "i" } } });
-    identifierStorage.getIdentifierMetadata.mockRejectedValueOnce(
-      new Error(IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING)
-    );
-
-    await keriaNotificationService.processNotification(
-      notificationIpexOfferProp
-    );
-
-    expect(markNotificationMock).toBeCalledWith(notificationIpexOfferProp.i);
-  });
-
   test("Original grant is linked to first received /multisig/exn admit message, and no notification record is created", async () => {
     identifierStorage.getIdentifierMetadata = jest
       .fn()

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -898,7 +898,6 @@ class KeriaNotificationService extends AgentService {
                     exnSaid: grantExchange.exn.d,
                   });
               for (const notification of notifications) {
-                await this.markNotification(notification.id)
                 // @TODO: Delete other long running operations in linkedGroupRequests
                 await deleteNotificationRecordById(
                   this.props.signifyClient,
@@ -1002,7 +1001,6 @@ class KeriaNotificationService extends AgentService {
                   exnSaid: applyExchange.exn.d,
                 });
             for (const notification of notifications) {
-              await this.markNotification(notification.id)
               // @TODO: Delete other long running operations in linkedGroupRequests
               await deleteNotificationRecordById(
                 this.props.signifyClient,
@@ -1048,7 +1046,6 @@ class KeriaNotificationService extends AgentService {
                     exnSaid: agreeExchange.exn.d,
                   });
               for (const notification of notifications) {
-                await this.markNotification(notification.id)
                 // @TODO: Delete other long running operations in linkedGroupRequests
                 await deleteNotificationRecordById(
                   this.props.signifyClient,

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -256,7 +256,8 @@ class KeriaNotificationService extends AgentService {
     } else if (notif.a.r === NotificationRoute.MultiSigExn) {
       shouldCreateRecord = await this.processMultiSigExnNotification(notif);
     } else if (notif.a.r === NotificationRoute.ExnIpexOffer) {
-      shouldCreateRecord = await this.processExnIpexOfferNotification(notif);
+      // @TODO - DTIS-1381; message appearing as notification after being multi-sig sent
+      shouldCreateRecord = false;
     }
     if (!shouldCreateRecord) {
       return;
@@ -358,30 +359,6 @@ class KeriaNotificationService extends AgentService {
         recordType: OperationPendingRecordType.ExchangeRevokeCredential,
       });
       this.pendingOperations.push(pendingOperation);
-      await this.markNotification(notif.i);
-      return false;
-    }
-    return true;
-  }
-
-  private async processExnIpexOfferNotification(
-    notif: Notification
-  ): Promise<boolean> {
-    const exchange = await this.props.signifyClient.exchanges().get(notif.a.d);
-    const ourIdentifier = await this.identifierStorage
-      .getIdentifierMetadata(exchange.exn.a.i)
-      .catch((error) => {
-        if (
-          (error as Error).message ===
-          IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING
-        ) {
-          return undefined;
-        } else {
-          throw error;
-        }
-      });
-
-    if (!ourIdentifier) {
       await this.markNotification(notif.i);
       return false;
     }


### PR DESCRIPTION
## Description

This will help us build back up the local version of it in case of recovery.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1379)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated