### PR TITLE
feat(ui): Generic error toasts in the UI

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -10,7 +10,7 @@ import { IonReactRouter } from "@ionic/react-router";
 import { StrictMode, useEffect, useState } from "react";
 import { RoutePath, Routes } from "../routes";
 import { PublicRoutes } from "../routes/paths";
-import { useAppSelector } from "../store/hooks";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
 import {
   getAuthentication,
   getCurrentOperation,
@@ -31,6 +31,7 @@ import { LockPage } from "./pages/LockPage/LockPage";
 import "./styles/ionic.scss";
 import "./styles/style.scss";
 import "./App.scss";
+import { showError } from "./utils/error";
 
 setupIonicReact();
 
@@ -41,6 +42,29 @@ const App = () => {
   const currentRoute = useAppSelector(getCurrentRoute);
   const currentOperation = useAppSelector(getCurrentOperation);
   const [showScan, setShowScan] = useState(false);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const handleUnknownPromiseError = (event: PromiseRejectionEvent) => {
+      // prevent log error to console.
+      event.preventDefault();
+      event.promise.catch((e) => showError("Unhandled error", e, dispatch));
+    }
+
+    window.addEventListener("unhandledrejection", handleUnknownPromiseError);
+
+    const handleUnknownError = (event: ErrorEvent) => {
+      event.preventDefault();
+      showError("Unhandled error", event.error, dispatch);
+    }
+
+    window.addEventListener("error", handleUnknownError)
+
+    return () => {
+      window.removeEventListener("unhandledrejection", handleUnknownPromiseError);
+      window.removeEventListener("error", handleUnknownError);
+    }
+  }, [dispatch]);
 
   useEffect(() => {
     setShowScan(


### PR DESCRIPTION
## Description

Add global event to catch unhandled error and show toast message.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-122](https://cardanofoundation.atlassian.net/browse/DTIS-122)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser

https://github.com/user-attachments/assets/23282d62-6a68-44a9-92c8-2ae87ff7cf9f


[DTIS-122]: https://cardanofoundation.atlassian.net/browse/DTIS-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ