### PR TITLE
fix: catch ios key not found error in secure storage

### DIFF
--- a/src/core/storage/secureStorage/secureStorage.ts
+++ b/src/core/storage/secureStorage/secureStorage.ts
@@ -9,8 +9,11 @@ enum KeyStoreKeys {
 }
 
 class SecureStorage {
-  static readonly KEY_NOT_FOUND =
-    "Item with given key does not exist";
+  static readonly KEY_NOT_FOUND_ERRORS =
+    [
+      "Item with given key does not exist", // Android/Web
+      "Error key doesn't exist",            // iOS
+    ];
 
   static async get(key: string): Promise<string | null> {
     try {
@@ -18,7 +21,7 @@ class SecureStorage {
       return result.value;
     } catch (e) {
       const error = e as { message?: string };
-      if (!error.message?.includes(SecureStorage.KEY_NOT_FOUND)) {
+      if (!SecureStorage.isErrorKeyNotFound(error.message)) {
         throw e;
       }
       return null;
@@ -34,6 +37,10 @@ class SecureStorage {
     if (result) {
       await SecureStoragePlugin.remove({ key });
     }
+  }
+
+  static isErrorKeyNotFound(errorMessage?: string): boolean {
+    return errorMessage ? SecureStorage.KEY_NOT_FOUND_ERRORS.some(err => errorMessage.includes(err)) : false;
   }
 
   static async isKeyStoreSupported() {

--- a/src/ui/components/VerifyPassword/VerifyPassword.tsx
+++ b/src/ui/components/VerifyPassword/VerifyPassword.tsx
@@ -52,23 +52,11 @@ const VerifyPassword = ({
   const handleFetchStoredValues = useCallback(async () => {
     if (!isOpen) return;
 
-    try {
-      const password = await SecureStorage.get(KeyStoreKeys.APP_OP_PASSWORD);
-      if (password) {
-        setStoredPassword(`${password}`);
-      }
-    } catch (e) {
-      if (
-        !(e instanceof Error) ||
-        !(
-          e instanceof Error &&
-          e.message ===
-            `${SecureStorage.KEY_NOT_FOUND} ${KeyStoreKeys.APP_OP_PASSWORD}`
-        )
-      ) {
-        showErrorMessage("Unable to get password", e, dispatch);
-        throw e;
-      }
+    const password = await SecureStorage.get(KeyStoreKeys.APP_OP_PASSWORD);
+    if (password) {
+      setStoredPassword(`${password}`);
+    } else {
+      showErrorMessage("Unable to get password", new Error("Unable to get password"), dispatch);
     }
 
     let hint;


### PR DESCRIPTION
## Description

Fix for catching error from iOS when key not in the secure storage.