### PR TITLE
feat: refresh IPEX notifications on major signing events

### DIFF
--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -120,6 +120,7 @@ interface KeriaNotification {
   multisigId?: string;
   connectionId: string;
   read: boolean;
+  groupReplied: boolean;
 }
 
 enum KeriConnectionType {

--- a/src/core/agent/event.types.ts
+++ b/src/core/agent/event.types.ts
@@ -81,7 +81,7 @@ interface KeriaStatusChangedEvent extends BaseEventEmitter {
 interface NotificationRemovedEvent extends BaseEventEmitter {
   type: typeof EventTypes.NotificationRemoved;
   payload: {
-    keriaNotif: KeriaNotification;
+    id: string;
   };
 }
 

--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -1939,6 +1939,7 @@ describe("IPEX communication service of agent", () => {
       },
       connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       read: true,
+      groupReplied: false,
     };
     schemaGetMock.mockResolvedValue(QVISchema);
     credentialStorage.getCredentialMetadatasById.mockResolvedValue([
@@ -2167,6 +2168,7 @@ describe("IPEX communication service of agent", () => {
       },
       connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       read: true,
+      groupReplied: false,
     };
     schemaGetMock.mockRejectedValue(
       new Error("request - 404 - SignifyClient message")
@@ -2188,6 +2190,7 @@ describe("IPEX communication service of agent", () => {
       },
       connectionId: "EGR7Jm38EcsXRIidKDZBYDm_xox6eapfU1tqxdAUzkFd",
       read: true,
+      groupReplied: false,
     };
     await expect(
       ipexCommunicationService.offerAcdcFromApply(noti.id, {})

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -22,7 +22,6 @@ import {
 } from "../records";
 import { OperationPendingRecordType } from "../records/operationPendingRecord.type";
 import { OperationPendingRecord } from "../records/operationPendingRecord";
-import { IonicStorage } from "../../storage/ionicStorage";
 import { MultiSigService } from "./multiSigService";
 import { IpexCommunicationService } from "./ipexCommunicationService";
 import {
@@ -279,8 +278,9 @@ class KeriaNotificationService extends AgentService {
       return;
     }
 
-    const exn = await this.getExternalExnMessage(notif);
-    if (!exn) {
+    const exn = await this.props.signifyClient.exchanges().get(notif.a.d);
+    if (await this.outboundExchange(exn)) {
+      await this.markNotification(notif.i);
       return;
     }
 
@@ -302,9 +302,11 @@ class KeriaNotificationService extends AgentService {
         exn
       );
     }
+
     if (!shouldCreateRecord) {
       return;
     }
+
     try {
       const keriaNotif = await this.createNotificationRecord(notif);
       if (notif.a.r !== NotificationRoute.ExnIpexAgree) {
@@ -389,11 +391,9 @@ class KeriaNotificationService extends AgentService {
     }
   }
 
-  private async getExternalExnMessage(
-    notif: Notification
-  ): Promise<ExnMessage | undefined> {
-    const exchange = await this.props.signifyClient.exchanges().get(notif.a.d);
-
+  private async outboundExchange(
+    exchange: ExnMessage 
+  ): Promise<boolean> {
     const ourIdentifier = await this.identifierStorage
       .getIdentifierMetadata(exchange.exn.i)
       .catch((error) => {
@@ -407,11 +407,7 @@ class KeriaNotificationService extends AgentService {
         }
       });
 
-    if (ourIdentifier) {
-      await this.markNotification(notif.i);
-      return undefined;
-    }
-    return exchange;
+    return ourIdentifier !== undefined;
   }
 
   private async processExnIpexApplyNotification(
@@ -471,14 +467,7 @@ class KeriaNotificationService extends AgentService {
         this.props.eventEmitter.emit<NotificationRemovedEvent>({
           type: EventTypes.NotificationRemoved,
           payload: {
-            keriaNotif: {
-              id: notificationRecord.id,
-              createdAt: notificationRecord.createdAt.toISOString(),
-              a: notificationRecord.a,
-              multisigId: notificationRecord.multisigId,
-              connectionId: notificationRecord.connectionId,
-              read: notificationRecord.read,
-            },
+            id: notificationRecord.id,
           },
         });
       }
@@ -541,6 +530,7 @@ class KeriaNotificationService extends AgentService {
               },
               read: false,
               connectionId: exchange.exn.i,
+              groupReplied: false,
             },
           },
         });
@@ -659,13 +649,38 @@ class KeriaNotificationService extends AgentService {
         throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
       }
 
+      // Refresh the date and read status for UI, and link
       const notificationRecord = grantNotificationRecords[0];
       notificationRecord.linkedGroupRequest = {
         ...notificationRecord.linkedGroupRequest,
         current: exchange.exn.d,
       };
+      notificationRecord.createdAt = new Date();
+      notificationRecord.read = false;
 
       await this.notificationStorage.update(notificationRecord);
+
+      this.props.eventEmitter.emit<NotificationRemovedEvent>({
+        type: EventTypes.NotificationRemoved,
+        payload: {
+          id: notificationRecord.id,
+        },
+      });
+      this.props.eventEmitter.emit<NotificationAddedEvent>({
+        type: EventTypes.NotificationAdded,
+        payload: {
+          keriaNotif: {
+            id: notificationRecord.id,
+            createdAt: notificationRecord.createdAt.toISOString(),
+            a: notificationRecord.a,
+            multisigId: notificationRecord.multisigId,
+            connectionId: notificationRecord.connectionId,
+            read: notificationRecord.read, 
+            groupReplied: true,
+          }
+        }
+      });
+
       return false;
     }
     case ExchangeRoute.IpexOffer: {
@@ -683,14 +698,39 @@ class KeriaNotificationService extends AgentService {
         // @TODO - foconnor: For deleted applies, we should track SAID in connection history
         throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
       }
-      
+
+      // Refresh the date and read status for UI, and link
       const notificationRecord = applyNotificationRecords[0];
       notificationRecord.linkedGroupRequest = {
         ...notificationRecord.linkedGroupRequest,
         current: exchange.exn.d,
       };
+      notificationRecord.createdAt = new Date();
+      notificationRecord.read = false;
 
       await this.notificationStorage.update(notificationRecord);
+
+      this.props.eventEmitter.emit<NotificationRemovedEvent>({
+        type: EventTypes.NotificationRemoved,
+        payload: {
+          id: notificationRecord.id,
+        },
+      });
+      this.props.eventEmitter.emit<NotificationAddedEvent>({
+        type: EventTypes.NotificationAdded,
+        payload: {
+          keriaNotif: {
+            id: notificationRecord.id,
+            createdAt: notificationRecord.createdAt.toISOString(),
+            a: notificationRecord.a,
+            multisigId: notificationRecord.multisigId,
+            connectionId: notificationRecord.connectionId,
+            read: notificationRecord.read, 
+            groupReplied: true,
+          }
+        }
+      });
+
       return false;
     }
     case ExchangeRoute.IpexGrant: {
@@ -770,6 +810,7 @@ class KeriaNotificationService extends AgentService {
       multisigId: result.multisigId,
       connectionId: result.connectionId,
       read: result.read,
+      groupReplied: result.linkedGroupRequest.current !== undefined,
     };
   }
 
@@ -795,7 +836,7 @@ class KeriaNotificationService extends AgentService {
     await this.notificationStorage.update(notificationRecord);
   }
 
-  async getAllNotifications(): Promise<KeriaNotification[]> {
+  async getNotifications(): Promise<KeriaNotification[]> {
     const notifications = await this.notificationStorage.findAllByQuery({
       $not: {
         route: NotificationRoute.ExnIpexAgree,
@@ -809,6 +850,7 @@ class KeriaNotificationService extends AgentService {
         multisigId: notification.multisigId,
         connectionId: notification.connectionId,
         read: notification.read,
+        groupReplied: notification.linkedGroupRequest.current !== undefined
       };
     });
   }
@@ -1000,14 +1042,7 @@ class KeriaNotificationService extends AgentService {
               this.props.eventEmitter.emit<NotificationRemovedEvent>({
                 type: EventTypes.NotificationRemoved,
                 payload: {
-                  keriaNotif: {
-                    id: notification.id,
-                    createdAt: notification.createdAt.toISOString(),
-                    a: notification.a,
-                    multisigId: notification.multisigId,
-                    connectionId: notification.connectionId,
-                    read: notification.read,
-                  },
+                  id: notification.id,
                 },
               });
             }
@@ -1038,15 +1073,20 @@ class KeriaNotificationService extends AgentService {
                   exnSaid: applyExchange.exn.d,
                 });
             for (const notification of notifications) {
-              await deleteNotificationRecordById(
-                this.props.signifyClient,
-                this.notificationStorage,
-                notification.id,
-                  notification.a.r as NotificationRoute
-              );
+              // "Refresh" the notification so user is aware offer is successfully sent
+              notification.createdAt = new Date();
+              notification.read = false;
+              await this.notificationStorage.update(notification);
 
               this.props.eventEmitter.emit<NotificationRemovedEvent>({
                 type: EventTypes.NotificationRemoved,
+                payload: {
+                  id: notification.id,
+                },
+              });
+
+              this.props.eventEmitter.emit<NotificationAddedEvent>({
+                type: EventTypes.NotificationAdded,
                 payload: {
                   keriaNotif: {
                     id: notification.id,
@@ -1054,9 +1094,10 @@ class KeriaNotificationService extends AgentService {
                     a: notification.a,
                     multisigId: notification.multisigId,
                     connectionId: notification.connectionId,
-                    read: notification.read,
-                  },
-                },
+                    read: notification.read, 
+                    groupReplied: true,
+                  }
+                }
               });
             }
           }

--- a/src/store/reducers/notificationsCache/notificationsCache.test.ts
+++ b/src/store/reducers/notificationsCache/notificationsCache.test.ts
@@ -3,16 +3,16 @@ import { KeriaNotification } from "../../../core/agent/agent.types";
 import { OperationType } from "../../../ui/globals/types";
 import { RootState } from "../../index";
 import {
-  deleteNotification,
+  deleteNotificationById,
   getNotificationsCache,
   notificationsCacheSlice,
   setNotificationsCache,
-  setReadedNotification,
+  markNotificationAsRead,
 } from "./notificationsCache";
 import { IdentifiersFilters } from "../../../ui/pages/Identifiers/Identifiers.types";
 import { CredentialsFilters } from "../../../ui/pages/Credentials/Credentials.types";
 
-const notification = {
+const notification: KeriaNotification = {
   id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMmG",
   createdAt: "2024-06-25T12:38:36.988Z",
   a: {
@@ -22,6 +22,7 @@ const notification = {
   },
   connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
   read: true,
+  groupReplied: false,
 };
 
 describe("Notifications cache", () => {
@@ -34,14 +35,14 @@ describe("Notifications cache", () => {
     ).toEqual(initialState);
   });
 
-  it("should handle setReadedNotification", () => {
+  it("should handle markNotificationAsRead", () => {
     const initialState = {
       notifications: [notification],
     };
 
     const newState = notificationsCacheSlice.reducer(
       initialState,
-      setReadedNotification({
+      markNotificationAsRead({
         id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMmG",
         read: false,
       })
@@ -58,6 +59,7 @@ describe("Notifications cache", () => {
         },
         connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
         read: false,
+        groupReplied: false,
       },
     ]);
   });
@@ -69,7 +71,7 @@ describe("Notifications cache", () => {
 
     const newState = notificationsCacheSlice.reducer(
       initialState,
-      deleteNotification(notification)
+      deleteNotificationById(notification.id)
     );
 
     expect(newState.notifications).toEqual([]);
@@ -87,6 +89,7 @@ describe("Notifications cache", () => {
         },
         connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
         read: true,
+        groupReplied: false,
       },
     ];
     const newState = notificationsCacheSlice.reducer(
@@ -184,6 +187,7 @@ describe("Notifications cache", () => {
             },
             connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
             read: true,
+            groupReplied: false,
           },
         ],
       },

--- a/src/store/reducers/notificationsCache/notificationsCache.ts
+++ b/src/store/reducers/notificationsCache/notificationsCache.ts
@@ -14,7 +14,7 @@ const notificationsCacheSlice = createSlice({
   name: "notificationsCache",
   initialState,
   reducers: {
-    setReadedNotification: (
+    markNotificationAsRead: (
       state,
       action: PayloadAction<{
         id: string;
@@ -30,9 +30,9 @@ const notificationsCacheSlice = createSlice({
         };
       });
     },
-    deleteNotification: (state, action: PayloadAction<KeriaNotification>) => {
+    deleteNotificationById: (state, action: PayloadAction<string>) => {
       state.notifications = state.notifications.filter(
-        (notification) => notification.id !== action.payload.id
+        (notification) => notification.id !== action.payload
       );
     },
     setNotificationsCache: (
@@ -51,8 +51,8 @@ export { initialState, notificationsCacheSlice };
 
 export const {
   setNotificationsCache,
-  setReadedNotification,
-  deleteNotification,
+  markNotificationAsRead,
+  deleteNotificationById,
   addNotification,
 } = notificationsCacheSlice.actions;
 

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -59,7 +59,7 @@ jest.mock("../core/agent/agent", () => ({
       keriaNotifications: {
         pollNotifications: jest.fn(),
         pollLongOperations: jest.fn(),
-        getAllNotifications: jest.fn(),
+        getNotifications: jest.fn(),
         stopNotification: jest.fn(),
         startNotification: jest.fn(),
         onNewNotification: jest.fn(),

--- a/src/ui/__fixtures__/notificationsFix.ts
+++ b/src/ui/__fixtures__/notificationsFix.ts
@@ -12,6 +12,7 @@ const notificationsFix: KeriaNotification[] = [
     },
     connectionId: "EJNd_YCOZA_g5fT8BnvY6KWgSMbIP9selgebbVNu8gNw",
     read: false,
+    groupReplied: false,
   },
   {
     id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMmG",
@@ -23,6 +24,7 @@ const notificationsFix: KeriaNotification[] = [
     },
     connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
     read: false,
+    groupReplied: false,
   },
   {
     id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMmv",
@@ -34,6 +36,7 @@ const notificationsFix: KeriaNotification[] = [
     },
     connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
     read: false,
+    groupReplied: false,
   },
   {
     id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMmk",
@@ -47,6 +50,7 @@ const notificationsFix: KeriaNotification[] = [
     },
     connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
     read: false,
+    groupReplied: false,
   },
   {
     id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMmc",
@@ -60,6 +64,7 @@ const notificationsFix: KeriaNotification[] = [
     },
     connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
     read: false,
+    groupReplied: false,
   },
   {
     id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMm1",
@@ -72,6 +77,7 @@ const notificationsFix: KeriaNotification[] = [
     },
     connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
     read: false,
+    groupReplied: false,
   },
   {
     id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMm2",
@@ -83,6 +89,7 @@ const notificationsFix: KeriaNotification[] = [
     },
     connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
     read: false,
+    groupReplied: false,
   },
 ];
 

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -101,7 +101,7 @@ jest.mock("../../../core/agent/agent", () => ({
       keriaNotifications: {
         pollNotifications: jest.fn(),
         pollLongOperations: jest.fn(),
-        getAllNotifications: jest.fn(),
+        getNotifications: jest.fn(),
         onNewNotification: jest.fn(),
         onLongOperationComplete: jest.fn(),
         onRemoveNotification: jest.fn(),

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -69,7 +69,7 @@ import { CardListViewType } from "../SwitchCardView";
 import "./AppWrapper.scss";
 import { useActivityTimer } from "./hooks/useActivityTimer";
 import {
-  notificatiStateChanged,
+  notificationStateChanged,
   signifyOperationStateChangeHandler,
 } from "./coreEventListeners";
 import {
@@ -274,7 +274,7 @@ const AppWrapper = (props: { children: ReactNode }) => {
       const storedPeerConnections =
         await Agent.agent.peerConnectionMetadataStorage.getAllPeerConnectionMetadata();
       const notifications =
-        await Agent.agent.keriaNotifications.getAllNotifications();
+        await Agent.agent.keriaNotifications.getNotifications();
 
       dispatch(setIdentifiersCache(storedIdentifiers));
       dispatch(setCredsCache(credsCache));
@@ -479,7 +479,7 @@ const AppWrapper = (props: { children: ReactNode }) => {
       }
     );
     Agent.agent.keriaNotifications.onNewNotification((event) => {
-      notificatiStateChanged(event, dispatch);
+      notificationStateChanged(event, dispatch);
     });
 
     Agent.agent.keriaNotifications.onLongOperationComplete((event) => {
@@ -487,7 +487,7 @@ const AppWrapper = (props: { children: ReactNode }) => {
     });
 
     Agent.agent.keriaNotifications.onRemoveNotification((event) => {
-      notificatiStateChanged(event, dispatch);
+      notificationStateChanged(event, dispatch);
     });
   };
 

--- a/src/ui/components/AppWrapper/coreEventListeners.ts
+++ b/src/ui/components/AppWrapper/coreEventListeners.ts
@@ -8,12 +8,12 @@ import { useAppDispatch } from "../../../store/hooks";
 import { updateIsPending } from "../../../store/reducers/identifiersCache";
 import {
   addNotification,
-  deleteNotification,
+  deleteNotificationById,
 } from "../../../store/reducers/notificationsCache";
 import { setToastMsg } from "../../../store/reducers/stateCache";
 import { ToastMsgType } from "../../globals/types";
 
-const notificatiStateChanged = (
+const notificationStateChanged = (
   event: NotificationRemovedEvent | NotificationAddedEvent,
   dispatch: ReturnType<typeof useAppDispatch>
 ) => {
@@ -22,7 +22,7 @@ const notificatiStateChanged = (
     dispatch(addNotification(event.payload.keriaNotif));
     break;
   case EventTypes.NotificationRemoved:
-    dispatch(deleteNotification(event.payload.keriaNotif));
+    dispatch(deleteNotificationById(event.payload.id));
     break;
   default:
     break;
@@ -41,4 +41,4 @@ const signifyOperationStateChangeHandler = async (
     break;
   }
 };
-export { notificatiStateChanged, signifyOperationStateChangeHandler };
+export { notificationStateChanged, signifyOperationStateChangeHandler };

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -21,7 +21,7 @@ import {
 } from "../../../../../store/reducers/connectionsCache";
 import { getIdentifiersCache } from "../../../../../store/reducers/identifiersCache";
 import {
-  deleteNotification,
+  deleteNotificationById,
   getNotificationsCache,
   setNotificationsCache,
 } from "../../../../../store/reducers/notificationsCache";
@@ -181,7 +181,7 @@ const ReceiveCredential = ({
         notificationDetails.id,
         notificationDetails.a.r as NotificationRoute
       );
-      dispatch(deleteNotification(notificationDetails));
+      dispatch(deleteNotificationById(notificationDetails.id));
       handleBack();
     } catch (e) {
       showError("Unable to remove notification", e, dispatch);

--- a/src/ui/pages/Notifications/Notifications.tsx
+++ b/src/ui/pages/Notifications/Notifications.tsx
@@ -11,7 +11,7 @@ import { TabsRoutePath } from "../../../routes/paths";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
   getNotificationsCache,
-  setReadedNotification,
+  markNotificationAsRead,
 } from "../../../store/reducers/notificationsCache";
 import { setCurrentRoute } from "../../../store/reducers/stateCache";
 import { CredentialDetailModal } from "../../components/CredentialDetailModule";
@@ -93,7 +93,7 @@ const Notifications = () => {
       await Agent.agent.keriaNotifications.readNotification(notification.id);
 
       dispatch(
-        setReadedNotification({
+        markNotificationAsRead({
           id: notification.id,
           read: !notification.read,
         })

--- a/src/ui/pages/Notifications/components/NotificationOptionsModal.test.tsx
+++ b/src/ui/pages/Notifications/components/NotificationOptionsModal.test.tsx
@@ -3,11 +3,12 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { ReactNode, act } from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
+import { KeriaNotification } from "../../../../core/agent/agent.types";
 import EN_TRANSLATIONS from "../../../../locales/en/en.json";
 import { TabsRoutePath } from "../../../../routes/paths";
 import {
-  deleteNotification,
-  setReadedNotification,
+  deleteNotificationById,
+  markNotificationAsRead,
 } from "../../../../store/reducers/notificationsCache";
 import { NotificationOptionsModal } from "./NotificationOptionsModal";
 
@@ -16,7 +17,7 @@ jest.mock("@ionic/react", () => ({
   IonModal: ({ children }: { children: ReactNode }) => children,
 }));
 
-const notification = {
+const notification: KeriaNotification = {
   id: "AL3XmFY8BM9F604qmV-l9b0YMZNvshHG7X6CveMWKMmG",
   createdAt: "2024-06-25T12:38:36.988Z",
   a: {
@@ -26,6 +27,7 @@ const notification = {
   },
   connectionId: "EMrT7qX0FIMenQoe5pJLahxz_rheks1uIviGW8ch8pfB",
   read: false,
+  groupReplied: false,
 };
 
 const deleteNotificationMock = jest.fn((id: string) => Promise.resolve(id));
@@ -128,7 +130,7 @@ describe("Notification Options modal", () => {
 
     await waitFor(() => {
       expect(deleteNotificationMock).toBeCalledWith(notification.id);
-      expect(dispatchMock).toBeCalledWith(deleteNotification(notification));
+      expect(dispatchMock).toBeCalledWith(deleteNotificationById(notification.id));
     });
   });
 
@@ -153,7 +155,7 @@ describe("Notification Options modal", () => {
     await waitFor(() => {
       expect(readNotificationMock).toBeCalledWith(notification.id);
       expect(dispatchMock).toBeCalledWith(
-        setReadedNotification({
+        markNotificationAsRead({
           id: notification.id,
           read: !notification.read,
         })
@@ -185,7 +187,7 @@ describe("Notification Options modal", () => {
     await waitFor(() => {
       expect(unreadNotificationMock).toBeCalledWith(notification.id);
       expect(dispatchMock).toBeCalledWith(
-        setReadedNotification({
+        markNotificationAsRead({
           id: notification.id,
           read: false,
         })

--- a/src/ui/pages/Notifications/components/NotificationOptionsModal.tsx
+++ b/src/ui/pages/Notifications/components/NotificationOptionsModal.tsx
@@ -9,8 +9,8 @@ import { Agent } from "../../../../core/agent/agent";
 import { i18n } from "../../../../i18n";
 import { useAppDispatch } from "../../../../store/hooks";
 import {
-  deleteNotification,
-  setReadedNotification,
+  deleteNotificationById,
+  markNotificationAsRead,
 } from "../../../../store/reducers/notificationsCache";
 import { Alert } from "../../../components/Alert";
 import { OptionItem, OptionModal } from "../../../components/OptionsModal";
@@ -43,7 +43,7 @@ const NotificationOptionsModal = ({
       }
 
       dispatch(
-        setReadedNotification({
+        markNotificationAsRead({
           id: notification.id,
           read: !notification.read,
         })
@@ -60,7 +60,7 @@ const NotificationOptionsModal = ({
         notification.id,
         notification.a.r as NotificationRoute
       );
-      dispatch(deleteNotification(notification));
+      dispatch(deleteNotificationById(notification.id));
       closeModal();
     } catch (e) {
       showError("Unable to remove notification", e, dispatch);


### PR DESCRIPTION
## Description

This PR allows the UI to more closely match our notifications design for group IPEX for refreshing. Refreshing here means marking the notification as unread, and setting it's `createdAt` date to now. We will be renaming createdAt in the future to better reflect this.

Changes:
- When the leader accepts a credential, the notification will be refreshed for other members
- When the leader proposes a credential from a request, the notification will be refreshed for other members
- When a credential presentation meets the threshold, the notification will be refreshed for all members instead of being removed

When the threshold is met for receiving a credential, the notification will still be deleted because the user can see that the credential went from pending to confirmed. (There is connection history, but this is less obvious)

Finally, I've introduced a `groupReplied` field for notification details in the list. Based on Robert's designs, the text of the notification should say "X has proposed a credential for Y's request" once the leader has proposed something. This should be tackled in the current UI ticket.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications