### PR TITLE
feat(core): marking notification as read when deleting distributed reliability

### DIFF
--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -347,6 +347,7 @@ describe("Receive individual ACDC actions", () => {
           JSON.stringify(connectionNote),
       })
     );
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
 
     await ipexCommunicationService.admitAcdcFromGrant(id);
 
@@ -1078,6 +1079,7 @@ describe("Offer ACDC individual actions", () => {
       id: "opName",
       recordType: OperationPendingRecordType.ExchangeOfferCredential,
     });
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
 
     await ipexCommunicationService.offerAcdcFromApply(id, grantForIssuanceExnMessage.exn.e.acdc);
 
@@ -1542,6 +1544,7 @@ describe("Grant ACDC individual actions", () => {
       recordType: OperationPendingRecordType.ExchangePresentCredential,
     });
     ipexGrantMock.mockResolvedValue(["grant", "sigs", "gend"]);
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
 
     await ipexCommunicationService.grantAcdcFromAgree("agree-note-id");
 

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -407,6 +407,8 @@ describe("Signify notification service of agent", () => {
 
   test("should call delete keri notification when trigger deleteNotificationRecordById", async () => {
     const id = "uuid";
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
+
     await keriaNotificationService.deleteNotificationRecordById(
       id,
       NotificationRoute.ExnIpexAgree
@@ -421,6 +423,8 @@ describe("Signify notification service of agent", () => {
     const notificationStorage = new NotificationStorage(
       agentServicesProps.signifyClient
     );
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
+
     notificationStorage.deleteById = jest.fn();
     await deleteNotificationRecordById(
       agentServicesProps.signifyClient,
@@ -721,6 +725,7 @@ describe("Signify notification service of agent", () => {
       updatedAt: new Date(),
     };
     notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([notification]);
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
 
     await keriaNotificationService.processNotification(
       notificationIpexGrantProp
@@ -793,6 +798,7 @@ describe("Signify notification service of agent", () => {
       .mockResolvedValue({
         id: "id",
       });
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
 
     await keriaNotificationService.processNotification(
       notificationIpexGrantProp
@@ -2506,6 +2512,7 @@ describe("Long running operation tracker", () => {
         updatedAt: new Date(),
       },
     ]);
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
 
     await keriaNotificationService.processOperation(operationRecord);
 
@@ -2693,6 +2700,7 @@ describe("Long running operation tracker", () => {
         updatedAt: new Date(),
       },
     ]);
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
 
     await keriaNotificationService.processOperation(operationRecord);
 

--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -582,7 +582,7 @@ describe("Creation of multi-sig", () => {
       id: `group.${multisigIdentifier}`,
       recordType: OperationPendingRecordType.Group,
     });
-
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
     expect(
       await multiSigService.joinMultisig(
         "id",
@@ -647,6 +647,9 @@ describe("Creation of multi-sig", () => {
         groupCreated: true,
       },
     });
+
+    markNotificationMock.mockResolvedValueOnce({status: "done"});
+
     await multiSigService.joinMultisig(
       "id",
       NotificationRoute.MultiSigIcp,

--- a/src/core/agent/services/utils.ts
+++ b/src/core/agent/services/utils.ts
@@ -74,7 +74,13 @@ export const deleteNotificationRecordById = async (
   route: NotificationRoute
 ): Promise<void> => {
   if (!/^\/local/.test(route)) {
-    await client.notifications().mark(id);
+    await client.notifications().mark(id)
+      .catch((error) => {
+        const status = error.message.split(" - ")[1];
+        if (!/404/gi.test(status)) {
+          throw error;
+        }
+      });
   }
   await notificationStorage.deleteById(id);
 };


### PR DESCRIPTION
## Description

We mark notifications as read once we have deleted them, or we are done processing them if they are not user facing.

A notification can only be marked once, or it will return 404.

It’s possible that we mark it as read, and crash before deleting the notification in the local database of the wallet.

When we try to delete again, we will hit this 404 error.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [1597](https://cardanofoundation.atlassian.net/browse/DTIS-1597)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated