### PR TITLE
fix(core): $and $or queries should be skipped for empty arrays

### DIFF
--- a/src/core/storage/sqliteStorage/sqliteStorage.ts
+++ b/src/core/storage/sqliteStorage/sqliteStorage.ts
@@ -254,6 +254,7 @@ class SqliteStorage<T extends BaseRecord> implements StorageService<T> {
     const conditions: string[] = [];
     let values: string[] = [];
     const dbQuery = convertDbQuery(query);
+
     for (const [queryKey, queryVal] of Object.entries(dbQuery)) {
       if (queryKey === "$or" || queryKey === "$and") {
         const orConditions: string[] = [];
@@ -262,11 +263,14 @@ class SqliteStorage<T extends BaseRecord> implements StorageService<T> {
           orConditions.push(orQuery.condition);
           values = values.concat(orQuery.values);
         }
-        conditions.push(
-          orConditions
-            .map((condition) => "(" + condition + ")")
-            .join(queryKey === "$or" ? " OR " : " AND ")
-        );
+
+        if (orConditions.length > 0) {
+          conditions.push(
+            orConditions
+              .map((condition) => "(" + condition + ")")
+              .join(queryKey === "$or" ? " OR " : " AND ")
+          );
+        }
       } else if (queryKey === "$not") {
         const notQuery = this.getQueryConditionSql(
           queryVal as Query<BasicRecord>


### PR DESCRIPTION
## Description

In case it's an empty list, you will end up with a query of `''` on the join. Then the final outer query string will end up with ` AND <otherquery2> AND <otherquery3>`, which is invalid. Should be `<otherquery2> AND <otherquery3>`.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1660)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated