### PR TITLE
feat(core): change ESNext and pass { cause: e } to propagate error stacks

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -246,9 +246,13 @@ class Agent {
         /* eslint-disable no-console */
         console.error(e);
         if (e.message === "Failed to fetch") {
-          throw new Error(Agent.KERIA_BOOT_FAILED_BAD_NETWORK);
+          throw new Error(Agent.KERIA_BOOT_FAILED_BAD_NETWORK, {
+            cause: e,
+          });
         }
-        throw new Error(Agent.KERIA_BOOT_FAILED);
+        throw new Error(Agent.KERIA_BOOT_FAILED, {
+          cause: e,
+        });
       });
 
       if (!bootResult.ok && bootResult.status !== 409) {
@@ -281,7 +285,9 @@ class Agent {
       bran = branBuffer.toString("utf-8");
     } catch (error) {
       if (error instanceof Error && error.message === "Invalid mnemonic") {
-        throw new Error(Agent.INVALID_MNEMONIC);
+        throw new Error(Agent.INVALID_MNEMONIC, {
+          cause: error,
+        });
       }
       throw error;
     }
@@ -307,12 +313,18 @@ class Agent {
       console.error(error);
       const status = error.message.split(" - ")[1];
       if (error.message === "Failed to fetch") {
-        throw new Error(Agent.KERIA_CONNECT_FAILED_BAD_NETWORK);
+        throw new Error(Agent.KERIA_CONNECT_FAILED_BAD_NETWORK, {
+          cause: error,
+        });
       }
       if (/404/gi.test(status)) {
-        throw new Error(Agent.KERIA_NOT_BOOTED);
+        throw new Error(Agent.KERIA_NOT_BOOTED, {
+          cause: error,
+        });
       }
-      throw new Error(Agent.KERIA_BOOTED_ALREADY_BUT_CANNOT_CONNECT);
+      throw new Error(Agent.KERIA_BOOTED_ALREADY_BUT_CANNOT_CONNECT, {
+        cause: error,
+      });
     });
   }
 

--- a/src/core/agent/services/connectionService.test.ts
+++ b/src/core/agent/services/connectionService.test.ts
@@ -726,8 +726,12 @@ describe("Connection service of agent", () => {
     contactGetMock.mockRejectedValue(
       new Error("request - 404 - SignifyClient message")
     );
-    await expect(connectionService.getConnectionById("id")).rejects.toThrow(
-      new Error(`${Agent.MISSING_DATA_ON_KERIA}: id`)
+    await expect(
+      connectionService.getConnectionById("id")
+    ).rejects.toMatchObject(
+      new Error(`${Agent.MISSING_DATA_ON_KERIA}: id`, {
+        cause: "request - 404 - SignifyClient message",
+      })
     );
   });
 

--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -248,7 +248,9 @@ class ConnectionService extends AgentService {
       .catch((error) => {
         const status = error.message.split(" - ")[1];
         if (/404/gi.test(status)) {
-          throw new Error(`${Agent.MISSING_DATA_ON_KERIA}: ${id}`);
+          throw new Error(`${Agent.MISSING_DATA_ON_KERIA}: ${id}`, {
+            cause: error,
+          });
         } else {
           throw error;
         }
@@ -470,7 +472,9 @@ class ConnectionService extends AgentService {
         5000
       )) as Operation & { response: State };
       if (!operation.done) {
-        throw new Error(`${ConnectionService.FAILED_TO_RESOLVE_OOBI} [url: ${url}]`);
+        throw new Error(
+          `${ConnectionService.FAILED_TO_RESOLVE_OOBI} [url: ${url}]`
+        );
       }
       if (operation.response && operation.response.i) {
         const connectionId = operation.response.i;

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -275,8 +275,10 @@ describe("Single sig service of agent", () => {
     );
     await expect(
       identifierService.getIdentifier(keriMetadataRecord.id)
-    ).rejects.toThrow(
-      new Error(`${Agent.MISSING_DATA_ON_KERIA}: ${keriMetadataRecord.id}`)
+    ).rejects.toMatchObject(
+      new Error(`${Agent.MISSING_DATA_ON_KERIA}: ${keriMetadataRecord.id}`, {
+        cause: "request - 404 - SignifyClient message",
+      })
     );
     expect(identifierStorage.getIdentifierMetadata).toBeCalledWith(
       keriMetadataRecord.id

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -106,7 +106,9 @@ class IdentifierService extends AgentService {
       .catch((error) => {
         const status = error.message.split(" - ")[1];
         if (/404/gi.test(status)) {
-          throw new Error(`${Agent.MISSING_DATA_ON_KERIA}: ${metadata.id}`);
+          throw new Error(`${Agent.MISSING_DATA_ON_KERIA}: ${metadata.id}`, {
+            cause: error,
+          });
         } else {
           throw error;
         }
@@ -171,7 +173,9 @@ class IdentifierService extends AgentService {
     let op = await operation.op().catch((error) => {
       const err = error.message.split(" - ");
       if (/400/gi.test(err[1]) && /already incepted/gi.test(err[2])) {
-        throw new Error(`${IdentifierService.IDENTIFIER_NAME_TAKEN}: ${name}`);
+        throw new Error(`${IdentifierService.IDENTIFIER_NAME_TAKEN}: ${name}`, {
+          cause: error,
+        });
       }
       throw error;
     });

--- a/src/core/agent/services/utils.ts
+++ b/src/core/agent/services/utils.ts
@@ -57,7 +57,9 @@ export const OnlineOnly = (
       ) {
         Agent.agent.markAgentStatus(false);
         Agent.agent.connect(1000);
-        throw new Error(Agent.KERIA_CONNECTION_BROKEN);
+        throw new Error(Agent.KERIA_CONNECTION_BROKEN, {
+          cause: error,
+        });
       } else {
         throw error;
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "lib": [
       "dom",
       "dom.iterable",
-      "es2020"
+      "es2022"
     ],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Description

Change ESNext and pass { cause: e } to propagate error stacks

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: (https://cardanofoundation.atlassian.net/browse/DTIS-1417)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated