### PR TITLE
fix(core): apply dev mode after app_already_init check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "webpack serve --config webpack.dev.cjs --host 0.0.0.0 --port 3003",
-    "build": "cross-env ENVIRONMENT=remote-dev-comm DEV_SKIP_ONBOARDING=true webpack --config webpack.prod.cjs",
+    "build": "cross-env ENVIRONMENT=remote-dev-comm webpack --config webpack.prod.cjs",
     "build:local": "cross-env ENVIRONMENT=local-direct webpack --config webpack.prod.cjs",
     "build:cap": "npm run build && npx cap sync",
     "build:e2e": "npm run build:local && npx cap sync",

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -427,11 +427,6 @@ const AppWrapper = (props: { children: ReactNode }) => {
     await new ConfigurationService().start();
     await Agent.agent.initDatabaseConnection();
 
-    // This will skip the onboarding screen with dev mode.
-    if (process.env.DEV_SKIP_ONBOARDING === "true") {
-      await Agent.agent.devPreload();
-    }
-
     // @TODO - foconnor: This is a temp hack for development to be removed pre-release.
     // These items are removed from the secure storage on re-install to re-test the on-boarding for iOS devices.
     const initState = await Agent.agent.basicStorage.findById(
@@ -442,6 +437,12 @@ const AppWrapper = (props: { children: ReactNode }) => {
       await SecureStorage.delete(KeyStoreKeys.APP_OP_PASSWORD);
       await SecureStorage.delete(KeyStoreKeys.SIGNIFY_BRAN);
     }
+
+    // This will skip the onboarding screen with dev mode.
+    if (process.env.DEV_SKIP_ONBOARDING === "true") {
+      await Agent.agent.devPreload();
+    }
+
     await loadDatabase();
     const { keriaConnectUrlRecord } = await loadCacheBasicStorage();
 


### PR DESCRIPTION
## Description

I accidentally pushed dev mode to the package json when doing the builds, so this is my (late) revert. :P

The app wrapper change means that on a fresh install, the key store will be wiped before we apply the dev mode, which is the correct order.

@jimcase I had another fix to allow us to re-launch the app with dev mode on and not hit an error, but seems on develop I had already fixed it. Didn't remember that.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
