### PR TITLE
feat(core): sane KAWA thresholds

### DIFF
--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -244,6 +244,18 @@ const WITNESSES = [
   "http://witnesess:5645/oobi/BM35JN8XeJSEfpxopjn5jr7tAHCE5749f0OobhMLCorE/controller?role=witness",
   "http://witnesess:5646/oobi/BIj15u5V11bkbtAxMA7gcNJZcax-7TgaBMLsQnMHpYHP/controller?role=witness",
   "http://witnesess:5647/oobi/BF2rZTW79z4IXocYRQnjjsOuvFUQv-ptCf8Yltd7PfsM/controller?role=witness",
+  "http://witnesess:5648/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2HA/controller?role=witness",
+  "http://witnesess:5649/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapA/controller?role=witness",
+  "http://witnesess:5650/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfA/controller?role=witness",
+  "http://witnesess:5651/oobi/BM35JN8XeJSEfpxopjn5jr7tAHCE5749f0OobhMLCorA/controller?role=witness",
+  "http://witnesess:5652/oobi/BIj15u5V11bkbtAxMA7gcNJZcax-7TgaBMLsQnMHpYHA/controller?role=witness",
+  "http://witnesess:5653/oobi/BF2rZTW79z4IXocYRQnjjsOuvFUQv-ptCf8Yltd7PfsB/controller?role=witness",
+  "http://witnesess:5654/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2HB/controller?role=witness",
+  "http://witnesess:5655/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapB/controller?role=witness",
+  "http://witnesess:5656/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfB/controller?role=witness",
+  "http://witnesess:5657/oobi/BM35JN8XeJSEfpxopjn5jr7tAHCE5749f0OobhMLCorB/controller?role=witness",
+  "http://witnesess:5658/oobi/BIj15u5V11bkbtAxMA7gcNJZcax-7TgaBMLsQnMHpYHB/controller?role=witness",
+  "http://witnesess:5659/oobi/BF2rZTW79z4IXocYRQnjjsOuvFUQv-ptCf8Yltd7PfsB/controller?role=witness",
 ];
 const witnessEids = WITNESSES.map(
   (oobi: string) => oobi.split("/oobi/")[1].split("/")[0]
@@ -254,7 +266,7 @@ describe("Single sig service of agent", () => {
     jest.resetAllMocks();
 
     getAgentConfigMock.mockResolvedValue({
-      iurls: WITNESSES,
+      iurls: WITNESSES.slice(0, 6),
     });
   });
 
@@ -446,7 +458,7 @@ describe("Single sig service of agent", () => {
     }));
     expect(createIdentifierMock).toBeCalledWith("0:displayName", {
       toad: 4,
-      wits: witnessEids,
+      wits: witnessEids.slice(0, 6),
     });
     expect(identifierStorage.createIdentifierMetadataRecord).toBeCalledWith(expect.objectContaining({
       displayName,
@@ -521,7 +533,7 @@ describe("Single sig service of agent", () => {
     expect(basicStorage.createOrUpdateBasicRecord).not.toBeCalled();
     expect(createIdentifierMock).toBeCalledWith("0:displayName", {
       toad: 4,
-      wits: witnessEids,
+      wits: witnessEids.slice(0, 6),
     });
     expect(identifierStorage.createIdentifierMetadataRecord).toBeCalledWith(expect.objectContaining({
       displayName,
@@ -591,7 +603,7 @@ describe("Single sig service of agent", () => {
     expect(basicStorage.createOrUpdateBasicRecord).not.toBeCalled();
     expect(createIdentifierMock).toBeCalledWith("0:displayName", {
       toad: 4,
-      wits: witnessEids,
+      wits: witnessEids.slice(0, 6),
     });
     expect(identifierStorage.createIdentifierMetadataRecord).toBeCalledWith(expect.objectContaining({
       displayName,
@@ -661,7 +673,7 @@ describe("Single sig service of agent", () => {
     expect(basicStorage.createOrUpdateBasicRecord).not.toBeCalled();
     expect(createIdentifierMock).toBeCalledWith("0:displayName", {
       toad: 4,
-      wits: witnessEids,
+      wits: witnessEids.slice(0, 6),
     });
     expect(identifierStorage.createIdentifierMetadataRecord).not.toBeCalled();
     expect(eventEmitter.emit).not.toBeCalled();
@@ -707,7 +719,7 @@ describe("Single sig service of agent", () => {
     expect(basicStorage.createOrUpdateBasicRecord).not.toBeCalled();
     expect(createIdentifierMock).toBeCalledWith("0:displayName", {
       toad: 4,
-      wits: witnessEids,
+      wits: witnessEids.slice(0, 6),
     });
     expect(identifierStorage.createIdentifierMetadataRecord).toBeCalledWith(expect.objectContaining({
       displayName,
@@ -769,7 +781,7 @@ describe("Single sig service of agent", () => {
     expect(basicStorage.createOrUpdateBasicRecord).not.toBeCalled();
     expect(createIdentifierMock).toBeCalledWith("0:displayName", {
       toad: 4,
-      wits: witnessEids,
+      wits: witnessEids.slice(0, 6),
     });
     expect(identifierStorage.createIdentifierMetadataRecord).toBeCalledWith(expect.objectContaining({
       displayName,
@@ -1245,11 +1257,11 @@ describe("Single sig service of agent", () => {
     getAgentConfigMock.mockResolvedValueOnce({
       iurls: [
         "http://witnesess:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller",
-        ...WITNESSES
+        ...WITNESSES.slice(0, 6)
       ],
     });
 
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 4, witnesses: [...witnessEids] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 4, witnesses: [...witnessEids.slice(0, 6)] });
     expect(getAgentConfigMock).toBeCalled();
   });
 
@@ -1262,40 +1274,49 @@ describe("Single sig service of agent", () => {
     expect(getAgentConfigMock).toBeCalled();
   });
 
+  test("duplicate witnesses are ignored", async () => {
+    getAgentConfigMock.mockResolvedValueOnce({
+      iurls: [...WITNESSES.slice(0, 6), ...WITNESSES.slice(0, 6)] 
+    });
+
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 4, witnesses: [...witnessEids.slice(0, 6)] }); 
+    expect(getAgentConfigMock).toBeCalled();
+  });
+
   test("different witness list sizes", async () => {
     getAgentConfigMock.mockResolvedValueOnce({
-      iurls: [...WITNESSES, ...WITNESSES.slice(0, 1)],
+      iurls: WITNESSES.slice(0, 7),
     });
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 5, witnesses: [...witnessEids, ...witnessEids.slice(0, 1)] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 5, witnesses: [...witnessEids.slice(0, 7)] });
     
     getAgentConfigMock.mockResolvedValueOnce({
-      iurls: [...WITNESSES, ...WITNESSES.slice(0, 2)],
+      iurls: WITNESSES.slice(0, 8),
     });
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 5, witnesses: [...witnessEids, ...witnessEids.slice(0, 1)] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 5, witnesses: [...witnessEids.slice(0, 7)] });
 
     getAgentConfigMock.mockResolvedValueOnce({
-      iurls: [...WITNESSES, ...WITNESSES.slice(0, 3)],
+      iurls: WITNESSES.slice(0, 9),
     });
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 6, witnesses: [...witnessEids, ...witnessEids.slice(0, 3)] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 6, witnesses: [...witnessEids.slice(0, 9)] });
 
     getAgentConfigMock.mockResolvedValueOnce({
-      iurls: [...WITNESSES, ...WITNESSES.slice(0, 4)],
+      iurls: WITNESSES.slice(0, 10),
     });
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 7, witnesses: [...witnessEids, ...witnessEids.slice(0, 4)] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 7, witnesses: [...witnessEids.slice(0, 10)] });
 
     getAgentConfigMock.mockResolvedValueOnce({
-      iurls: [...WITNESSES, ...WITNESSES.slice(0, 5)],
+      iurls: WITNESSES.slice(0, 11),
     });
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 7, witnesses: [...witnessEids, ...witnessEids.slice(0, 4)] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 7, witnesses: [...witnessEids.slice(0, 10)] });
 
     getAgentConfigMock.mockResolvedValueOnce({
-      iurls: [...WITNESSES, ...WITNESSES.slice(0, 6)],
+      iurls: WITNESSES.slice(0, 12),
     });
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 8, witnesses: [...witnessEids, ...witnessEids.slice(0, 6)] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 8, witnesses: [...witnessEids.slice(0, 12)] });
 
     getAgentConfigMock.mockResolvedValueOnce({
-      iurls: [...WITNESSES, ...WITNESSES, ...WITNESSES],
+      iurls: WITNESSES
     });
-    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 8, witnesses: [...witnessEids, ...witnessEids.slice(0, 6)] });
+    expect(await identifierService.getAvailableWitnesses()).toStrictEqual({ toad: 8, witnesses: [...witnessEids.slice(0, 12)] });
   });
 });

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -29,7 +29,7 @@ import {
 } from "../event.types";
 import { StorageMessage } from "../../storage/storage.types";
 
-const identifierTypeThemes = [
+const UI_THEMES = [
   0, 1, 2, 3, 10, 11, 12, 13, 20, 21, 22, 23, 30, 31, 32, 33, 40, 41, 42, 43,
 ];
 
@@ -45,8 +45,8 @@ class IdentifierService extends AgentService {
     "Failed to obtain key manager for given AID";
   static readonly IDENTIFIER_IS_PENDING =
     "Cannot fetch identifier details as the identifier is still pending";
-  static readonly NO_WITNESSES_AVAILABLE =
-    "No discoverable witnesses available on connected KERIA instance";
+  static readonly INSUFFICIENT_WITNESSES_AVAILABLE =
+    "An insufficient number of discoverable witnesses are available on connected KERIA instance";
   static readonly MISCONFIGURED_AGENT_CONFIGURATION =
     "Misconfigured KERIA agent for this wallet type";
   static readonly INVALID_QUEUED_DISPLAY_NAMES_FORMAT =
@@ -205,12 +205,9 @@ class IdentifierService extends AgentService {
     metadata: Omit<IdentifierMetadataRecordProps, "id" | "createdAt">,
     backgroundTask = false,
   ): Promise<CreateIdentifierResult> {
-    const witnesses = await this.getAvailableWitnesses();
-    if (witnesses.length === 0) {
-      throw new Error(IdentifierService.NO_WITNESSES_AVAILABLE);
-    }
+    const { toad, witnesses } = await this.getAvailableWitnesses();
 
-    if (!identifierTypeThemes.includes(metadata.theme)) {
+    if (!UI_THEMES.includes(metadata.theme)) {
       throw new Error(IdentifierService.THEME_WAS_NOT_VALID);
     }
 
@@ -247,12 +244,10 @@ class IdentifierService extends AgentService {
 
     let identifier;
     try {
-      // @TODO - foconnor: Follow up ticket to pick a sane default for threshold. Right now max is too much.
-      //   Must also enforce a minimum number of available witnesses.
       const result = await this.props.signifyClient
         .identifiers()
         .create(name, {
-          toad: witnesses.length,
+          toad,
           wits: witnesses,
         });
       await result.op();  // @TODO - foconnor: Update Signify to await the POST before returning so error thrown predicably
@@ -614,7 +609,7 @@ class IdentifierService extends AgentService {
     }
   }
 
-  async getAvailableWitnesses(): Promise<string[]> {
+  async getAvailableWitnesses(): Promise<{ toad: number, witnesses: string[] }> {
     const config = await this.props.signifyClient.config().get();
     if (!config.iurls) {
       throw new Error(IdentifierService.MISCONFIGURED_AGENT_CONFIGURATION);
@@ -628,7 +623,13 @@ class IdentifierService extends AgentService {
       }
     }
 
-    return witnesses;
+    if (witnesses.length >= 12) return { toad: 8, witnesses: witnesses.slice(0, 12) };
+    if (witnesses.length >= 10) return { toad: 7, witnesses: witnesses.slice(0, 10) };
+    if (witnesses.length >= 9) return { toad: 6, witnesses: witnesses.slice(0, 9) };
+    if (witnesses.length >= 7) return { toad: 5, witnesses: witnesses.slice(0, 7) };
+    if (witnesses.length >= 6) return { toad: 4, witnesses: witnesses.slice(0, 6) };
+
+    throw new Error(IdentifierService.INSUFFICIENT_WITNESSES_AVAILABLE);
   }
 
   private async searchByName(name: string): Promise<HabState & { icp_dt: string } | undefined> {

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -623,11 +623,12 @@ class IdentifierService extends AgentService {
       }
     }
 
-    if (witnesses.length >= 12) return { toad: 8, witnesses: witnesses.slice(0, 12) };
-    if (witnesses.length >= 10) return { toad: 7, witnesses: witnesses.slice(0, 10) };
-    if (witnesses.length >= 9) return { toad: 6, witnesses: witnesses.slice(0, 9) };
-    if (witnesses.length >= 7) return { toad: 5, witnesses: witnesses.slice(0, 7) };
-    if (witnesses.length >= 6) return { toad: 4, witnesses: witnesses.slice(0, 6) };
+    const uniquew = [...new Set(witnesses)];
+    if (uniquew.length >= 12) return { toad: 8, witnesses: uniquew.slice(0, 12) };
+    if (uniquew.length >= 10) return { toad: 7, witnesses: uniquew.slice(0, 10) };
+    if (uniquew.length >= 9) return { toad: 6, witnesses: uniquew.slice(0, 9) };
+    if (uniquew.length >= 7) return { toad: 5, witnesses: uniquew.slice(0, 7) };
+    if (uniquew.length >= 6) return { toad: 4, witnesses: uniquew.slice(0, 6) };
 
     throw new Error(IdentifierService.INSUFFICIENT_WITNESSES_AVAILABLE);
   }

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -526,7 +526,7 @@ describe("App", () => {
 
 describe("Witness availability", () => {
   test("No witness availability", async () => {
-    getAvailableWitnessesMock.mockImplementation(() => Promise.resolve([]));
+    getAvailableWitnessesMock.mockRejectedValue(new Error(IdentifierService.INSUFFICIENT_WITNESSES_AVAILABLE));
 
     const initialState = {
       stateCache: {
@@ -618,7 +618,7 @@ describe("Witness availability", () => {
   });
 
   test("Throw error", async () => {
-    getAvailableWitnessesMock.mockImplementation(() => Promise.reject(new Error(IdentifierService.MISCONFIGURED_AGENT_CONFIGURATION)));
+    getAvailableWitnessesMock.mockRejectedValue(new Error(IdentifierService.MISCONFIGURED_AGENT_CONFIGURATION));
 
     const initialState = {
       stateCache: {

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -199,14 +199,10 @@ const AppWrapper = (props: { children: ReactNode }) => {
     if(!authentication.ssiAgentIsSet || !isOnline) return;
 
     try {
-      const witness = await Agent.agent.identifiers.getAvailableWitnesses();
-
-      if (witness.length === 0)
-        throw new Error(IdentifierService.NO_WITNESSES_AVAILABLE)
-
+      await Agent.agent.identifiers.getAvailableWitnesses();
     } catch(e) {
       const errorMessage = (e as Error).message;
-      if(errorMessage.includes(IdentifierService.NO_WITNESSES_AVAILABLE) || errorMessage.includes(IdentifierService.MISCONFIGURED_AGENT_CONFIGURATION)) {
+      if(errorMessage.includes(IdentifierService.INSUFFICIENT_WITNESSES_AVAILABLE) || errorMessage.includes(IdentifierService.MISCONFIGURED_AGENT_CONFIGURATION)) {
         dispatch(showNoWitnessAlert(true));
         return;
       }

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
@@ -423,7 +423,7 @@ describe("Create Identifier modal", () => {
   });
 
   test("No witness availability", async () => {
-    createIdentifierMock.mockImplementation(() => Promise.reject(new Error(IdentifierService.NO_WITNESSES_AVAILABLE)));
+    createIdentifierMock.mockImplementation(() => Promise.reject(new Error(IdentifierService.INSUFFICIENT_WITNESSES_AVAILABLE)));
 
     const { getByTestId } = render(
       <Provider store={storeMocked}>

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
@@ -197,7 +197,7 @@ const CreateIdentifier = ({
     } catch (e) {
       const errorMessage = (e as Error).message;
 
-      if(errorMessage.includes(IdentifierService.NO_WITNESSES_AVAILABLE) || errorMessage.includes(IdentifierService.MISCONFIGURED_AGENT_CONFIGURATION)) {
+      if(errorMessage.includes(IdentifierService.INSUFFICIENT_WITNESSES_AVAILABLE) || errorMessage.includes(IdentifierService.MISCONFIGURED_AGENT_CONFIGURATION)) {
         dispatch(showNoWitnessAlert(true));
         return;
       }


### PR DESCRIPTION
## Description

KAWA is KERI's witness agreement algorithm. Given a correctly configured witness pool (with correct thresholds) it can guarantee immunity based. See table here: https://github.com/WebOfTrust/keripy/discussions/837

For our first release, I've taken that table from witness count 6 up, and using the lower threshold to allow for higher availability. Maximum pool size of 12, can be extended if needed.

KAWA, given the constraints guarantees immunity by way of a witness pool will either produce a fully signed event or none at all.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1576)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated