### PR TITLE
feat(core): Deleting a keria connection when the record pendingDeletion is true

### DIFF
--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -203,7 +203,7 @@ class ConnectionService extends AgentService {
       pendingDeletion: false,
     });
     for (const connection of associatedContacts) {
-      connectionsDetails.push(await this.getConnectionShortDetails(connection));
+      connectionsDetails.push(this.getConnectionShortDetails(connection));
     }
     return connectionsDetails;
   }

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -905,12 +905,7 @@ class KeriaNotificationService extends AgentService {
         //   .get((operation.response as State).i)
         //   .catch(() => undefined);
         //if (connectionRecord && !existingConnection) {
-        if (connectionRecord) {
-          if (connectionRecord.pendingDeletion) {
-            await this.props.signifyClient
-              .contacts()
-              .delete((operation.response as State).i);
-          }
+        if (connectionRecord && !connectionRecord.pendingDeletion) {
           connectionRecord.pending = false;
           connectionRecord.createdAt = new Date(
             (operation.response as State).dt

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -389,7 +389,7 @@ class KeriaNotificationService extends AgentService {
           credentialId: existingCredential.id,
           credentialTitle: existingCredential.credentialType,
         },
-        connectionId:existingCredential.connectionId,
+        connectionId: existingCredential.connectionId,
         read: false,
         route: NotificationRoute.LocalAcdcRevoked,
       };
@@ -906,6 +906,11 @@ class KeriaNotificationService extends AgentService {
         //   .catch(() => undefined);
         //if (connectionRecord && !existingConnection) {
         if (connectionRecord) {
+          if (connectionRecord.pendingDeletion) {
+            await this.props.signifyClient
+              .contacts()
+              .delete((operation.response as State).i);
+          }
           connectionRecord.pending = false;
           connectionRecord.createdAt = new Date(
             (operation.response as State).dt


### PR DESCRIPTION
## Description

Deleting a keria connection when the record pendingDeletion is true

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: no

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated