### PR TITLE
Feat/dtis 1702 screenshot not disable

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -27,7 +27,7 @@ const config: CapacitorConfig = {
     PrivacyScreen: {
       enable: false,
       imageName: "Splashscreen",
-      preventScreenshots: false
+      preventScreenshots: true
     }
   }
 };

--- a/src/ui/hooks/privacyScreenHook.ts
+++ b/src/ui/hooks/privacyScreenHook.ts
@@ -2,20 +2,22 @@ import { useEffect, useRef, useCallback } from "react";
 import { PrivacyScreen } from "@capacitor-community/privacy-screen";
 import { Capacitor } from "@capacitor/core";
 
-const usePrivacyScreen = () => {
+const usePrivacyScreen = (autoEnable = true) => {
   const unmount = useRef(false);
 
-  const enablePrivacy = useCallback(() => {
+  const enablePrivacy = useCallback(async () => {
     if (!Capacitor.isNativePlatform()) return;
-    PrivacyScreen.enable();
+    return PrivacyScreen.enable();
   }, []);
 
-  const disablePrivacy = useCallback(() => {
+  const disablePrivacy = useCallback(async () => {
     if (!Capacitor.isNativePlatform()) return;
-    PrivacyScreen.disable();
+    return PrivacyScreen.disable();
   }, []);
 
   useEffect(() => {
+    if(!autoEnable) return;
+
     setTimeout(() => {
       if (unmount.current) return;
       enablePrivacy();
@@ -25,7 +27,7 @@ const usePrivacyScreen = () => {
       unmount.current = true;
       disablePrivacy();
     };
-  }, [enablePrivacy, disablePrivacy]);
+  }, [enablePrivacy, disablePrivacy, autoEnable]);
 
   return { enablePrivacy, disablePrivacy };
 };

--- a/src/ui/pages/LockPage/LockPage.tsx
+++ b/src/ui/pages/LockPage/LockPage.tsx
@@ -46,7 +46,7 @@ const LockPageContainer = () => {
   const biometricsCache = useSelector(getBiometricsCacheCache);
   const firstAppLaunch = useSelector(geFirstAppLaunch);
   const [openRecoveryAuth, setOpenRecoveryAuth] = useState(false);
-  const { enablePrivacy, disablePrivacy } = usePrivacyScreen();
+  const { enablePrivacy, disablePrivacy } = usePrivacyScreen(false);
 
   const {
     isLock,
@@ -130,13 +130,13 @@ const LockPageContainer = () => {
   };
 
   const handleBiometrics = async () => {
-    disablePrivacy();
+    await disablePrivacy();
     const isAuthenticated = await handleBiometricAuth();
+    await enablePrivacy();
     if (isAuthenticated === true) {
       dispatch(login());
       dispatch(setFirstAppLaunch(false));
     }
-    enablePrivacy();
   };
 
   const resetPasscode = () => {


### PR DESCRIPTION
## Description

This PR will fix a bug that would otherwise allow the user to take a screenshot of the recovery phrase during onboarding.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-1702**](https://cardanofoundation.atlassian.net/issues/DTIS-1702)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS
##### _Before_


https://github.com/user-attachments/assets/9e3348f5-951b-4381-b447-0731a215ee06


##### _After_


https://github.com/user-attachments/assets/181e337c-cf01-4fdc-8f0a-e642eaf780ad

