### PR TITLE
fix(core): handle delayed rev telStatus when cred not accepted

### DIFF
--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -446,18 +446,18 @@ class KeriaNotificationService extends AgentService {
       await this.credentialStorage.getCredentialMetadata(exchange.exn.e.acdc.d);
     const telStatus = (await this.props.signifyClient
       .credentials()
-      .state(exchange.exn.e.acdc.ri, exchange.exn.e.acdc.d)).et; 
+      .state(exchange.exn.e.acdc.ri, exchange.exn.e.acdc.d)).et;
+    
+    const oldGrantNotifications = await this.notificationStorage.findAllByQuery({
+      credentialId: exchange.exn.e.acdc.d,
+    });
 
     // IPEX messages and TEL updates are not strictly ordered, so this will put to the failed notifications queue to re-process out of order
-    if (existingCredential && telStatus === Ilks.iss) {
+    if (telStatus === Ilks.iss && (existingCredential || oldGrantNotifications.length > 0)) {
       throw new Error(`${KeriaNotificationService.DUPLICATE_ISSUANCE}: [grant: ${exchange.exn.d}] [credential: ${exchange.exn.e.acdc.d}]`);
     }
 
     if (telStatus === Ilks.rev) {
-      const oldGrantNotifications = await this.notificationStorage.findAllByQuery({
-        credentialId: exchange.exn.e.acdc.d,
-      });
-
       for (const notificationRecord of oldGrantNotifications) {
         await this.deleteNotificationRecordById(
           notificationRecord.id,


### PR DESCRIPTION
## Description

When we receive the notification we check the TEL (transaction event log - for tracking revocations) status of the credential. Everything is async in KERI, so it's possible that the status is still `iss` and not `rev`. We handled this case for already accepted credentials. This PR now handles it when you have not yet accepted the credential.

The bug (which is intermittent) is that you would have 2 identical notifications (in appearance). But now the new notification replaces the old.

In case the old notification is deleted, then it will appear as if it's the first, which is as expected.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1659)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [X] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [X] In case PR contains changes to the UI, add some screenshots to notice the differences