### PR TITLE
fix(core): only process pending connection ops when online

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -317,9 +317,13 @@ class Agent {
   }
 
   markAgentStatus(online: boolean) {
-    Agent.isOnline = true;
-    this.connectionService.removeConnectionsPendingDeletion();
-    this.connectionService.resolvePendingConnections();
+    Agent.isOnline = online;
+
+    if (online) {
+      this.connections.removeConnectionsPendingDeletion();
+      this.connections.resolvePendingConnections();
+    }
+    
     this.agentServicesProps.eventEmitter.emit<KeriaStatusChangedEvent>({
       type: EventTypes.KeriaStatusChanged,
       payload: {

--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -106,7 +106,6 @@ class ConnectionService extends AgentService {
       oobi: url,
       pending: true,
       createdAtUTC: connectionDate,
-      groupId,
     };
 
     const connection = {
@@ -128,6 +127,7 @@ class ConnectionService extends AgentService {
       connectionMetadata.pending = false;
       connectionMetadata.createdAtUTC = oobiResult.op.response.dt;
       connectionMetadata.status = ConnectionStatus.CONFIRMED;
+      connectionMetadata.groupId = groupId;
 
       const identifierWithGroupId =
         await this.identifierStorage.getIdentifierMetadataByGroupId(groupId);


### PR DESCRIPTION
Small issue from #806 - we should use `connections` to make sure it's initialised, and it should only be called when online.

Also, the function was always setting `isOnline` to true for some reason, fixed. That could've been the source of some issues with offline mode.