### PR TITLE
test(core): remove duplicate test

### DIFF
--- a/src/core/__fixtures__/agent/ipexCommunicationFixtures.ts
+++ b/src/core/__fixtures__/agent/ipexCommunicationFixtures.ts
@@ -169,7 +169,7 @@ const credentialMetadataRecord = {
   type: "CredentialMetadataRecord",
   id: "EJuFvMGiT3uhEXtd7UQlkAm4N_MymeHfhkgnOgPhK0cJ",
   isArchived: false,
-  isDeleted: false,
+  pendingDeletion: false,
   createdAt: "2024-08-09T04:21:18.311Z",
   issuanceDate: "2024-08-09T04:21:12.575Z",
   credentialType: "Qualified vLEI Issuer Credential",

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -626,7 +626,7 @@ describe("Signify notification service of agent", () => {
     expect(multiSigs.joinAuthorization).toBeCalledTimes(1);
   });
 
-  test("Should call createLinkedIpexMessageRecord with CREDENTIAL_REQUEST_PRESENT", async () => {
+  test("Can process incoming presentation requests and log in connection history", async () => {
     exchangesGetMock.mockResolvedValue(grantForIssuanceExnMessage);
     identifierStorage.getIdentifierMetadata.mockRejectedValueOnce(
       new Error(IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING)
@@ -639,49 +639,13 @@ describe("Signify notification service of agent", () => {
     await keriaNotificationService.processNotification(
       notificationIpexApplyProp
     );
+
     expect(
       ipexCommunications.createLinkedIpexMessageRecord
     ).toHaveBeenCalledWith(
       grantForIssuanceExnMessage,
       ConnectionHistoryType.CREDENTIAL_REQUEST_PRESENT
     );
-  });
-
-  test("Should call createLinkedIpexMessageRecord with CREDENTIAL_REVOKED", async () => {
-    exchangesGetMock.mockResolvedValue(grantForIssuanceExnMessage);
-    credentialStateMock.mockResolvedValueOnce({
-      ...credentialStateIssued,
-      et: "rev",
-    });
-    notificationStorage.save = jest
-      .fn()
-      .mockReturnValue({ id: "id", createdAt: new Date(), content: {} });
-    credentialStorage.getCredentialMetadata.mockResolvedValue(
-      credentialMetadataMock
-    );
-    admitMock.mockResolvedValue([{}, ["sigs"], "end"]);
-    getCredentialMock.mockResolvedValue(getCredentialResponse);
-    identifierStorage.getIdentifierMetadata = jest
-      .fn()
-      .mockRejectedValueOnce(
-        new Error(IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING)
-      )
-      .mockResolvedValue({
-        id: "id",
-      });
-    submitAdmitMock.mockResolvedValueOnce({
-      name: "name",
-      done: true,
-    });
-    notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
-    notificationStorage.findById = jest.fn().mockResolvedValueOnce({linkedRequest: {current: "current_id"}});
-
-    await keriaNotificationService.processNotification(
-      notificationIpexGrantProp
-    );
-
-    expect(markNotificationMock).toBeCalledTimes(1);
-    expect(ipexCommunications.createLinkedIpexMessageRecord).toBeCalledWith(grantForIssuanceExnMessage, ConnectionHistoryType.CREDENTIAL_REVOKED);
   });
 
   test("Should call createLinkedIpexMessageRecord with TEL status is revoked and exists locally", async () => {


### PR DESCRIPTION
Covered by "Should call createLinkedIpexMessageRecord with TEL status is revoked and exists locally"

This is for https://cardanofoundation.atlassian.net/browse/DTIS-1575 but with recent refactoring to only update connection history from long running operations for IPEX, all the expects were in place.