### PR TITLE
feat: deleting a keria connection when the local connection metadata record does not exist

### DIFF
--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -176,9 +176,9 @@ class ConnectionService extends AgentService {
     const associatedContacts = await this.connectionStorage.findAllByQuery({
       groupId,
     });
-    associatedContacts.forEach(async (connection) => {
-      connectionsDetails.push(this.getConnectionShortDetails(connection));
-    });
+    for (const connection of associatedContacts) {
+      connectionsDetails.push(await this.getConnectionShortDetails(connection));
+    }
     return connectionsDetails;
   }
 

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -866,6 +866,10 @@ class KeriaNotificationService extends AgentService {
               alias,
               createdAt: new Date((operation.response as State).dt),
             });
+        } else {
+          await this.props.signifyClient
+            .contacts()
+            .delete((operation.response as State).i);
         }
         this.props.eventEmitter.emit<OperationCompleteEvent>({
           type: EventTypes.OperationComplete,


### PR DESCRIPTION
## Description

deleting a Keria connection when the local connection metadata record does not exist

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1470](https://cardanofoundation.atlassian.net/browse/DTIS-1470)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

[DTIS-1470]: https://cardanofoundation.atlassian.net/browse/DTIS-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ