### PR TITLE
fix(ui): Force status bar style is dark mode on iOS failing test

### DIFF
--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -228,7 +228,7 @@ describe("App", () => {
   });
 
   test("Should not force status bar style is dark mode on android or browser", async () => {
-    getPlatformsMock.mockImplementationOnce(() => ["android", "mobileweb"]);
+    getPlatformsMock.mockImplementation(() => ["android", "mobileweb"]);
 
     render(
       <Provider store={store}>
@@ -242,7 +242,7 @@ describe("App", () => {
   });
 
   test("Should lock screen orientation to portrait mode", async () => {
-    getPlatformsMock.mockImplementationOnce(() => ["android"]);
+    getPlatformsMock.mockImplementation(() => ["android"]);
 
     render(
       <Provider store={store}>

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -1,14 +1,14 @@
 import { Style, StyleOptions } from "@capacitor/status-bar";
 import { render, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
+import Eng_Trans from "../locales/en/en.json";
 import { TabsRoutePath } from "../routes/paths";
 import { store } from "../store";
 import { showGenericError } from "../store/reducers/stateCache";
 import { App } from "./App";
 import { OperationType } from "./globals/types";
-import { Identifiers } from "./pages/Identifiers";
 
 const mockInitDatabase = jest.fn();
 
@@ -195,6 +195,7 @@ const storeMocked = {
 describe("App", () => {
   beforeEach(() => {
     mockInitDatabase.mockClear();
+    getPlatformsMock.mockImplementation(() => ["android"]);
   })
 
   test("Mobile header hidden when app not in preview mode", async () => {
@@ -210,8 +211,8 @@ describe("App", () => {
     });
   });
 
-  test.skip("Force status bar style is dark mode on ios", async () => {
-    getPlatformsMock.mockImplementationOnce(() => ["ios"]);
+  test("Force status bar style is dark mode on ios", async () => {
+    getPlatformsMock.mockImplementation(() => ["ios"]);
 
     render(
       <Provider store={store}>
@@ -270,7 +271,7 @@ describe("App", () => {
       stateCache: {
         isOnline: false,
         initialized: true,
-        routes: [{ path: "/route1" }, { path: "/route2" }, { path: "/route3" }],
+        routes: [{ path: "/" }, { path: "/route2" }, { path: "/route3" }],
         authentication: {
           passcodeIsSet: true,
           seedPhraseIsSet: false,
@@ -392,20 +393,92 @@ describe("App", () => {
 
     spy.mockClear();
   });
+  test("It renders SetUserName modal", async () => {
+    const initialState = {
+      stateCache: {
+        routes: [{ path: TabsRoutePath.ROOT }],
+        authentication: {
+          loggedIn: true,
+          userName: "",
+          time: Date.now(),
+          passcodeIsSet: true,
+          seedPhraseIsSet: true,
+          passwordIsSet: false,
+          passwordIsSkipped: true,
+          ssiAgentIsSet: true,
+          recoveryWalletProgress: false,
+          loginAttempt: {
+            attempts: 0,
+            lockedUntil: Date.now(),
+          },
+        },
+        toastMsgs: [],
+        queueIncomingRequest: {
+          isProcessing: false,
+          queues: [],
+          isPaused: false,
+        },
+      },
+      seedPhraseCache: {
+        seedPhrase: "",
+        bran: "",
+      },
+      identifiersCache: {
+        identifiers: [],
+        favourites: [],
+        multiSigGroup: {
+          groupId: "",
+          connections: [],
+        },
+      },
+      credsCache: { creds: [], favourites: [] },
+      credsArchivedCache: { creds: [] },
+      connectionsCache: {
+        connections: {},
+        multisigConnections: {},
+      },
+      walletConnectionsCache: {
+        walletConnections: [],
+        connectedWallet: null,
+        pendingConnection: null,
+      },
+      viewTypeCache: {
+        identifier: {
+          viewType: null,
+          favouriteIndex: 0,
+        },
+        credential: {
+          viewType: null,
+          favouriteIndex: 0,
+        }
+      },
+      biometricsCache: {
+        enabled: false,
+      },
+      ssiAgentCache: {
+        bootUrl: "",
+        connectUrl: "",
+      },
+      notificationsCache: {
+        notifications: [],
+      },
+    };
 
-  test.skip("It renders SetUserName modal", async () => {
-    const { queryByTestId } = render(
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const { getByText } = render(
       <Provider store={storeMocked}>
         <MemoryRouter initialEntries={[TabsRoutePath.IDENTIFIERS]}>
-          <Route
-            path={TabsRoutePath.IDENTIFIERS}
-            component={Identifiers}
-          />
+          <App />
         </MemoryRouter>
       </Provider>
     );
+
     await waitFor(() => {
-      expect(queryByTestId("set-user-name")).toBeInTheDocument();
+      expect(getByText(Eng_Trans.inputrequest.title.username)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Description

Fix UT on `App.test.tsx` file:

- `Force status bar style is dark mode on ios`: Currently, this UT is using mock implementation of `getPlatforms` function by using `mockImplementationOnce` function. It mean after first run `getPlatforms` mock implementation will be cleaned and other test will override mock implementation of `getPlatforms`. In this case we should use `mockImplementation` instead.

- `It renders SetUserName modal`: Update this test follow new implement of `SetUserName` modal.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-892](https://cardanofoundation.atlassian.net/browse/DTIS-892)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---

[DTIS-892]: https://cardanofoundation.atlassian.net/browse/DTIS-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ