### PR TITLE
fix(ui): Cannot accept multi sig invitation

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -623,12 +623,6 @@
           "confirm": "Clear all",
           "cancel": "Cancel"
         }
-      },
-      "toomanyattempts": {
-        "text": "Too many failed attempts. Please try again later.",
-        "button": {
-          "confirm": "Ok"
-        }
       }
     }
   },
@@ -745,7 +739,8 @@
       "invalidurl": "Enter a valid URL",
       "invalidbooturl": "Enter a valid boot URL",
       "invalidconnecturl": "Enter a valid connect URL",
-      "mismatchconnecturl": "This connect URL doesn’t match the boot URL"
+      "mismatchconnecturl": "This connect URL doesn’t match the boot URL",
+      "recoverymismatchconnecturl": "Please check this connect URL matches the original boot URL used for onboarding and that your agent is still active"
     }
   },
   "operationspasswordregex": {

--- a/src/ui/components/InputRequest/InputRequest.tsx
+++ b/src/ui/components/InputRequest/InputRequest.tsx
@@ -155,7 +155,7 @@ const InputRequest = () => {
       id={componentId}
       data-testid={`${componentId}-modal`}
       className={missingAliasUrl ? "connection-alias" : undefined}
-      backdropDismiss={showModal}
+      backdropDismiss={false}
       animated={!isPlatform("ios") || !!missingAliasUrl}
     >
       <div className={`${componentId}-wrapper`}>

--- a/src/ui/components/RecoverySeedPhraseModule/RecoverySeedPhraseModule.tsx
+++ b/src/ui/components/RecoverySeedPhraseModule/RecoverySeedPhraseModule.tsx
@@ -44,7 +44,6 @@ const RecoverySeedPhraseModule = forwardRef<
 
     const [alertIsOpen, setAlertIsOpen] = useState(false);
     const [clearAlertOpen, setClearAlertOpen] = useState(false);
-    const [alertManyAttempOpen, setAlertManyAttempOpen] = useState(false);
 
     const [seedPhraseInfo, setSeedPhraseInfo] = useState<SeedPhraseInfo[]>([
       {
@@ -327,21 +326,6 @@ const RecoverySeedPhraseModule = forwardRef<
           )}`}
           cancelButtonText={`${i18n.t(
             "verifyrecoveryseedphrase.alert.clear.button.cancel"
-          )}`}
-          className={alerClasses}
-          actionConfirm={handleClearState}
-          actionCancel={closeClearAlert}
-          actionDismiss={closeClearAlert}
-        />
-        <AlertFail
-          isOpen={alertManyAttempOpen}
-          setIsOpen={setAlertManyAttempOpen}
-          dataTestId="alert-fail"
-          headerText={i18n.t(
-            "verifyrecoveryseedphrase.alert.toomanyattempts.text"
-          )}
-          confirmButtonText={`${i18n.t(
-            "verifyrecoveryseedphrase.alert.toomanyattempts.button.confirm"
           )}`}
           className={alerClasses}
           actionConfirm={handleClearState}

--- a/src/ui/components/RecoverySeedPhraseModule/RecoverySeedPhraseModule.tsx
+++ b/src/ui/components/RecoverySeedPhraseModule/RecoverySeedPhraseModule.tsx
@@ -6,20 +6,19 @@ import { Agent } from "../../../core/agent/agent";
 import { i18n } from "../../../i18n";
 import { useAppDispatch } from "../../../store/hooks";
 import { setSeedPhraseCache } from "../../../store/reducers/seedPhraseCache";
+import { showError } from "../../utils/error";
 import { Alert as AlertFail } from "../Alert";
 import { PageFooter } from "../PageFooter";
 import { SeedPhraseModule } from "../SeedPhraseModule";
 import { SeedPhraseModuleRef } from "../SeedPhraseModule/SeedPhraseModule.types";
+import { SwitchOnboardingMode } from "../SwitchOnboardingMode";
+import { OnboardingMode } from "../SwitchOnboardingMode/SwitchOnboardingMode.types";
 import "./RecoverySeedPhraseModule.scss";
 import {
   RecoverySeedPhraseModuleProps,
   RecoverySeedPhraseModuleRef,
   SeedPhraseInfo,
 } from "./RecoverySeedPhraseModule.types";
-import { SwitchOnboardingMode } from "../SwitchOnboardingMode";
-import { OnboardingMode } from "../SwitchOnboardingMode/SwitchOnboardingMode.types";
-import { showError } from "../../utils/error";
-import { ToastMsgType } from "../../globals/types";
 
 const SEED_PHRASE_LENGTH = 18;
 const SUGGEST_SEED_PHRASE_LENGTH = 4;
@@ -187,7 +186,7 @@ const RecoverySeedPhraseModule = forwardRef<
         onVerifySuccess();
       } catch (e) {
         setAlertIsOpen(true);
-        showError("Unable to verify recovery seed phrase", e, dispatch);
+        showError("Unable to verify recovery seed phrase", e);
       }
     };
 

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -386,7 +386,7 @@ const CreateSSIAgent = () => {
               }
               errorMessage={
                 hasMismatchError
-                  ? `${i18n.t("ssiagent.error.mismatchconnecturl")}`
+                  ? `${i18n.t(isRecoveryMode ? "ssiagent.error.recoverymismatchconnecturl" : "ssiagent.error.mismatchconnecturl")}`
                   : displayBootUrlError && !isInvalidConnectUrl
                     ? `${i18n.t("ssiagent.error.invalidurl")}`
                     : `${i18n.t("ssiagent.error.invalidconnecturl")}`

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.tsx
@@ -37,6 +37,7 @@ import { JoinedMember } from "../JoinedMember";
 import { LightCredentialDetailModal } from "../LightCredentialDetailModal";
 import { MembersModal } from "../MembersModal";
 import "./ChooseCredential.scss";
+import { getNotificationsCache, setNotificationsCache } from "../../../../../../store/reducers/notificationsCache";
 
 const CRED_EMPTY = "Credential is empty";
 
@@ -52,6 +53,7 @@ const ChooseCredential = ({
 }: ChooseCredentialProps) => {
   const credsCache = useAppSelector(getCredsCache);
   const connections = useAppSelector(getConnectionsCache);
+  const notifications = useAppSelector(getNotificationsCache);
   const dispatch = useDispatch();
   const [selectedCred, setSelectedCred] = useState<RequestCredential | null>(
     null
@@ -130,6 +132,14 @@ const ChooseCredential = ({
     setViewCredDetail(null);
   };
 
+  const handleNotificationUpdate = async () => {
+    const updatedNotifications = notifications.filter(
+      (notification) => notification.id !== notificationDetails.id
+    );
+    dispatch(setNotificationsCache(updatedNotifications));
+  };
+
+
   const handleRequestCredential = async () => {
     try {
       if (!selectedCred) {
@@ -141,6 +151,11 @@ const ChooseCredential = ({
         notificationDetails.id,
         selectedCred.acdc
       );
+
+      if(!linkedGroup) {
+        handleNotificationUpdate();
+      }
+
       dispatch(setToastMsg(ToastMsgType.SHARE_CRED_SUCCESS));
       onClose();
     } catch (e) {


### PR DESCRIPTION
## Description

Fix issues: 
- Missing accept button when accept multisig request
- Credential request notification not removed after user accept
- Remove unused alert on verify seed phrase
- Prevent dismiss set user name popup

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1508](https://cardanofoundation.atlassian.net/browse/DTIS-1508)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Clear notification after share multisig

https://github.com/user-attachments/assets/0c5c1009-cf1e-4756-9a26-9154d98b3d67

#### Missing accept button on multisig request
##### IOS

<img width="1065" alt="Screenshot 2024-10-23 at 18 15 26" src="https://github.com/user-attachments/assets/d9e836c7-7d33-46a8-b868-28d0e18b21a4">

##### Android

![Screenshot_20241023_172822](https://github.com/user-attachments/assets/bc0b3253-6284-4f4b-bf26-f29c6a736b20)

#### Prevent dismiss set user name popup

https://github.com/user-attachments/assets/19beea8f-a3be-4d6d-84a4-43d81f403c91




[DTIS-1508]: https://cardanofoundation.atlassian.net/browse/DTIS-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ