### PR TITLE
ci(gha): remove develop branch and ignore on main

### DIFF
--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -2,12 +2,11 @@ name: Build and publish docker artifacts
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
     types: [ opened, synchronize ]
-    branches-ignore: [ main ]
     paths:
     - 'Earthfile'
     - '.github/workflows/docker-builds.yaml'

--- a/.github/workflows/gh-verify-branch.yaml
+++ b/.github/workflows/gh-verify-branch.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - develop
 
 env:
   PRODUCTION_BRANCH: main

--- a/.github/workflows/gh-verify-pr.yaml
+++ b/.github/workflows/gh-verify-pr.yaml
@@ -9,7 +9,6 @@ name: verify-pr
 on:
   pull_request:
     types: [ opened, synchronize ]
-    branches-ignore: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
No longer using develop. Need this to get tests back on PRs to main etc and general cleanup.