### PR TITLE
feat(ui): Updates: group notifications and identifiers cache

### DIFF
--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -122,6 +122,8 @@ interface KeriaNotification {
   connectionId: string;
   read: boolean;
   groupReplied: boolean;
+  initiatorAid?: string;
+  groupInitiator?: boolean;
 }
 
 enum KeriConnectionType {

--- a/src/core/agent/records/notificationRecord.ts
+++ b/src/core/agent/records/notificationRecord.ts
@@ -14,6 +14,9 @@ interface NotificationRecordStorageProps {
   connectionId: string;
   credentialId?: string;
   linkedGroupRequest?: LinkedGroupRequest;
+  groupReplied?: boolean,
+  initiatorAid?: string,
+  groupInitiator?: boolean,
 }
 
 class NotificationRecord extends BaseRecord {
@@ -24,6 +27,9 @@ class NotificationRecord extends BaseRecord {
   connectionId!: string;
   linkedGroupRequest!: LinkedGroupRequest;
   credentialId?: string;
+  groupReplied?: boolean;
+  initiatorAid?: string;
+  groupInitiator?: boolean;
 
   static readonly type = "NotificationRecord";
   readonly type = NotificationRecord.type;
@@ -41,6 +47,9 @@ class NotificationRecord extends BaseRecord {
       this._tags = props.tags ?? {};
       this.linkedGroupRequest = props.linkedGroupRequest ?? { accepted: false };
       this.credentialId = props.credentialId;
+      this.groupReplied = props.groupReplied;
+      this.initiatorAid = props.initiatorAid;
+      this.groupInitiator = props.groupInitiator;
     }
   }
 
@@ -51,6 +60,9 @@ class NotificationRecord extends BaseRecord {
       multisigId: this.multisigId,
       exnSaid: this.a.d,
       credentialId: this.credentialId,
+      groupReplied: this.groupReplied,
+      initiatorAid: this.initiatorAid,
+      groupInitiator: this.groupInitiator,
       ...this._tags,
     };
   }

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -2575,8 +2575,35 @@ describe("Long running operation tracker", () => {
         linkedGroupRequest: { accepted: false },
         connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
         updatedAt: new Date(),
+        groupReplied: true,
+        initiatorAid: "EAL7pX9Hklc_iq7pkVYSjAilCfQX3sr5RbX76AxYs2UH",
+        groupInitiator: true,
       },
     ]);
+
+    multiSigs.getMultisigParticipants.mockResolvedValue({
+      ourIdentifier: {
+        id: "EC1cyV3zLnGs4B9AYgoGNjXESyQZrBWygz3jLlRD30bR",
+        displayName:"holder",
+        createdAt: "2024-09-23T08:53:11.981Z",
+        theme: 0,
+        groupMetadata: {
+          groupId: "group-id",
+          groupInitiator: true,
+          groupCreated: true,
+        },
+      },
+      multisigMembers: [
+        {
+          aid: "EC1cyV3zLnGs4B9AYgoGNjXESyQZrBWygz3jLlRD30bR",
+          ends: [],
+        },
+        {
+          aid: "EGaEIhOGSTPccSMvnXvfvOVyC1C5AFq62GLTrRKVZBS5",
+          ends: [],
+        },
+      ],
+    });
 
     await keriaNotificationService.processOperation(operationRecord);
 

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -212,6 +212,7 @@ const multiSigs = jest.mocked({
   joinAuthorization: jest.fn(),
   hasMultisig: jest.fn(),
   endRoleAuthorization: jest.fn(),
+  getMultisigParticipants: jest.fn(),
 });
 
 const ipexCommunications = jest.mocked({
@@ -1496,6 +1497,31 @@ describe("Group IPEX presentation", () => {
     exchangesGetMock
       .mockResolvedValueOnce(multisigExnOfferForPresenting)
       .mockResolvedValueOnce(applyForPresentingExnMessage);
+
+    multiSigs.getMultisigParticipants.mockResolvedValue({
+      ourIdentifier: {
+        id: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_z8",
+        displayName: "Identifier 2",
+        createdAt: "2024-09-23T08:53:11.981Z",
+        theme: 0,
+        groupMetadata: {
+          groupId: "group-id",
+          groupInitiator: true,
+          groupCreated: true,
+        },
+      },
+      multisigMembers: [
+        {
+          aid: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_z8",
+          ends: [],
+        },
+        {
+          aid: "EGaEIhOGSTPccSMvnXvfvOVyC1C5AFq62GLTrRKVZBS5",
+          ends: [],
+        },
+      ],
+    });
+
     notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([
       {
         type: "NotificationRecord",
@@ -1517,6 +1543,8 @@ describe("Group IPEX presentation", () => {
       notificationMultisigExnProp
     );
 
+    expect(multiSigs.getMultisigParticipants).toBeCalledWith("EC1cyV3zLnGs4B9AYgoGNjXESyQZrBWygz3jLlRD30bR");
+    
     expect(notificationStorage.update).toBeCalledWith(expect.objectContaining({
       id: "id",
       route: NotificationRoute.ExnIpexApply,

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -716,6 +716,13 @@ class KeriaNotificationService extends AgentService {
           id: notificationRecord.id,
         },
       });
+      const { multisigMembers, ourIdentifier } =
+          await this.multiSigs.getMultisigParticipants(exchange.exn.a.gid);
+
+      const initiatorAid = multisigMembers.map(
+        (member: any) => member.aid
+      )[0];
+
       this.props.eventEmitter.emit<NotificationAddedEvent>({
         type: EventTypes.NotificationAdded,
         payload: {
@@ -723,12 +730,14 @@ class KeriaNotificationService extends AgentService {
             id: notificationRecord.id,
             createdAt: notificationRecord.createdAt.toISOString(),
             a: notificationRecord.a,
-            multisigId: notificationRecord.multisigId,
+            multisigId: exchange.exn.a.gid,
             connectionId: notificationRecord.connectionId,
-            read: notificationRecord.read, 
+            read: notificationRecord.read,
             groupReplied: true,
-          }
-        }
+            initiatorAid,
+            groupInitiator: ourIdentifier.groupMetadata?.groupInitiator,
+          },
+        },
       });
 
       return false;

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1139,7 +1139,8 @@
           "exnipexgrant": "<strong>{{connection}}</strong> wants to issue you a credential",
           "multisigicp": "<strong>{{connection}}</strong> is requesting to create a group identifier with you",
           "exnipexapply": "<strong>{{connection}}</strong> has requested a credential from you",
-          "exnipexgrantrevoke": "Your <strong>{{credential}}</strong> credential has been revoked"
+          "exnipexgrantrevoke": "Your <strong>{{credential}}</strong> credential has been revoked",
+          "exnipexapplyproposed": "<strong>{{initiator}}</strong>  has proposed a credential for the <strong>{{connection}}’s</strong> request"
         }
       },
       "details": {

--- a/src/routes/backRoute/backRoute.test.ts
+++ b/src/routes/backRoute/backRoute.test.ts
@@ -58,7 +58,7 @@ describe("getBackRoute", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",
@@ -210,7 +210,7 @@ describe("getPreviousRoute", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",

--- a/src/routes/nextRoute/nextRoute.test.ts
+++ b/src/routes/nextRoute/nextRoute.test.ts
@@ -57,7 +57,7 @@ describe("NextRoute", () => {
         bran: "",
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",
@@ -317,7 +317,7 @@ describe("getNextRoute", () => {
       bran: "",
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
       favourites: [],
       multiSigGroup: {
         groupId: "",

--- a/src/store/reducers/identifiersCache/identifiersCache.test.ts
+++ b/src/store/reducers/identifiersCache/identifiersCache.test.ts
@@ -26,7 +26,7 @@ import { IdentifiersFilters } from "../../../ui/pages/Identifiers/Identifiers.ty
 
 describe("identifiersCacheSlice", () => {
   const initialState = {
-    identifiers: [],
+    identifiers: {},
     favourites: [],
     multiSigGroup: undefined,
     openMultiSigId: undefined,
@@ -52,7 +52,15 @@ describe("identifiersCacheSlice", () => {
       initialState,
       setIdentifiersCache(identifiers)
     );
-    expect(newState.identifiers).toEqual(identifiers);
+    expect(newState.identifiers).toEqual({
+      "id-1" : {
+        id: "id-1",
+        displayName: "example-name",
+        createdAtUTC: "example-date",
+        theme: 0,
+        isPending: false,
+      }
+    });
   });
 
   it("should handle setMultiSigGroupCache", () => {
@@ -100,7 +108,7 @@ describe("identifiersCacheSlice", () => {
   });
   it("should handle removeFavouriteIdentifierCache", () => {
     const initialState = {
-      identifiers: [],
+      identifiers: {},
       favourites: [
         {
           id: "abcd",
@@ -151,7 +159,22 @@ describe("identifiersCacheSlice", () => {
       currentState,
       updateOrAddIdentifiersCache(identifier)
     );
-    expect(newState.identifiers).toEqual([...identifiers, identifier]);
+    expect(newState.identifiers).toEqual({
+      "id-1": {
+        id: "id-1",
+        displayName: "example-name",
+        createdAtUTC: "example-date",
+        theme: 0,
+        isPending: false,
+      },
+      "id-2": {
+        id: "id-2",
+        displayName: "example-name",
+        createdAtUTC: "example-date",
+        theme: 0,
+        isPending: false,
+      }
+    });
   });
 
   it("should handle updateIsPending", () => {
@@ -164,10 +187,12 @@ describe("identifiersCacheSlice", () => {
         isPending: true,
       },
     ];
+    
     const currentState = identifiersCacheSlice.reducer(
       initialState,
       setIdentifiersCache(identifiers)
     );
+
     const identifier: IdentifierShortDetails = {
       id: "id-1",
       displayName: "example-name",
@@ -175,11 +200,21 @@ describe("identifiersCacheSlice", () => {
       theme: 0,
       isPending: false,
     };
+
     const newState = identifiersCacheSlice.reducer(
       currentState,
       updateIsPending({ id: identifier.id, isPending: identifier.isPending })
     );
-    expect(newState.identifiers).toEqual([identifier]);
+
+    expect(newState.identifiers).toEqual({
+      "id-1" : {
+        id: "id-1",
+        displayName: "example-name",
+        createdAtUTC: "example-date",
+        theme: 0,
+        isPending: false,
+      }
+    });
   });
 
   it("should handle setOpenMultiSigId", () => {
@@ -203,20 +238,17 @@ describe("get identifier Cache", () => {
   it("should return the identifiers cache from RootState", () => {
     const state = {
       identifiersCache: {
-        identifiers: [
-          {
-            id: "id-1",
-            displayName: "example-name-1",
-            createdAtUTC: "example-date",
-          },
-          {
-            id: "id-2",
-            displayName: "example-name-2",
-            createdAtUTC: "example-date",
-          },
-        ],
+        identifiers: {},
       },
     } as RootState;
+    state.identifiersCache.identifiers["id-1"] = {
+      id: "id-1",
+      displayName: "example-name-1",
+      createdAtUTC: "example-date", 
+      theme: 0,
+      isPending: false
+    }
+  
     const identifiersCache = getIdentifiersCache(state);
     expect(identifiersCache).toEqual(state.identifiersCache.identifiers);
   });

--- a/src/store/reducers/identifiersCache/identifiersCache.types.ts
+++ b/src/store/reducers/identifiersCache/identifiersCache.types.ts
@@ -13,7 +13,7 @@ interface MultiSigGroup {
 }
 
 interface IdentifierCacheState {
-  identifiers: IdentifierShortDetails[];
+  identifiers: Record<string, IdentifierShortDetails>;
   favourites: FavouriteIdentifier[];
   filters: IdentifiersFilters;
   multiSigGroup: MultiSigGroup | undefined;

--- a/src/store/reducers/notificationsCache/notificationsCache.test.ts
+++ b/src/store/reducers/notificationsCache/notificationsCache.test.ts
@@ -135,7 +135,7 @@ describe("Notifications cache", () => {
         bran: "",
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",

--- a/src/store/reducers/notificationsCache/notificationsCache.ts
+++ b/src/store/reducers/notificationsCache/notificationsCache.ts
@@ -1,9 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { RootState } from "../../index";
 import { KeriaNotification } from "../../../core/agent/agent.types";
+import { RootState } from "../../index";
 import {
-  NotificationCacheState,
-  NotificationDetailCacheState,
+  NotificationCacheState
 } from "./notificationCache.types";
 
 const initialState: NotificationCacheState = {

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -174,7 +174,7 @@ const initialState = {
     bran: "",
   },
   identifiersCache: {
-    identifiers: [],
+    identifiers: {},
     favourites: [],
     multiSigGroup: {
       groupId: "",
@@ -327,7 +327,7 @@ describe("App", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",
@@ -459,7 +459,7 @@ describe("App", () => {
         bran: "",
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",

--- a/src/ui/__fixtures__/filteredIdentifierFix.ts
+++ b/src/ui/__fixtures__/filteredIdentifierFix.ts
@@ -40,6 +40,12 @@ const filteredIdentifierFix: IdentifierShortDetails[] = [
   },
 ];
 
+const filteredIdentifierMapFix = filteredIdentifierFix.reduce((result, next) => {
+  result[next.id] = next;
+
+  return result;
+}, {} as Record<string, IdentifierShortDetails>);
+
 const multisignIdentifierFix: IdentifierShortDetails[] = [
   {
     id: "ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb",
@@ -71,6 +77,7 @@ const pendingMultisignIdentifierFix: IdentifierShortDetails[] = [
 ];
 
 export {
+  filteredIdentifierMapFix,
   filteredIdentifierFix,
   multisignIdentifierFix,
   pendingMultisignIdentifierFix,

--- a/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.test.tsx
@@ -61,7 +61,7 @@ describe("Create Identifier modal", () => {
       isOnline: true,
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
     },
   };
 

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
@@ -89,7 +89,7 @@ describe("Create group identifier - Setup Connection", () => {
       },
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
       favourites: [],
       multiSigGroup: {
         groupId: "b75838e5-98cb-46cf-9233-8bf3beca4cd3",
@@ -361,7 +361,7 @@ describe("Create group identifier - Setup Connection", () => {
         },
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "b75838e5-98cb-46cf-9233-8bf3beca4cd3",

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnections.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnections.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Agent } from "../../../../core/agent/agent";
+import { ConnectionShortDetails } from "../../../../core/agent/agent.types";
 import { i18n } from "../../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../../store/hooks";
 import {
   getIdentifiersCache,
   getMultiSigGroupCache,
-  setIdentifiersCache,
-  setScanGroupId,
+  removeIdentifierCache,
+  setScanGroupId
 } from "../../../../store/reducers/identifiersCache";
 import {
   getCurrentOperation,
@@ -17,15 +18,14 @@ import {
 } from "../../../../store/reducers/stateCache";
 import { OperationType, ToastMsgType } from "../../../globals/types";
 import { useOnlineStatusEffect } from "../../../hooks";
+import { showError } from "../../../utils/error";
 import { getTheme } from "../../../utils/theme";
 import { Alert } from "../../Alert";
 import { TabsRoutePath } from "../../navigation/TabsMenu";
+import { Verification } from "../../Verification";
 import { IdentifierStageProps, Stage } from "../CreateGroupIdentifier.types";
 import { SetupConnectionBodyInit } from "./SetupConnectionBodyInit";
 import { SetupConnectionBodyResume } from "./SetupConnectionBodyResume";
-import { showError } from "../../../utils/error";
-import { Verification } from "../../Verification";
-import { ConnectionShortDetails } from "../../../../core/agent/agent.types";
 
 const SetupConnections = ({
   state,
@@ -147,14 +147,11 @@ const SetupConnections = ({
 
     try {
       setVerifyIsOpen(false);
-      const updatedIdentifiers = identifierData.filter(
-        (item) => item.id !== identifierId
-      );
 
       await Agent.agent.identifiers.markIdentifierPendingDelete(identifierId);
 
       dispatch(setToastMsg(ToastMsgType.IDENTIFIER_DELETED));
-      dispatch(setIdentifiersCache(updatedIdentifiers));
+      dispatch(removeIdentifierCache(identifierId));
       handleDone();
     } catch (e) {
       showError(

--- a/src/ui/components/CreateGroupIdentifier/components/Summary.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/Summary.tsx
@@ -62,7 +62,7 @@ const Summary = ({
             isPending: !!isPending,
             multisigManageAid: ourIdentifier,
           };
-          const filteredIdentifiersData = identifiersData.filter(
+          const filteredIdentifiersData = Object.values(identifiersData).filter(
             (item) => item.id !== ourIdentifier
           );
           dispatch(

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
@@ -124,7 +124,7 @@ describe("Create Identifier modal", () => {
       isOnline: true,
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
     },
   };
 

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
@@ -18,11 +18,9 @@ import {
   IdentifierShortDetails,
 } from "../../../core/agent/services/identifier.types";
 import { i18n } from "../../../i18n";
-import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { useAppDispatch } from "../../../store/hooks";
 import {
-  getIdentifiersCache,
-  setIdentifiersCache,
-  setMultiSigGroupCache,
+  setMultiSigGroupCache
 } from "../../../store/reducers/identifiersCache";
 import { MultiSigGroup } from "../../../store/reducers/identifiersCache/identifiersCache.types";
 import {
@@ -80,7 +78,6 @@ const CreateIdentifier = ({
     MultiSigGroup | undefined
   >();
 
-  const identifiersData = useAppSelector(getIdentifiersCache);
   const [openAIDInfo, setOpenAIDInfo] = useState(false);
 
   const [duplicateName, setDuplicateName] = useState(false);

--- a/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
+++ b/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
@@ -106,7 +106,7 @@ const initialStateNoPasswordCurrent = {
     notificationDetailCache: null,
   },
   identifiersCache: {
-    identifiers: [],
+    identifiers: {},
   },
 };
 
@@ -136,7 +136,7 @@ const initialStateNoPasswordArchived = {
     notificationDetailCache: null,
   },
   identifiersCache: {
-    identifiers: [],
+    identifiers: {},
   },
 };
 
@@ -355,7 +355,7 @@ describe("Cred Detail Module - current not archived credential", () => {
         notificationDetailCache: null,
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
     };
 
@@ -421,7 +421,7 @@ describe("Cred Detail Module - current not archived credential", () => {
         })),
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       notificationsCache: {
         notificationDetailCache: null,
@@ -697,7 +697,7 @@ describe("Cred Detail Module - light mode", () => {
       enabled: false,
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
     },
     notificationsCache: {
       notificationDetailCache: {
@@ -763,7 +763,7 @@ describe("Cred detail - revoked", () => {
       bran: "bran",
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
     },
     credsCache: { creds: credsFixAcdc },
     credsArchivedCache: { creds: [] },
@@ -897,7 +897,7 @@ describe("Cred detail - view only", () => {
       enabled: false,
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
     },
     notificationsCache: {
       notificationDetailCache: {

--- a/src/ui/components/CredentialDetailModule/components/CredentialContent.test.tsx
+++ b/src/ui/components/CredentialDetailModule/components/CredentialContent.test.tsx
@@ -1,18 +1,18 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
+import { ACDCDetails, CredentialStatus } from "../../../../core/agent/services/credentialService.types";
+import { IdentifierType } from "../../../../core/agent/services/identifier.types";
 import EN_TRANSLATIONS from "../../../../locales/en/en.json";
 import { store } from "../../../../store";
 import {
   connectionDetailsFix,
   credsFixAcdc,
 } from "../../../__fixtures__/credsFix";
-import { filteredIdentifierFix } from "../../../__fixtures__/filteredIdentifierFix";
+import { filteredIdentifierMapFix } from "../../../__fixtures__/filteredIdentifierFix";
 import { identifierFix } from "../../../__fixtures__/identifierFix";
 import { formatShortDate, formatTimeToSec } from "../../../utils/formatters";
 import { CredentialContent } from "./CredentialContent";
-import { ACDCDetails, CredentialStatus } from "../../../../core/agent/services/credentialService.types";
-import { IdentifierType } from "../../../../core/agent/services/identifier.types";
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,
@@ -154,7 +154,7 @@ describe("Creds content", () => {
       credsCache: { creds: credsFixAcdc, favourites: [] },
       credsArchivedCache: { creds: credsFixAcdc },
       identifiersCache: {
-        identifiers: filteredIdentifierFix,
+        identifiers: filteredIdentifierMapFix,
       },
     };
 

--- a/src/ui/components/CredentialDetailModule/components/CredentialContent.tsx
+++ b/src/ui/components/CredentialDetailModule/components/CredentialContent.tsx
@@ -9,6 +9,7 @@ import { useAppSelector } from "../../../../store/hooks";
 import { getIdentifiersCache } from "../../../../store/reducers/identifiersCache";
 import KeriLogo from "../../../assets/images/KeriGeneric.jpg";
 import { formatShortDate, formatTimeToSec } from "../../../utils/formatters";
+import { Alert } from "../../Alert";
 import {
   CardBlock,
   CardDetailsBlock,
@@ -22,7 +23,6 @@ import { CredentialAttributeContent, CredentialAttributeDetailModal } from "./Cr
 import { CredentialContentProps } from "./CredentialContent.types";
 import { MultisigMember } from "./MultisigMember";
 import { MemberAcceptStatus } from "./MultisigMember.types";
-import { Alert } from "../../Alert";
 
 const CredentialContent = ({
   cardData,
@@ -36,7 +36,7 @@ const CredentialContent = ({
   const [openIdentifierDetail, setOpenIdentifierDetail] = useState(false);
   const [showMissingIssuerModal, setShowMissingIssuerModal] = useState(false);
 
-  const identifier = identifiers.find(item => item.id === cardData.identifierId);
+  const identifier = identifiers[cardData.identifierId];
 
   const openConnection = () => {
     if(connectionShortDetails) {

--- a/src/ui/components/EditIdentifier/EditIdentifier.test.tsx
+++ b/src/ui/components/EditIdentifier/EditIdentifier.test.tsx
@@ -1,17 +1,17 @@
+import { IonInput, IonLabel } from "@ionic/react";
 import { ionFireEvent, waitForIonicReact } from "@ionic/react-test-utils";
 import { AnyAction, Store } from "@reduxjs/toolkit";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { IonInput, IonLabel } from "@ionic/react";
-import { filteredIdentifierFix } from "../../__fixtures__/filteredIdentifierFix";
+import { IdentifierService } from "../../../core/agent/services";
+import EN_TRANSLATIONS from "../../../locales/en/en.json";
+import { filteredIdentifierMapFix } from "../../__fixtures__/filteredIdentifierFix";
 import { identifierFix } from "../../__fixtures__/identifierFix";
+import { CustomInputProps } from "../CustomInput/CustomInput.types";
 import { TabsRoutePath } from "../navigation/TabsMenu";
 import { EditIdentifier } from "./EditIdentifier";
-import EN_TRANSLATIONS from "../../../locales/en/en.json";
-import { CustomInputProps } from "../CustomInput/CustomInput.types";
-import { IdentifierService } from "../../../core/agent/services";
 
 const updateMock = jest.fn();
 
@@ -96,7 +96,7 @@ describe("Edit identifier", () => {
         },
       },
       identifiersCache: {
-        identifiers: filteredIdentifierFix,
+        identifiers: filteredIdentifierMapFix,
       },
     };
     mockedStore = {

--- a/src/ui/components/EditIdentifier/EditIdentifier.tsx
+++ b/src/ui/components/EditIdentifier/EditIdentifier.tsx
@@ -3,15 +3,18 @@ import { Keyboard } from "@capacitor/keyboard";
 import { IonModal, IonSpinner } from "@ionic/react";
 import { useEffect, useState } from "react";
 import { Agent } from "../../../core/agent/agent";
+import { IdentifierService } from "../../../core/agent/services";
 import { i18n } from "../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
   getIdentifiersCache,
-  setIdentifiersCache,
+  updateOrAddIdentifiersCache
 } from "../../../store/reducers/identifiersCache";
 import { setToastMsg } from "../../../store/reducers/stateCache";
 import { DISPLAY_NAME_LENGTH } from "../../globals/constants";
 import { ToastMsgType } from "../../globals/types";
+import { showError } from "../../utils/error";
+import { nameChecker } from "../../utils/nameChecker";
 import { createThemeValue, getTheme } from "../../utils/theme";
 import { IdentifierColorSelector } from "../CreateIdentifier/components/IdentifierColorSelector";
 import { IdentifierThemeSelector } from "../CreateIdentifier/components/IdentifierThemeSelector";
@@ -22,9 +25,8 @@ import { PageFooter } from "../PageFooter";
 import { PageHeader } from "../PageHeader";
 import "./EditIdentifier.scss";
 import { EditIdentifierProps } from "./EditIdentifier.types";
-import { showError } from "../../utils/error";
-import { IdentifierService } from "../../../core/agent/services";
-import { nameChecker } from "../../utils/nameChecker";
+
+const IDENTIFIER_NOT_EXIST = "Identifier not existed. id: ";
 
 const EditIdentifier = ({
   modalIsOpen,
@@ -84,13 +86,15 @@ const EditIdentifier = ({
   const handleSubmit = async () => {
     try {
       setLoading(true);
-      const updatedIdentifiers = [...identifiersData];
-      const index = updatedIdentifiers.findIndex(
-        (identifier) => identifier.id === cardData.id
-      );
+      const currentIdentifier = identifiersData[cardData.id];
+
+      if(!currentIdentifier) {
+        throw new Error(`${IDENTIFIER_NOT_EXIST} ${cardData.id}`)
+      }
+
       const theme = Number(`${newSelectedColor}${newSelectedTheme}`);
-      updatedIdentifiers[index] = {
-        ...updatedIdentifiers[index],
+      const updatedIdentifier = {
+        ...currentIdentifier,
         displayName: newDisplayName,
         theme,
       };
@@ -104,7 +108,7 @@ const EditIdentifier = ({
         theme,
       });
       handleCancel();
-      dispatch(setIdentifiersCache(updatedIdentifiers));
+      dispatch(updateOrAddIdentifiersCache(updatedIdentifier));
       dispatch(setToastMsg(ToastMsgType.IDENTIFIER_UPDATED));
     } catch (e) {
       if((e as Error).message.includes(IdentifierService.IDENTIFIER_NAME_TAKEN)) {

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
@@ -597,8 +597,8 @@ describe("Group Identifier details page", () => {
       bran: "bran",
     },
     identifiersCache: {
-      identifiers: [
-        {
+      identifiers: {
+        "EJexLqpflqJr3HQhMNECkgFL_D5Z3xAMbSmlHyPhqYut" : {
           displayName: "GG",
           id: "EJexLqpflqJr3HQhMNECkgFL_D5Z3xAMbSmlHyPhqYut",
           createdAtUTC: "2024-10-14T13:11:52.963Z",
@@ -606,7 +606,7 @@ describe("Group Identifier details page", () => {
           isPending: false,
           multisigManageAid: "ELUXM-ajSu0o1qyFvss-3QQfkj3DOke9aHNwt72Byi9x",
         },
-      ],
+      },
       favourites: [],
     },
     connectionsCache: {
@@ -670,8 +670,8 @@ describe("Group Identifier details page", () => {
         bran: "bran",
       },
       identifiersCache: {
-        identifiers: [
-          {
+        identifiers: {
+          "EJexLqpflqJr3HQhMNECkgFL_D5Z3xAMbSmlHyPhqYut" : {
             displayName: "GG",
             id: "EJexLqpflqJr3HQhMNECkgFL_D5Z3xAMbSmlHyPhqYut",
             createdAtUTC: "2024-10-14T13:11:52.963Z",
@@ -679,7 +679,7 @@ describe("Group Identifier details page", () => {
             isPending: false,
             multisigManageAid: "ELUXM-ajSu0o1qyFvss-3QQfkj3DOke9aHNwt72Byi9x",
           },
-        ],
+        },
         favourites: [],
       },
       connectionsCache: {
@@ -1038,7 +1038,9 @@ describe("Group Identifier details page", () => {
         bran: "bran",
       },
       identifiersCache: {
-        identifiers: [filteredIdentifierFix[2]],
+        identifiers: {
+          [filteredIdentifierFix[2].id]: filteredIdentifierFix[2]
+        },
         favourites: [],
       },
       connectionsCache: {

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
@@ -21,9 +21,8 @@ import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
   addFavouriteIdentifierCache,
   getFavouritesIdentifiersCache,
-  getIdentifiersCache,
   removeFavouriteIdentifierCache,
-  setIdentifiersCache,
+  removeIdentifierCache
 } from "../../../store/reducers/identifiersCache";
 import {
   getStateCache,
@@ -55,7 +54,6 @@ const IdentifierDetailModule = ({ identifierDetailId, onClose: handleDone, navAn
   const history = useHistory();
   const dispatch = useAppDispatch();
   const stateCache = useAppSelector(getStateCache);
-  const identifierData = useAppSelector(getIdentifiersCache);
   const favouritesIdentifiersData = useAppSelector(
     getFavouritesIdentifiersCache
   );
@@ -127,13 +125,9 @@ const IdentifierDetailModule = ({ identifierDetailId, onClose: handleDone, navAn
           ? identifierDetailId
           : undefined;
 
-      const updatedIdentifiers = identifierData.filter(
-        (item) => item.id !== filterId
-      );
-
       await deleteIdentifier();
       dispatch(setToastMsg(ToastMsgType.IDENTIFIER_DELETED));
-      dispatch(setIdentifiersCache(updatedIdentifiers));
+      dispatch(removeIdentifierCache(filterId || ""));
     } catch (e) {
       showError(
         "Unable to delete identifier",

--- a/src/ui/components/IdentifierDetailModule/components/IdentifierContent.tsx
+++ b/src/ui/components/IdentifierDetailModule/components/IdentifierContent.tsx
@@ -19,9 +19,9 @@ import {
 import { CardDetailsItem } from "../../../components/CardDetails/CardDetailsItem";
 import { ListHeader } from "../../../components/ListHeader";
 import { formatShortDate, formatTimeToSec } from "../../../utils/formatters";
-import { IdentifierContentProps } from "./IdentifierContent.types";
-import { DetailView } from "./IdentifierAttributeDetailModal/IdentifierAttributeDetailModal.types";
 import { IdentifierAttributeDetailModal } from "./IdentifierAttributeDetailModal/IdentifierAttributeDetailModal";
+import { DetailView } from "./IdentifierAttributeDetailModal/IdentifierAttributeDetailModal.types";
+import { IdentifierContentProps } from "./IdentifierContent.types";
 
 const DISPLAY_MEMBERS = 3;
 
@@ -42,7 +42,7 @@ const IdentifierContent = ({
   }, []);
 
   const isMultiSig = useMemo(() => {
-    const identifier = identifiersData.find((data) => data.id === cardData.id);
+    const identifier = identifiersData[cardData.id];
 
     return (
       cardData.multisigManageAid || (identifier && identifier.multisigManageAid)

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.test.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.test.tsx
@@ -5,7 +5,7 @@ import { act } from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import EN_TRANSLATIONS from "../../../locales/en/en.json";
-import { filteredIdentifierFix } from "../../__fixtures__/filteredIdentifierFix";
+import { filteredIdentifierMapFix } from "../../__fixtures__/filteredIdentifierFix";
 import { identifierFix } from "../../__fixtures__/identifierFix";
 import { TabsRoutePath } from "../navigation/TabsMenu";
 import { IdentifierOptions } from "./IdentifierOptions";
@@ -48,7 +48,7 @@ describe("Identifier Options modal", () => {
         },
       },
       identifiersCache: {
-        identifiers: filteredIdentifierFix,
+        identifiers: filteredIdentifierMapFix,
       },
     };
     mockedStore = {
@@ -128,7 +128,7 @@ describe("Identifier Options function test", () => {
         },
       },
       identifiersCache: {
-        identifiers: filteredIdentifierFix,
+        identifiers: filteredIdentifierMapFix,
       },
     };
     mockedStore = {

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
@@ -29,7 +29,7 @@ const IdentifierOptions = ({
   const [shareIsOpen, setShareIsOpen] = useState(false);
 
   useEffect(() => {
-    const identifier = identifiersData.find((data) => data.id === cardData.id);
+    const identifier = identifiersData[cardData.id];
     if (identifier && identifier.multisigManageAid) {
       setIsMultiSig(true);
     }

--- a/src/ui/components/Scanner/Scanner.test.tsx
+++ b/src/ui/components/Scanner/Scanner.test.tsx
@@ -151,7 +151,7 @@ describe("Scanner", () => {
       toastMsgs: [],
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
       favourites: [],
       multiSigGroup: {
         groupId: "",
@@ -344,7 +344,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         scanGroupId: "mock",
       },
       connectionsCache: {
@@ -423,7 +423,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         scanGroupId: "72e2f089cef6",
         multiSigGroup: {
           connections: [connectionsFix[0]],
@@ -480,7 +480,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         scanGroupId: "72e2f089cef6",
       },
       connectionsCache: {
@@ -568,7 +568,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -607,7 +607,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -684,7 +684,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -761,7 +761,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -832,7 +832,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -903,7 +903,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -983,7 +983,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -1061,7 +1061,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},
@@ -1127,7 +1127,7 @@ describe("Scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       connectionsCache: {
         connections: {},

--- a/src/ui/components/VerifyPasscode/VerifyPasscode.test.tsx
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.test.tsx
@@ -60,7 +60,7 @@ const initialStateNoPassword = {
     notificationDetailCache: null,
   },
   identifiersCache: {
-    identifiers: [],
+    identifiers: {},
   },
 };
 

--- a/src/ui/pages/Connections/Connections.test.tsx
+++ b/src/ui/pages/Connections/Connections.test.tsx
@@ -209,7 +209,7 @@ describe("Connections page", () => {
         connections: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
     };
     const mockStore = configureStore();
@@ -309,7 +309,7 @@ describe("Connections page", () => {
       },
       seedPhraseCache: {},
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       viewTypeCache: {
         identifier: {
@@ -379,7 +379,7 @@ describe("Connections page", () => {
       },
       seedPhraseCache: {},
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       viewTypeCache: {
         identifier: {
@@ -478,7 +478,7 @@ describe("Connections page from Credentials tab", () => {
       },
       seedPhraseCache: {},
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       credsCache: {
         creds: [],

--- a/src/ui/pages/Connections/Connections.tsx
+++ b/src/ui/pages/Connections/Connections.tsx
@@ -64,7 +64,7 @@ const Connections = forwardRef<ConnectionsOptionRef, ConnectionsComponentProps>(
     const [connectionShortDetails, setConnectionShortDetails] = useState<
       ConnectionShortDetails | undefined
     >(undefined);
-    const availableIdentifiers = identifierCache
+    const availableIdentifiers = Object.values(identifierCache)
       .filter((item) => !item.isPending)
       .filter((item) => !item.groupMetadata?.groupId);
     const [mappedConnections, setMappedConnections] = useState<

--- a/src/ui/pages/Connections/components/IdentifierSelectorModal/IdentifierSelectorModal.tsx
+++ b/src/ui/pages/Connections/components/IdentifierSelectorModal/IdentifierSelectorModal.tsx
@@ -22,7 +22,7 @@ const IdentifierSelectorModal = ({
   const [selectedIdentifier, setSelectedIdentifier] =
     useState<IdentifierShortDetails | null>(null);
 
-  const displayIdentifiers = identifierCache
+  const displayIdentifiers = Object.values(identifierCache)
     .filter((item) => !item.isPending)
     .filter((item) => !item.groupMetadata?.groupId)
     .map(

--- a/src/ui/pages/CredentialDetails/CredentialDetails.test.tsx
+++ b/src/ui/pages/CredentialDetails/CredentialDetails.test.tsx
@@ -92,7 +92,7 @@ const initialStateNoPasswordCurrent = {
     notificationDetailCache: null,
   },
   identifiersCache: {
-    identifiers: [],
+    identifiers: {},
   },
 };
 
@@ -122,7 +122,7 @@ const initialStateNoPasswordArchived = {
     notificationDetailCache: null,
   },
   identifiersCache: {
-    identifiers: [],
+    identifiers: {},
   },
 };
 
@@ -188,7 +188,7 @@ describe("Cred Details page - current not archived credential", () => {
         notificationDetailCache: null,
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
     };
 

--- a/src/ui/pages/FullPageScanner/FullPageScanner.test.tsx
+++ b/src/ui/pages/FullPageScanner/FullPageScanner.test.tsx
@@ -143,7 +143,7 @@ describe("Full page scanner", () => {
       toastMsgs: [],
     },
     identifiersCache: {
-      identifiers: [],
+      identifiers: {},
       favourites: [],
       multiSigGroup: {
         groupId: "",
@@ -198,7 +198,7 @@ describe("Full page scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",
@@ -254,7 +254,7 @@ describe("Full page scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",
@@ -339,7 +339,7 @@ describe("Full page scanner", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",

--- a/src/ui/pages/Identifiers/Identifiers.test.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.test.tsx
@@ -521,7 +521,7 @@ describe("Identifiers Tab", () => {
       },
       seedPhraseCache: {},
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       viewTypeCache: {
         identifier: {

--- a/src/ui/pages/Identifiers/Identifiers.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.tsx
@@ -15,9 +15,9 @@ import {
   getIdentifiersFilters,
   getMultiSigGroupCache,
   getOpenMultiSig,
-  setIdentifiersCache,
+  removeIdentifierCache,
   setIdentifiersFilters,
-  setOpenMultiSigId,
+  setOpenMultiSigId
 } from "../../../store/reducers/identifiersCache";
 import {
   getCurrentOperation,
@@ -87,7 +87,7 @@ const AdditionalButtons = ({
 const Identifiers = () => {
   const pageId = "identifiers-tab";
   const dispatch = useAppDispatch();
-  const identifiersData = useAppSelector(getIdentifiersCache);
+  const identifiersDataCache = useAppSelector(getIdentifiersCache);
   const multisigGroupCache = useAppSelector(getMultiSigGroupCache);
   const favouriteIdentifiers = useAppSelector(getFavouritesIdentifiersCache);
   const currentOperation = useAppSelector(getCurrentOperation);
@@ -126,6 +126,8 @@ const Identifiers = () => {
   const [openDeletePendingAlert, setOpenDeletePendingAlert] = useState(false);
   const favouriteContainerElement = useRef<HTMLDivElement>(null);
   const selectedFilter = identifiersFiltersCache ?? IdentifiersFilters.All;
+
+  const identifiersData = useMemo(() => Object.values(identifiersDataCache), [identifiersDataCache])
 
   useIonViewWillEnter(() => {
     dispatch(setCurrentRoute({ path: TabsRoutePath.IDENTIFIERS }));
@@ -251,14 +253,10 @@ const Identifiers = () => {
     setDeletePendingItem(null);
 
     try {
-      const updatedIdentifiers = identifiersData.filter(
-        (item) => item.id !== deletedPendingItem.id
-      );
-
       await Agent.agent.identifiers.markIdentifierPendingDelete(deletedPendingItem.id);
 
       dispatch(setToastMsg(ToastMsgType.IDENTIFIER_DELETED));
-      dispatch(setIdentifiersCache(updatedIdentifiers));
+      dispatch(removeIdentifierCache(deletedPendingItem.id));
     } catch (e) {
       showError(
         "Unable to delete identifier",

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -283,7 +283,7 @@ describe("Wallet connect: empty history", () => {
         walletConnections: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       biometricsCache: {
         enabled: false,
@@ -356,8 +356,8 @@ describe("Wallet connect: empty history", () => {
         walletConnections: [],
       },
       identifiersCache: {
-        identifiers: [
-          {
+        identifiers: {
+          "EFn1HAaIyISfu_pwLA8DFgeKxr0pLzBccb4eXHSPVQ6L" : {
             displayName: "ms",
             id: "EFn1HAaIyISfu_pwLA8DFgeKxr0pLzBccb4eXHSPVQ6L",
             createdAtUTC: "2024-07-25T13:33:20.323Z",
@@ -365,7 +365,7 @@ describe("Wallet connect: empty history", () => {
             isPending: false,
             multisigManageAid: "EBze49sDYvxxtq5eFbX2TKbK7g4SPS7DJVdoTRIyybxN",
           },
-          {
+          "EFn1HAaIyISfu_pwLA8DFgeKxr0pLzBccb4eXHSPVQ61": {
             displayName: "ms",
             id: "EFn1HAaIyISfu_pwLA8DFgeKxr0pLzBccb4eXHSPVQ6L",
             createdAtUTC: "2024-07-25T13:33:20.323Z",
@@ -373,7 +373,7 @@ describe("Wallet connect: empty history", () => {
             isPending: false,
             groupMetadata: {},
           },
-        ],
+        },
       },
       biometricsCache: {
         enabled: false,
@@ -716,7 +716,7 @@ describe("Wallet connect", () => {
         connectedWallet: null,
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
       biometricsCache: {
         enabled: false,
@@ -790,8 +790,8 @@ describe("Wallet connect", () => {
         pendingConnection: walletConnectionsFix[0],
       },
       identifiersCache: {
-        identifiers: [
-          {
+        identifiers: {
+          "EN5dwY0N7RKn6OcVrK7ksIniSgPcItCuBRax2JFUpuRd" : {
             id: "EN5dwY0N7RKn6OcVrK7ksIniSgPcItCuBRax2JFUpuRd",
             displayName: "Professional ID",
             createdAtUTC: "2023-01-01T19:23:24Z",
@@ -813,7 +813,7 @@ describe("Wallet connect", () => {
             b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"], // List of backers
             di: "test", // Delegated identifier prefix, don't show if ""
           },
-        ],
+        },
       },
       biometricsCache: {
         enabled: false,
@@ -859,8 +859,8 @@ describe("Wallet connect", () => {
         pendingConnection: null,
       },
       identifiersCache: {
-        identifiers: [
-          {
+        identifiers: {
+          "EN5dwY0N7RKn6OcVrK7ksIniSgPcItCuBRax2JFUpuRd" : {
             id: "EN5dwY0N7RKn6OcVrK7ksIniSgPcItCuBRax2JFUpuRd",
             displayName: "Professional ID",
             createdAtUTC: "2023-01-01T19:23:24Z",
@@ -882,7 +882,7 @@ describe("Wallet connect", () => {
             b: ["BIe_q0F4EkYPEne6jUnSV1exxOYeGf_AMSMvegpF4XQP"], // List of backers
             di: "test", // Delegated identifier prefix, don't show if ""
           },
-        ],
+        },
       },
       biometricsCache: {
         enabled: false,

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.tsx
@@ -48,7 +48,7 @@ const ConnectWallet = forwardRef<ConnectWalletOptionRef, object>(
     const dispatch = useAppDispatch();
     const toastMsgs = useAppSelector(getToastMsgs);
     const pendingConnection = useAppSelector(getPendingConnection);
-    const defaultIdentifierCache = useAppSelector(getIdentifiersCache).filter(
+    const defaultIdentifierCache = Object.values(useAppSelector(getIdentifiersCache)).filter(
       (identifier) => !identifier.multisigManageAid && !identifier.groupMetadata
     );
     const connections = useAppSelector(getWalletConnectionsCache);

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.test.tsx
@@ -255,7 +255,7 @@ describe("Credential request - choose request", () => {
         ],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
     };
 

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
@@ -180,11 +180,13 @@ describe("Credential request: Multisig", () => {
       notifications: notificationsFix,
     },
     identifiersCache: {
-      identifiers: [{
-        ...multisignIdentifierFix[0],
-        multisigManageAid: "member-1",
-        id: "id"
-      }],
+      identifiers: {
+        "id": {
+          ...multisignIdentifierFix[0],
+          multisigManageAid: "member-1",
+          id: "id"
+        }
+      },
       favourites: [],
     },
     connectionsCache: {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
@@ -1,21 +1,21 @@
 import { IonSpinner } from "@ionic/react";
 import { useCallback, useMemo, useState } from "react";
 import { Agent } from "../../../../../core/agent/agent";
+import { IdentifierType } from "../../../../../core/agent/services/identifier.types";
 import { CredentialsMatchingApply } from "../../../../../core/agent/services/ipexCommunicationService.types";
 import { i18n } from "../../../../../i18n";
+import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
+import { getMultisigConnectionsCache } from "../../../../../store/reducers/connectionsCache";
+import { getIdentifiersCache } from "../../../../../store/reducers/identifiersCache";
+import { getAuthentication } from "../../../../../store/reducers/stateCache";
 import { Alert } from "../../../../components/Alert";
 import { useOnlineStatusEffect } from "../../../../hooks";
+import { showError } from "../../../../utils/error";
 import { NotificationDetailsProps } from "../../NotificationDetails.types";
 import { ChooseCredential } from "./ChooseCredential";
 import "./CredentialRequest.scss";
-import { CredentialRequestInformation } from "./CredentialRequestInformation";
-import { showError } from "../../../../utils/error";
-import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
-import { getIdentifiersCache } from "../../../../../store/reducers/identifiersCache";
-import { IdentifierType } from "../../../../../core/agent/services/identifier.types";
 import { LinkedGroup } from "./CredentialRequest.types";
-import { getMultisigConnectionsCache } from "../../../../../store/reducers/connectionsCache";
-import { getAuthentication } from "../../../../../store/reducers/stateCache";
+import { CredentialRequestInformation } from "./CredentialRequestInformation";
 
 const CredentialRequest = ({
   pageId,
@@ -24,13 +24,12 @@ const CredentialRequest = ({
   handleBack,
 }: NotificationDetailsProps) => {
   const dispatch = useAppDispatch();
-  const identifiers = useAppSelector(getIdentifiersCache);
+  const identifiersData = useAppSelector(getIdentifiersCache);
   const multisignConnectionsCache = useAppSelector(getMultisigConnectionsCache);
   const userName = useAppSelector(getAuthentication)?.userName;
   const [requestStage, setRequestStage] = useState(0);
   const [credentialRequest, setCredentialRequest] =
     useState<CredentialsMatchingApply | null>();
-  const identifiersData = useAppSelector(getIdentifiersCache);
 
   const [linkedGroup, setLinkedGroup] = useState<LinkedGroup | null>(null);
   const [isOpenAlert, setIsOpenAlert] = useState(false);
@@ -42,10 +41,10 @@ const CredentialRequest = ({
   const userAID = useMemo(() => {
     if(!credentialRequest) return null;
 
-    const identifier = identifiers.find(item => item.id === credentialRequest.identifier);
+    const identifier = identifiersData[credentialRequest.identifier];
     
     return identifier ? identifier.multisigManageAid : null;
-  }, [credentialRequest, identifiers]);
+  }, [credentialRequest, identifiersData]);
 
   const getMultisigInfo = useCallback(async () => {
     const linkedGroup =
@@ -82,9 +81,7 @@ const CredentialRequest = ({
         notificationDetails
       );
 
-      const identifier = identifiersData.find(
-        (identifier) => identifier.id === request.identifier
-      );
+      const identifier = identifiersData[request.identifier];
 
       const identifierType =
         identifier?.multisigManageAid || identifier?.groupMetadata

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.tsx
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.tsx
@@ -36,7 +36,7 @@ const ErrorPage = ({
     const multiSignGroupId =
       connectionsCache[notificationDetails.connectionId].groupId;
 
-    const identifier = identifierCache.find(
+    const identifier = Object.values(identifierCache).find(
       (item) => item.groupMetadata?.groupId === multiSignGroupId
     );
 

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/MultiSigRequest.tsx
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/MultiSigRequest.tsx
@@ -126,7 +126,7 @@ const MultiSigRequest = ({
           isPending: !!isPending,
           multisigManageAid,
         };
-        const filteredIdentifiersData = identifiersData.filter(
+        const filteredIdentifiersData = Object.values(identifiersData).filter(
           (item) => item.id !== multisigIcpDetails?.ourIdentifier.id
         );
         dispatch(

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.test.tsx
@@ -10,7 +10,7 @@ import { TabsRoutePath } from "../../../../../routes/paths";
 import { showGenericError } from "../../../../../store/reducers/stateCache";
 import { connectionsForNotifications } from "../../../../__fixtures__/connectionsFix";
 import { credsFixAcdc } from "../../../../__fixtures__/credsFix";
-import { filteredIdentifierFix } from "../../../../__fixtures__/filteredIdentifierFix";
+import { filteredIdentifierMapFix, filteredIdentifierFix } from "../../../../__fixtures__/filteredIdentifierFix";
 import { identifierFix } from "../../../../__fixtures__/identifierFix";
 import { notificationsFix } from "../../../../__fixtures__/notificationsFix";
 import { passcodeFillerWithAct } from "../../../../utils/passcodeFiller";
@@ -98,7 +98,7 @@ const initialState = {
     notifications: notificationsFix,
   },
   identifiersCache: {
-    identifiers: filteredIdentifierFix,
+    identifiers: filteredIdentifierMapFix,
   },
 };
 
@@ -265,7 +265,7 @@ describe("Receive credential", () => {
         notifications: notificationsFix,
       },
       identifiersCache: {
-        identifiers: filteredIdentifierFix,
+        identifiers: filteredIdentifierMapFix,
       },
     };
 
@@ -318,7 +318,7 @@ describe("Receive credential", () => {
         notifications: notificationsFix,
       },
       identifiersCache: {
-        identifiers: filteredIdentifierFix,
+        identifiers: filteredIdentifierMapFix,
       },
     };
 
@@ -433,7 +433,7 @@ describe("Credential request: Multisig", () => {
       notifications: notificationsFix,
     },
     identifiersCache: {
-      identifiers: filteredIdentifierFix,
+      identifiers: filteredIdentifierMapFix,
     },
   };
 

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -13,6 +13,7 @@ import {
   ACDCDetails
 } from "../../../../../core/agent/services/credentialService.types";
 import { IdentifierType } from "../../../../../core/agent/services/identifier.types";
+import { LinkedGroupInfo } from "../../../../../core/agent/services/ipexCommunicationService.types";
 import { i18n } from "../../../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
 import {
@@ -34,6 +35,7 @@ import {
   MemberAcceptStatus,
   MultisigMember,
 } from "../../../../components/CredentialDetailModule/components";
+import { IdentifierDetailModal } from "../../../../components/IdentifierDetailModule";
 import { InfoCard } from "../../../../components/InfoCard";
 import { ScrollablePageLayout } from "../../../../components/layout/ScrollablePageLayout";
 import { PageFooter } from "../../../../components/PageFooter";
@@ -49,8 +51,6 @@ import { showError } from "../../../../utils/error";
 import { combineClassNames } from "../../../../utils/style";
 import { NotificationDetailsProps } from "../../NotificationDetails.types";
 import "./ReceiveCredential.scss";
-import { IdentifierDetailModal } from "../../../../components/IdentifierDetailModule";
-import { LinkedGroupInfo } from "../../../../../core/agent/services/ipexCommunicationService.types";
 
 const ANIMATION_DELAY = 2600;
 
@@ -100,7 +100,7 @@ const ReceiveCredential = ({
       Number(multisigMemberStatus.threshold);
 
   const identifier = useMemo(() => {
-    return identifiersData.find(item => item.id === credDetail?.identifierId)
+    return identifiersData[credDetail?.identifierId || ""]
   }, [credDetail?.identifierId, identifiersData]);
 
   const groupInitiatorAid = multisigMemberStatus.members[0] || "";
@@ -144,9 +144,7 @@ const ReceiveCredential = ({
           notificationDetails.a.d as string
         );
 
-      const identifier = identifiersData.find(
-        (identifier) => identifier.id === credential.identifierId
-      );
+      const identifier = identifiersData[credential.identifierId];
 
       // @TODO: identifierType is not needed to render the component so this could be optimised. If it's needed, it should be fetched in the core for simplicity.
       const identifierType =

--- a/src/ui/pages/Notifications/NotificationItem.tsx
+++ b/src/ui/pages/Notifications/NotificationItem.tsx
@@ -38,10 +38,19 @@ const NotificationItem = ({
       return t("tabs.notifications.tab.labels.multisigicp", {
         connection: multisigConnectionsCache?.[item.connectionId]?.label || t("connections.unknown"),
       });
-    case NotificationRoute.ExnIpexApply:
+    case NotificationRoute.ExnIpexApply: {
+      if(item.groupReplied && !item.groupInitiator) {
+        const initiator = item.initiatorAid ? multisigConnectionsCache[item.initiatorAid].label :  t("connections.unknown");
+        return t("tabs.notifications.tab.labels.exnipexapplyproposed", {
+          connection: connectionsCache?.[item.connectionId]?.label || t("connections.unknown"),
+          initiator
+        });
+      }
+
       return t("tabs.notifications.tab.labels.exnipexapply", {
         connection: connectionsCache?.[item.connectionId]?.label || t("connections.unknown"),
       });
+    }
     case NotificationRoute.LocalAcdcRevoked:
       return t("tabs.notifications.tab.labels.exnipexgrantrevoke", {
         credential: item.a.credentialTitle,
@@ -53,7 +62,7 @@ const NotificationItem = ({
     default:
       return "";
     }
-  }, [connectionsCache, item.a.credentialTitle, item.a.r, item.connectionId, multisigConnectionsCache])
+  }, [connectionsCache, item.a.credentialTitle, item.a.r, item.connectionId, item.groupInitiator, item.groupReplied, item.initiatorAid, multisigConnectionsCache])
 
   const referIcon = (item: KeriaNotification) => {
     switch (item.a.r) {

--- a/src/ui/pages/Notifications/NotificationItem.tsx
+++ b/src/ui/pages/Notifications/NotificationItem.tsx
@@ -39,7 +39,7 @@ const NotificationItem = ({
         connection: multisigConnectionsCache?.[item.connectionId]?.label || t("connections.unknown"),
       });
     case NotificationRoute.ExnIpexApply: {
-      if(item.groupReplied && !item.groupInitiator) {
+      if(item.groupReplied && !item.groupInitiator && item.initiatorAid) {
         const initiator = item.initiatorAid ? multisigConnectionsCache[item.initiatorAid].label :  t("connections.unknown");
         return t("tabs.notifications.tab.labels.exnipexapplyproposed", {
           connection: connectionsCache?.[item.connectionId]?.label || t("connections.unknown"),

--- a/src/ui/pages/Scan/Scan.test.tsx
+++ b/src/ui/pages/Scan/Scan.test.tsx
@@ -142,7 +142,7 @@ describe("Scan Tab", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         scanGroupId: "72e2f089cef6",
       },
       connectionsCache: {
@@ -190,7 +190,7 @@ describe("Scan Tab", () => {
         toastMsgs: [],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
         favourites: [],
         multiSigGroup: {
           groupId: "",

--- a/src/ui/pages/WalletConnect/WalletConnect.test.tsx
+++ b/src/ui/pages/WalletConnect/WalletConnect.test.tsx
@@ -211,7 +211,7 @@ describe("Wallet Connect Stage One", () => {
         pendingConnection: walletConnectionsFix[0],
       },
       identifiersCache: {
-        identifiers: [],
+        identifiers: {},
       },
     };
 

--- a/src/ui/pages/WalletConnect/WalletConnectStageOne.tsx
+++ b/src/ui/pages/WalletConnect/WalletConnectStageOne.tsx
@@ -23,7 +23,7 @@ const WalletConnectStageOne = ({
 }: WalletConnectStageOneProps) => {
   const dispatch = useAppDispatch();
   const [openDeclineAlert, setOpenDeclineAlert] = useState(false);
-  const defaultIdentifierCache = useAppSelector(getIdentifiersCache).filter(
+  const defaultIdentifierCache = Object.values(useAppSelector(getIdentifiersCache)).filter(
     (identifier) => !identifier.multisigManageAid && !identifier.groupMetadata
   );
   const [createIdentifierModalIsOpen, setCreateIdentifierModalIsOpen] =

--- a/src/ui/pages/WalletConnect/WalletConnectStageTwo.tsx
+++ b/src/ui/pages/WalletConnect/WalletConnectStageTwo.tsx
@@ -31,7 +31,7 @@ const WalletConnectStageTwo = ({
   onClose,
 }: WalletConnectStageTwoProps) => {
   const dispatch = useDispatch();
-  const identifierCache = useAppSelector(getIdentifiersCache);
+  const identifierCache = Object.values(useAppSelector(getIdentifiersCache));
   const existingConnections = useAppSelector(getWalletConnectionsCache);
 
   const [selectedIdentifier, setSelectedIdentifier] =


### PR DESCRIPTION
## Description

Refresh notification after group initiator has proposed a cred.

Credential request notification be marked unread and the count increased by +1 once the initiator has proposed a credential to the group.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1601](https://cardanofoundation.atlassian.net/browse/DTIS-1601)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Refresh notification when group initiator proposed a cred

https://github.com/user-attachments/assets/6682c42a-0506-4de4-9610-e6bf68fab1b0



[DTIS-1601]: https://cardanofoundation.atlassian.net/browse/DTIS-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ