### PR TITLE
fix(docker): update build context to latest commit from keria

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -11,7 +11,7 @@ ARG --global RELEASE_TAG=""
 ARG --global PUSH=false
 
 ARG --global KERIA_GIT_REPO_URL="https://github.com/WebOfTrust/keria.git"
-ARG --global KERIA_GIT_REF=c9d35f901e293f166d5abbd58cda249248555253
+ARG --global KERIA_GIT_REF=736947191069cfc1617a43f63dbc64210c351b5c
 
 ARG --global KERI_DOCKER_IMAGE_REPO=weboftrust/keri
 ARG --global KERI_DOCKER_IMAGE_TAG=1.1.6

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: idw-keria
     restart: unless-stopped
     build:
-      context: https://github.com/WebOfTrust/keria.git#c9d35f901e293f166d5abbd58cda249248555253
+      context: https://github.com/WebOfTrust/keria.git#736947191069cfc1617a43f63dbc64210c351b5c
       dockerfile: ./images/keria.dockerfile
     environment:
       - KERI_AGENT_CORS=true

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     container_name: idw-keria
     restart: unless-stopped
     build:
-      context: github.com/WebOfTrust/keria.git#c9d35f901e293f166d5abbd58cda249248555253
+      context: github.com/WebOfTrust/keria.git#736947191069cfc1617a43f63dbc64210c351b5c
       dockerfile: ./images/keria.dockerfile
     environment:
       - KERI_AGENT_CORS=true


### PR DESCRIPTION
## Description

The Keria version used in the docker-compose file was returning an error every time that you tried to validate the SSI Agent details. [This commit](https://github.com/WebOfTrust/keria/commit/736947191069cfc1617a43f63dbc64210c351b5c) from @iFergal solves the issue. This PR upgrades the version of KERIA used in the docker-compose file to fix the issue.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1518)

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated