### PR TITLE
fix(core): credential presentation filter after recent cred tag changes

### DIFF
--- a/src/core/__fixtures__/agent/keriaNotificationFixtures.ts
+++ b/src/core/__fixtures__/agent/keriaNotificationFixtures.ts
@@ -5,7 +5,7 @@ const credentialMetadataMock = {
   type: "CredentialMetadataRecord",
   id: "EJuFvMGiT3uhEXtd7UQlkAm4N_MymeHfhkgnOgPhK0cJ",
   isArchived: false,
-  isDeleted: false,
+  pendingDeletion: false,
   createdAt: "2024-08-09T04:21:18.311Z",
   issuanceDate: "2024-08-09T04:21:12.575Z",
   credentialType: "Qualified vLEI Issuer Credential",

--- a/src/core/agent/services/credentialService.test.ts
+++ b/src/core/agent/services/credentialService.test.ts
@@ -309,7 +309,7 @@ describe("Credential service of agent", () => {
       status: CredentialStatus.CONFIRMED,
       credentialType,
       issuanceDate: nowISO,
-      isDeleted: false,
+      pendingDeletion: false,
       connectionId: undefined,
       schema: "EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao",
       identifierType: IdentifierType.Individual,

--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -1925,7 +1925,7 @@ describe("IPEX communication service of agent", () => {
         status: "confirmed",
         connectionId: "connectionId",
         isArchived: false,
-        isDeleted: false,
+        pendingDeletion: false,
       },
     ]);
     credentialListMock.mockResolvedValue([

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -354,29 +354,25 @@ class IpexCommunicationService extends AgentService {
   async getIpexApplyDetails(
     notification: KeriaNotification
   ): Promise<CredentialsMatchingApply> {
-    const msgSaid = notification.a.d as string;
-    const msg = await this.props.signifyClient.exchanges().get(msgSaid);
-    const schemaSaid = msg.exn.a.s;
-    const attributes = msg.exn.a.a;
-    const recipient = msg.exn.rp;
-    const schemaKeri = await this.props.signifyClient
+    const exchange = await this.props.signifyClient.exchanges().get(notification.a.d as string);
+    
+    const schemaSaid = exchange.exn.a.s;
+    const schema = await this.props.signifyClient
       .schemas()
       .get(schemaSaid)
       .catch((error) => {
         const status = error.message.split(" - ")[1];
         if (/404/gi.test(status)) {
-          return undefined;
+          throw new Error(IpexCommunicationService.SCHEMA_NOT_FOUND);
         } else {
           throw error;
         }
       });
-    if (!schemaKeri) {
-      throw new Error(IpexCommunicationService.SCHEMA_NOT_FOUND);
-    }
 
+    const attributes = exchange.exn.a.a;
     const filter = {
       "-s": { $eq: schemaSaid },
-      "-a-i": recipient,
+      "-a-i": exchange.exn.rp,
       ...(Object.keys(attributes).length > 0
         ? {
           ...Object.fromEntries(
@@ -389,31 +385,31 @@ class IpexCommunicationService extends AgentService {
         : {}),
     };
 
-    const creds = await this.props.signifyClient.credentials().list({
+    const filtered = await this.props.signifyClient.credentials().list({
       filter,
     });
-
-    const credentialMetadatas =
+    const localFiltered =
       await this.credentialStorage.getCredentialMetadatasById(
-        creds.map((cred: any) => cred.sad.d),
+        filtered.map((cred: any) => cred.sad.d),
         {
-          $and: [{ isDeleted: false }, { isArchived: false }],
+          $and: [{ pendingDeletion: false }, { isArchived: false }],
         }
       );
+    
     return {
       schema: {
-        name: schemaKeri.title,
-        description: schemaKeri.description,
+        name: schema.title,
+        description: schema.description,
       },
-      credentials: credentialMetadatas.map((cr) => {
-        const credKeri = creds.find((cred: any) => cred.sad.d === cr.id);
+      credentials: localFiltered.map((cr) => {
+        const credKeri = filtered.find((cred: any) => cred.sad.d === cr.id);
         return {
           connectionId: cr.connectionId,
           acdc: credKeri.sad,
         };
       }),
       attributes: attributes,
-      identifier: msg.exn.a.i,
+      identifier: exchange.exn.a.i,
     };
   }
 


### PR DESCRIPTION
`isDeleted` was replaced with `pendingDeletion` with recent changes for distributed reliability, but the tag was not updated when searching for non deleted credentials for presentations.