### PR TITLE
fix(core): eventEmitter should be instantiated before operation storage

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -423,6 +423,10 @@ class Agent {
 
   async setupLocalDependencies(): Promise<void> {
     await this.storageSession.open(walletId);
+    this.agentServicesProps = {
+      signifyClient: this.signifyClient,
+      eventEmitter: new CoreEventEmitter(),
+    };
     this.basicStorageService = new BasicStorage(
       this.getStorageService<BasicRecord>(this.storageSession)
     );
@@ -445,10 +449,6 @@ class Agent {
       this.getStorageService<OperationPendingRecord>(this.storageSession),
       this.agentServicesProps.eventEmitter
     );
-    this.agentServicesProps = {
-      signifyClient: this.signifyClient,
-      eventEmitter: new CoreEventEmitter(),
-    };
     this.connections.onConnectionRemoved();
     this.connections.onConnectionAdded();
     this.identifiers.onIdentifierRemoved();


### PR DESCRIPTION
## Description

If we emit the event from the storage service, the event emitter needs to be initialised before the storage services. Otherwise the events aren't published properly and caught.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1833)]