### PR TITLE
feat(ui): Broken animation for accepting a credential

### DIFF
--- a/src/ui/pages/NotificationDetails/NotificationDetails.tsx
+++ b/src/ui/pages/NotificationDetails/NotificationDetails.tsx
@@ -1,13 +1,13 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
-import { NotificationRoute } from "../../../core/agent/agent.types";
+import { KeriaNotification, NotificationRoute } from "../../../core/agent/agent.types";
+import { TabsRoutePath } from "../../../routes/paths";
 import { useAppSelector } from "../../../store/hooks";
 import { getNotificationsCache } from "../../../store/reducers/notificationsCache";
 import { useAppIonRouter } from "../../hooks";
 import { CredentialRequest } from "./components/CredentialRequest";
 import { MultiSigRequest } from "./components/MultiSigRequest";
 import { ReceiveCredential } from "./components/ReceiveCredential";
-import { TabsRoutePath } from "../../../routes/paths";
 
 const NotificationDetails = () => {
   const pageId = "notification-details";
@@ -19,21 +19,25 @@ const NotificationDetails = () => {
     return notificationCache.find((notification) => notification.id === id);
   }, [id, notificationCache]);
 
+  const currentNotification = useRef<KeriaNotification | undefined>(notificationDetails);
+
   const handleBack = useCallback(() => {
     ionicRouter.push(TabsRoutePath.NOTIFICATIONS, "back", "pop");
   }, [ionicRouter]);
 
-  useEffect(() => {
-    if(!notificationDetails) handleBack();
-  }, [handleBack, notificationDetails]);
+  const displayNotification = currentNotification.current || notificationDetails;
 
-  switch (notificationDetails?.a?.r) {
+  useEffect(() => {
+    if(!displayNotification) handleBack();
+  }, [handleBack, displayNotification]);
+
+  switch (displayNotification?.a?.r) {
   case NotificationRoute.MultiSigIcp:
     return (
       <MultiSigRequest
         pageId={pageId}
-        activeStatus={!!notificationDetails}
-        notificationDetails={notificationDetails}
+        activeStatus={!!displayNotification}
+        notificationDetails={displayNotification}
         handleBack={handleBack}
       />
     );
@@ -41,8 +45,8 @@ const NotificationDetails = () => {
     return (
       <ReceiveCredential
         pageId={pageId}
-        activeStatus={!!notificationDetails}
-        notificationDetails={notificationDetails}
+        activeStatus={!!displayNotification}
+        notificationDetails={displayNotification}
         handleBack={handleBack}
       />
     );
@@ -50,8 +54,8 @@ const NotificationDetails = () => {
     return (
       <CredentialRequest
         pageId={pageId}
-        activeStatus={!!notificationDetails}
-        notificationDetails={notificationDetails}
+        activeStatus={!!displayNotification}
+        notificationDetails={displayNotification}
         handleBack={handleBack}
       />
     );
@@ -59,8 +63,8 @@ const NotificationDetails = () => {
     return (
       <ReceiveCredential
         pageId={pageId}
-        activeStatus={!!notificationDetails}
-        notificationDetails={notificationDetails}
+        activeStatus={!!displayNotification}
+        notificationDetails={displayNotification}
         handleBack={handleBack}
         multisigExn
       />


### PR DESCRIPTION
## Description

After user had accepted notification, core sent `NotificationRemoved` event to UI and current notification will be removed.
Notification page had been closed before setTimeout call (Because notification has been deleted in redux).

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [DTIS-1708](https://cardanofoundation.atlassian.net/browse/DTIS-1708)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/919d7a9c-3623-485a-b571-8dd99f687958

#### Android

https://github.com/user-attachments/assets/eac5a3a5-b64d-4722-8115-52981922f7b4


[DTIS-1708]: https://cardanofoundation.atlassian.net/browse/DTIS-1708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ