### PR TITLE
feat: delete identifier idempotency

### DIFF
--- a/src/core/agent/agent.test.ts
+++ b/src/core/agent/agent.test.ts
@@ -34,6 +34,10 @@ const mockConnectionService = {
   removeConnectionsPendingDeletion: jest.fn(),
   resolvePendingConnections: jest.fn(),
 };
+const mockIdentifierService = {
+  removeIdentifierPendingDeletion: jest.fn(),
+};
+
 const mockEntropy = "00000000000000000000000000000000";
 
 describe("test cases of bootAndConnect function", () => {
@@ -51,6 +55,7 @@ describe("test cases of bootAndConnect function", () => {
     (agent as any).basicStorageService = mockBasicStorageService;
     (agent as any).agentServicesProps = mockAgentServicesProps;
     (agent as any).connectionService = mockConnectionService;
+    (agent as any).identifierService = mockIdentifierService;
 
     mockAgentUrls = {
       url: "http://127.0.0.1:3901",
@@ -148,6 +153,9 @@ describe("test cases of bootAndConnect function", () => {
       .fn()
       .mockReturnValue(["id1", "id2"]);
     mockConnectionService.resolvePendingConnections = jest
+      .fn()
+      .mockReturnValue(undefined);
+    mockIdentifierService.removeIdentifierPendingDeletion = jest
       .fn()
       .mockReturnValue(undefined);
     await agent.bootAndConnect(mockAgentUrls);
@@ -263,6 +271,9 @@ describe("test cases of recoverKeriaAgent function", () => {
     mockConnectionService.removeConnectionsPendingDeletion = jest
       .fn()
       .mockReturnValue(["id1", "id2"]);
+    mockIdentifierService.removeIdentifierPendingDeletion = jest
+      .fn()
+      .mockReturnValue(undefined);
 
     await agent.recoverKeriaAgent(mockSeedPhrase, mockConnectUrl);
 

--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -141,7 +141,7 @@ class Agent {
         this.connectionStorage,
         this.credentialStorage,
         this.operationPendingStorage,
-        this.identifierStorage,
+        this.identifierStorage
       );
     }
     return this.connectionService;
@@ -322,6 +322,7 @@ class Agent {
     if (online) {
       this.connections.removeConnectionsPendingDeletion();
       this.connections.resolvePendingConnections();
+      this.identifierService.removeIdentifierPendingDeletion();
     }
     
     this.agentServicesProps.eventEmitter.emit<KeriaStatusChangedEvent>({

--- a/src/core/agent/event.types.ts
+++ b/src/core/agent/event.types.ts
@@ -20,6 +20,7 @@ enum EventTypes {
   AcdcStateChanged = "AcdcStateChanged",
   KeriaStatusChanged = "KeriaStatusChanged",
   NotificationRemoved = "NotificationRemoved",
+  IdentifierRemoved = "IdentifierRemoved",
 }
 
 interface NotificationAddedEvent extends BaseEventEmitter {
@@ -84,6 +85,13 @@ interface NotificationRemovedEvent extends BaseEventEmitter {
   };
 }
 
+interface IdentifierRemovedEvent extends BaseEventEmitter {
+  type: typeof EventTypes.IdentifierRemoved;
+  payload: {
+    id: string;
+  };
+}
+
 export type {
   NotificationAddedEvent,
   OperationCompleteEvent,
@@ -94,5 +102,6 @@ export type {
   OperationAddedEvent,
   NotificationRemovedEvent,
   ConnectionRemovedEvent,
+  IdentifierRemovedEvent,
 };
 export { EventTypes };

--- a/src/core/agent/records/identifierMetadataRecord.ts
+++ b/src/core/agent/records/identifierMetadataRecord.ts
@@ -21,6 +21,7 @@ class IdentifierMetadataRecord extends BaseRecord {
   displayName!: string;
   isDeleted?: boolean;
   isPending?: boolean;
+  pendingDeletion = false;
   theme!: number;
   multisigManageAid?: string;
   groupMetadata?: groupMetadata;
@@ -50,6 +51,7 @@ class IdentifierMetadataRecord extends BaseRecord {
       isDeleted: this.isDeleted,
       isPending: this.isPending,
       groupCreated: this.groupMetadata?.groupCreated,
+      pendingDeletion: this.pendingDeletion,
     };
   }
 }

--- a/src/core/agent/records/identifierStorage.ts
+++ b/src/core/agent/records/identifierStorage.ts
@@ -28,6 +28,7 @@ class IdentifierStorage {
     const records = await this.storageService.findAllByQuery(
       {
         isDeleted: false,
+        pendingDeletion: false,
         $not: {
           groupCreated: true,
         },
@@ -35,6 +36,18 @@ class IdentifierStorage {
       IdentifierMetadataRecord
     );
     return records;
+  }
+
+  async getIdentifierPendingDeletions(): Promise<IdentifierMetadataRecord[]> {
+    return this.storageService.findAllByQuery(
+      {
+        pendingDeletion: true,
+        $not: {
+          groupCreated: true,
+        },
+      },
+      IdentifierMetadataRecord
+    );
   }
 
   async getKeriIdentifiersMetadata(): Promise<IdentifierMetadataRecord[]> {
@@ -46,7 +59,7 @@ class IdentifierStorage {
     metadata: Partial<
       Pick<
         IdentifierMetadataRecord,
-        "displayName" | "theme" | "isPending" | "isDeleted" | "groupMetadata"
+        "displayName" | "theme" | "isPending" | "isDeleted" | "groupMetadata" | "pendingDeletion"
       >
     >
   ): Promise<void> {

--- a/src/core/agent/services/connectionService.test.ts
+++ b/src/core/agent/services/connectionService.test.ts
@@ -10,7 +10,6 @@ import {
   ConnectionHistoryType,
   KeriaContactKeyPrefix,
 } from "./connectionService.types";
-import { ConnectionRecord, ConnectionRecordStorageProps } from "../records";
 
 const contactListMock = jest.fn();
 let deleteContactMock = jest.fn();

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -26,6 +26,7 @@ jest.mock("../core/agent/agent", () => ({
       identifiers: {
         getIdentifiers: jest.fn().mockResolvedValue([]),
         syncKeriaIdentifiers: jest.fn(),
+        onIdentifierRemoved: jest.fn()
       },
       connections: {
         getConnections: jest.fn().mockResolvedValue([]),

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -65,6 +65,7 @@ jest.mock("../../../core/agent/agent", () => ({
       identifiers: {
         getIdentifiers: jest.fn().mockResolvedValue([]),
         syncKeriaIdentifiers: jest.fn(),
+        onIdentifierRemoved: jest.fn()
       },
       multiSigs: {
         getMultisigIcpDetails: jest.fn().mockResolvedValue({}),

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -489,6 +489,8 @@ const AppWrapper = (props: { children: ReactNode }) => {
     Agent.agent.keriaNotifications.onRemoveNotification((event) => {
       notificatiStateChanged(event, dispatch);
     });
+
+    Agent.agent.identifiers.onIdentifierRemoved()
   };
 
   const initApp = async () => {

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
@@ -28,6 +28,7 @@ const getOobiMock = jest.fn((...args: any) =>
 );
 
 const deleteIdentifier = jest.fn();
+const markIdentifierPendingDelete = jest.fn();
 
 jest.mock("@ionic/react", () => ({
   ...jest.requireActual("@ionic/react"),
@@ -43,6 +44,7 @@ jest.mock("../../../../core/agent/agent", () => ({
       },
       identifiers: {
         deleteIdentifier: () => deleteIdentifier(),
+        markIdentifierPendingDelete: () => markIdentifierPendingDelete(),
       },
     },
   },
@@ -481,7 +483,7 @@ describe("Create group identifier - Setup Connection", () => {
       await passcodeFiller(getByText, getByTestId, "1", 6);
 
       await waitFor(() => {
-        expect(deleteIdentifier).toBeCalled();
+        expect(markIdentifierPendingDelete).toBeCalled();
       });
     });
 

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnections.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnections.tsx
@@ -151,7 +151,7 @@ const SetupConnections = ({
         (item) => item.id !== identifierId
       );
 
-      await Agent.agent.identifiers.deleteIdentifier(identifierId);
+      await Agent.agent.identifiers.markIdentifierPendingDelete(identifierId);
 
       dispatch(setToastMsg(ToastMsgType.IDENTIFIER_DELETED));
       dispatch(setIdentifiersCache(updatedIdentifiers));

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
@@ -70,6 +70,7 @@ jest.mock("@ionic/react", () => ({
 
 const rotateIdentifierMock = jest.fn((id: string) => Promise.resolve(id));
 const deleteIdentifier = jest.fn(() => Promise.resolve());
+const markIdentifierPendingDelete = jest.fn(() => Promise.resolve());
 const createOrUpdateMock = jest.fn().mockResolvedValue(undefined);
 
 jest.mock("../../../core/agent/agent", () => ({
@@ -82,6 +83,7 @@ jest.mock("../../../core/agent/agent", () => ({
         rotateIdentifier: (id: string) => rotateIdentifierMock(id),
         deleteStaleLocalIdentifier: () => deleteStaleLocalIdentifierMock(),
         deleteIdentifier: () => deleteIdentifier(),
+        markIdentifierPendingDelete: () => markIdentifierPendingDelete(),
       },
       connections: {
         getOobi: jest.fn(() => Promise.resolve("oobi")),
@@ -150,11 +152,11 @@ describe("Individual Identifier details page", () => {
     Clipboard.write = jest.fn();
     const { getByText, getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -187,11 +189,11 @@ describe("Individual Identifier details page", () => {
     Clipboard.write = jest.fn();
     const { getByText, getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -229,11 +231,11 @@ describe("Individual Identifier details page", () => {
   test("It opens the sharing modal", async () => {
     const { getByTestId, queryByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -259,11 +261,11 @@ describe("Individual Identifier details page", () => {
   test("It opens the edit modal", async () => {
     const { getByTestId, queryByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -286,11 +288,11 @@ describe("Individual Identifier details page", () => {
   test("It shows the button to access the editor", async () => {
     const { getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -313,11 +315,11 @@ describe("Individual Identifier details page", () => {
 
     const { getByTestId, getByText, unmount, findByText, queryByText } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -366,11 +368,11 @@ describe("Individual Identifier details page", () => {
   test("It shows the warning when I click on the big delete button", async () => {
     const { getByTestId, queryByText, findByText, unmount } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -413,11 +415,11 @@ describe("Individual Identifier details page", () => {
 
     const { getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -434,11 +436,11 @@ describe("Individual Identifier details page", () => {
   test("Hide loading after retrieved indetifier data", async () => {
     const { queryByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -482,11 +484,11 @@ describe("Individual Identifier details page", () => {
 
     const { queryByTestId, getByTestId, getByText } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -709,11 +711,11 @@ describe("Group Identifier details page", () => {
 
     const { getByTestId, getAllByText } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -753,11 +755,11 @@ describe("Group Identifier details page", () => {
   test("Open group member", async () => {
     const { getByText, getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -795,11 +797,11 @@ describe("Group Identifier details page", () => {
   test("Open signing threshold", async () => {
     const { getByText, getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -837,11 +839,11 @@ describe("Group Identifier details page", () => {
   test("Open advanced detail", async () => {
     const { getByText, getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -938,11 +940,11 @@ describe("Group Identifier details page", () => {
   test("Open rotation threshold", async () => {
     const { getByText, getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -980,11 +982,11 @@ describe("Group Identifier details page", () => {
   test("Open group member from rotation threshold", async () => {
     const { getByText, getByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -1051,11 +1053,11 @@ describe("Group Identifier details page", () => {
 
     const { queryByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -1112,11 +1114,11 @@ describe("Checking the Identifier Details Page when information is missing from 
 
     const { getByTestId, getByText, unmount, queryByText } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -1186,11 +1188,11 @@ describe("Favourite identifier", () => {
 
     const { getByTestId, queryByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -1274,11 +1276,11 @@ describe("Favourite identifier", () => {
 
     const { getByTestId, queryByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -1341,11 +1343,11 @@ describe("Favourite identifier", () => {
 
     const { getByTestId, queryByTestId } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -1408,11 +1410,11 @@ describe("Favourite identifier", () => {
 
     const { getByTestId, queryByTestId, getByText, unmount } = render(
       <Provider store={storeMockedAidKeri}>
-        <IdentifierDetailModule 
+        <IdentifierDetailModule
           identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
           onClose={jest.fn()}
           pageId={pageId}
-          navAnimation          
+          navAnimation
         />
       </Provider>
     );
@@ -1444,7 +1446,7 @@ describe("Favourite identifier", () => {
     await passcodeFiller(getByText, getByTestId, "1", 6);
 
     await waitFor(() => {
-      expect(deleteIdentifier).toBeCalled();
+      expect(markIdentifierPendingDelete).toBeCalled();
     });
 
     unmount();

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
@@ -154,7 +154,7 @@ const IdentifierDetailModule = ({ identifierDetailId, onClose: handleDone, navAn
     }
 
     if (cardData) {
-      await Agent.agent.identifiers.deleteIdentifier(cardData.id);
+      await Agent.agent.identifiers.markIdentifierPendingDelete(cardData.id);
       if (isFavourite) {
         handleSetFavourite(cardData.id);
       }

--- a/src/ui/pages/Identifiers/Identifiers.test.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.test.tsx
@@ -36,6 +36,7 @@ import { IdentifiersFilters } from "./Identifiers.types";
 import { store } from "../../../store";
 
 const deleteIdentifierMock = jest.fn();
+const markIdentifierPendingDelete = jest.fn();
 
 jest.mock("react-qrcode-logo", () => {
   return {
@@ -50,6 +51,7 @@ jest.mock("../../../core/agent/agent", () => ({
       identifiers: {
         getIdentifier: jest.fn().mockResolvedValue({}),
         deleteIdentifier: () => deleteIdentifierMock(),
+        markIdentifierPendingDelete: () => markIdentifierPendingDelete(),
       },
       basicStorage: {
         deleteById: jest.fn(() => Promise.resolve()),
@@ -351,14 +353,23 @@ describe("Identifiers Tab", () => {
       jest.advanceTimersByTime(NAVIGATION_DELAY);
     });
 
-    
     await waitFor(() => {
-      expect(getByTestId("identifiers-tab").classList.contains("cards-identifier-nav")).toBeFalsy();
+      expect(
+        getByTestId("identifiers-tab").classList.contains(
+          "cards-identifier-nav"
+        )
+      ).toBeFalsy();
     });
 
     await waitFor(() => {
-      expect(getByTestId("identifiers-tab").classList.contains("cards-identifier-nav")).toBeFalsy();
-      expect(getByTestId("card-stack").classList.contains("transition-start")).toBeFalsy();
+      expect(
+        getByTestId("identifiers-tab").classList.contains(
+          "cards-identifier-nav"
+        )
+      ).toBeFalsy();
+      expect(
+        getByTestId("card-stack").classList.contains("transition-start")
+      ).toBeFalsy();
     });
 
     expect(
@@ -373,7 +384,7 @@ describe("Identifiers Tab", () => {
       expect(
         queryByText(EN_TRANSLATIONS.tabs.identifiers.tab.title)
       ).toBeVisible();
-    })
+    });
   });
 
   test("Open multisig", async () => {
@@ -416,12 +427,14 @@ describe("Identifiers Tab", () => {
       dispatch: dispatchMock,
     };
 
-
     const history = createMemoryHistory();
     history.push(TabsRoutePath.IDENTIFIERS);
 
     const { getByText } = render(
-      <IonReactMemoryRouter history={history} initialEntries={[TabsRoutePath.IDENTIFIERS]}>
+      <IonReactMemoryRouter
+        history={history}
+        initialEntries={[TabsRoutePath.IDENTIFIERS]}
+      >
         <Provider store={storeMocked}>
           <Route
             path={TabsRoutePath.IDENTIFIERS}
@@ -646,7 +659,7 @@ describe("Identifiers Tab", () => {
     clickButtonRepeatedly(getByText, "1", 6);
 
     await waitFor(() => {
-      expect(deleteIdentifierMock).toBeCalled();
+      expect(markIdentifierPendingDelete).toBeCalled();
     });
 
     unmount();
@@ -833,9 +846,12 @@ describe("Identifiers Tab", () => {
 
     const history = createMemoryHistory();
     history.push(TabsRoutePath.IDENTIFIERS);
-  
+
     const { getByText, getByTestId } = render(
-      <IonReactMemoryRouter history={history} initialEntries={[TabsRoutePath.IDENTIFIERS]}>
+      <IonReactMemoryRouter
+        history={history}
+        initialEntries={[TabsRoutePath.IDENTIFIERS]}
+      >
         <Provider store={storeMocked}>
           <Route
             path={TabsRoutePath.IDENTIFIERS}

--- a/src/ui/pages/Identifiers/Identifiers.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.tsx
@@ -255,7 +255,7 @@ const Identifiers = () => {
         (item) => item.id !== deletedPendingItem.id
       );
 
-      await Agent.agent.identifiers.deleteIdentifier(deletedPendingItem.id);
+      await Agent.agent.identifiers.markIdentifierPendingDelete(deletedPendingItem.id);
 
       dispatch(setToastMsg(ToastMsgType.IDENTIFIER_DELETED));
       dispatch(setIdentifiersCache(updatedIdentifiers));


### PR DESCRIPTION
## Description

In anticipation of deleting identifiers on the cloud (or abandoning them), we need to ensure our delete identifier operations from the user are reliable and that the local deletion and cloud deletion both happen atomically.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1512)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated