### PR TITLE
fix: building of essr tunneled req body 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "react-qrcode-logo": "^3.0.0",
         "react-redux": "^8.0.5",
         "react-router-dom": "^5.3.4",
-        "signify-ts": "github:WebOfTrust/signify-ts#a7353800fc225f8055f499c60872fa1e447dc39e",
+        "signify-ts": "github:WebOfTrust/signify-ts#b2395633ad75ecabbd3e54394c96e0fbf5148a2d",
         "swiper": "^11.1.14",
         "web-vitals": "^2.1.4"
       },
@@ -43931,8 +43931,8 @@
     },
     "node_modules/signify-ts": {
       "version": "0.3.0-rc1",
-      "resolved": "git+ssh://git@github.com/WebOfTrust/signify-ts.git#a7353800fc225f8055f499c60872fa1e447dc39e",
-      "integrity": "sha512-rr/hRuFWWKHvxWq349CINx0PqGuD5JL/t418biulA5pkLtPBbn5lmV/tUje90BYUxiFTXdlLIe+1SQRi6RlsRg==",
+      "resolved": "git+ssh://git@github.com/WebOfTrust/signify-ts.git#b2395633ad75ecabbd3e54394c96e0fbf5148a2d",
+      "integrity": "sha512-sf+g3BE54jWp1P/SzxlbB+rgwjiV14Je6yrx76zso6xyvG3vL36OJdAt2sVTw79gO6fhBhHCp/Njoj9QJgxghw==",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-qrcode-logo": "^3.0.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^5.3.4",
-    "signify-ts": "github:WebOfTrust/signify-ts#a7353800fc225f8055f499c60872fa1e447dc39e",
+    "signify-ts": "github:WebOfTrust/signify-ts#b2395633ad75ecabbd3e54394c96e0fbf5148a2d",
     "swiper": "^11.1.14",
     "web-vitals": "^2.1.4"
   },


### PR DESCRIPTION
For whatever bizarre reason, a fetch `Request` instance _with_ a body on Android WebViews will have a `req.body` value of `undefined`. No issues in Chrome (and both use Chromium), or iOS.

`await req.arrayBuffer()` still returns the body in bytes, so I just directly call this now. This also simplified the original code as I didn't realise this was available on the request as well as response, so removed the custom function I had in Signify to convert a `ReadableStream` to a `Uint8Array`.