### PR TITLE
fix: after recovering successfully, update redux and mark agent online

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -1,5 +1,4 @@
 import { Capacitor } from "@capacitor/core";
-import { EventEmitter } from "events";
 import {
   randomPasscode,
   SignifyClient,
@@ -66,6 +65,7 @@ class Agent {
   static readonly MISSING_DATA_ON_KERIA =
     "Attempted to fetch data by ID on KERIA, but was not found. May indicate stale data records in the local database.";
   static readonly BUFFER_ALLOC_SIZE = 3;
+  static readonly DEFAULT_RECONNECT_INTERVAL = 1000;
 
   private static instance: Agent;
   private agentServicesProps: AgentServicesProps = {
@@ -463,7 +463,10 @@ class Agent {
     this.credentials.onCredentialRemoved();
   }
 
-  async connect(retryInterval = 1000) {
+  async connect(
+    retryInterval = Agent.DEFAULT_RECONNECT_INTERVAL,
+    updateAgentStatus = true
+  ) {
     try {
       if (Agent.isOnline) {
         Agent.isOnline = false;
@@ -475,7 +478,10 @@ class Agent {
         });
       }
       await this.signifyClient.connect();
-      this.markAgentStatus(true);
+
+      if (updateAgentStatus) {
+        this.markAgentStatus(true);
+      }
     } catch (error) {
       await new Promise((resolve) => setTimeout(resolve, retryInterval));
       await this.connect(retryInterval);

--- a/src/core/agent/services/utils.ts
+++ b/src/core/agent/services/utils.ts
@@ -54,7 +54,7 @@ const OnlineOnly = (
 
       if (isNetworkError(error)) {
         Agent.agent.markAgentStatus(false);
-        Agent.agent.connect(1000);
+        Agent.agent.connect();
         throw new Error(Agent.KERIA_CONNECTION_BROKEN, {
           cause: error,
         });

--- a/src/routes/backRoute/backRoute.test.ts
+++ b/src/routes/backRoute/backRoute.test.ts
@@ -31,6 +31,7 @@ describe("getBackRoute", () => {
       stateCache: {
         isOnline: true,
         initialized: true,
+        recoveryCompleteNoInterruption: false,
         routes: [{ path: "/route1" }, { path: "/route2" }, { path: "/route3" }],
         authentication: {
           passcodeIsSet: true,
@@ -183,6 +184,7 @@ describe("getPreviousRoute", () => {
       stateCache: {
         isOnline: true,
         initialized: true,
+        recoveryCompleteNoInterruption: false,
         routes: [{ path: "/route1" }, { path: "/route2" }, { path: "/route3" }],
         authentication: {
           passcodeIsSet: true,

--- a/src/routes/nextRoute/nextRoute.test.ts
+++ b/src/routes/nextRoute/nextRoute.test.ts
@@ -26,6 +26,7 @@ describe("NextRoute", () => {
       stateCache: {
         isOnline: true,
         initialized: true,
+        recoveryCompleteNoInterruption: false,
         routes: [],
         authentication: {
           loggedIn: false,
@@ -286,6 +287,7 @@ describe("getNextRoute", () => {
     stateCache: {
       isOnline: true,
       initialized: true,
+      recoveryCompleteNoInterruption: false,
       routes: [],
       authentication: {
         loggedIn: false,

--- a/src/store/reducers/notificationsCache/notificationsCache.test.ts
+++ b/src/store/reducers/notificationsCache/notificationsCache.test.ts
@@ -104,6 +104,7 @@ describe("Notifications cache", () => {
       stateCache: {
         isOnline: true,
         initialized: true,
+        recoveryCompleteNoInterruption: false,
         routes: [],
         authentication: {
           loggedIn: false,

--- a/src/store/reducers/stateCache/stateCache.ts
+++ b/src/store/reducers/stateCache/stateCache.ts
@@ -14,6 +14,7 @@ import {
 
 const initialState: StateCacheProps = {
   initialized: false,
+  recoveryCompleteNoInterruption: false,
   isOnline: false,
   routes: [],
   authentication: {
@@ -51,6 +52,12 @@ const stateCacheSlice = createSlice({
     },
     setInitialized: (state, action: PayloadAction<boolean>) => {
       state.initialized = action.payload;
+    },
+    setRecoveryCompleteNoInterruption: (
+      state,
+      action: PayloadAction<boolean>
+    ) => {
+      state.recoveryCompleteNoInterruption = action.payload;
     },
     setCurrentRoute: (state, action: PayloadAction<CurrentRouteCacheProps>) => {
       const filteredRoutes = state.routes.filter(
@@ -173,6 +180,7 @@ const stateCacheSlice = createSlice({
 
 const {
   setInitialized,
+  setRecoveryCompleteNoInterruption,
   setCurrentRoute,
   removeCurrentRoute,
   removeSetPasscodeRoute,
@@ -198,6 +206,8 @@ const {
 
 const getStateCache = (state: RootState) => state.stateCache;
 const getIsInitialized = (state: RootState) => state.stateCache.initialized;
+const getRecoveryCompleteNoInterruption = (state: RootState) =>
+  state.stateCache.recoveryCompleteNoInterruption;
 const getRoutes = (state: RootState) => state.stateCache.routes;
 const getCurrentRoute = (state: RootState) =>
   state.stateCache.routes.length ? state.stateCache.routes[0] : undefined;
@@ -260,6 +270,7 @@ export {
   setCurrentOperation,
   setCurrentRoute,
   setInitialized,
+  setRecoveryCompleteNoInterruption,
   setIsOnline,
   setLoginAttempt,
   setFirstAppLaunch,
@@ -269,4 +280,5 @@ export {
   showGenericError,
   showConnections,
   stateCacheSlice,
+  getRecoveryCompleteNoInterruption,
 };

--- a/src/store/reducers/stateCache/stateCache.types.ts
+++ b/src/store/reducers/stateCache/stateCache.types.ts
@@ -50,6 +50,7 @@ interface ToastStackItem {
 
 interface StateCacheProps {
   initialized: boolean;
+  recoveryCompleteNoInterruption: boolean;
   isOnline: boolean;
   routes: CurrentRouteCacheProps[];
   authentication: AuthenticationCacheProps;

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -29,6 +29,7 @@ import {
 import {
   getStateCache,
   setCurrentOperation,
+  setRecoveryCompleteNoInterruption,
 } from "../../../store/reducers/stateCache";
 import { updateReduxState } from "../../../store/utils";
 import { CustomInput } from "../../components/CustomInput";
@@ -176,6 +177,8 @@ const CreateSSIAgent = () => {
         seedPhraseCache.seedPhrase.split(" "),
         ssiAgent.connectUrl
       );
+
+      dispatch(setRecoveryCompleteNoInterruption(true));
 
       const { nextPath, updateRedux } = getNextRoute(RoutePath.SSI_AGENT, {
         store: { stateCache },
@@ -406,13 +409,13 @@ const CreateSSIAgent = () => {
               errorMessage={
                 hasMismatchError
                   ? `${i18n.t(
-                      isRecoveryMode
-                        ? "ssiagent.error.recoverymismatchconnecturl"
-                        : "ssiagent.error.mismatchconnecturl"
-                    )}`
+                    isRecoveryMode
+                      ? "ssiagent.error.recoverymismatchconnecturl"
+                      : "ssiagent.error.mismatchconnecturl"
+                  )}`
                   : displayBootUrlError && !isInvalidConnectUrl
-                  ? `${i18n.t("ssiagent.error.invalidurl")}`
-                  : `${i18n.t("ssiagent.error.invalidconnecturl")}`
+                    ? `${i18n.t("ssiagent.error.invalidurl")}`
+                    : `${i18n.t("ssiagent.error.invalidconnecturl")}`
               }
             />
           </div>

--- a/src/ui/pages/GenerateSeedPhrase/GenerateSeedPhrase.tsx
+++ b/src/ui/pages/GenerateSeedPhrase/GenerateSeedPhrase.tsx
@@ -33,7 +33,7 @@ const GenerateSeedPhrase = () => {
   const dispatch = useAppDispatch();
   const stateCache = useAppSelector(getStateCache);
   const seedPhraseStore = useAppSelector(getSeedPhraseCache);
-  const [brandNMnemonic, setBrandNMnemonic] = useState<BranAndMnemonic>();
+  const [branNMnemonic, setBranNMnemonic] = useState<BranAndMnemonic>();
   const [seedPhrase, setSeedPhrase] = useState<string[]>([]);
   const [hideSeedPhrase, setHideSeedPhrase] = useState(true);
   const [alertConfirmIsOpen, setAlertConfirmIsOpen] = useState(false);
@@ -47,7 +47,7 @@ const GenerateSeedPhrase = () => {
     setHideSeedPhrase(true);
     if (seedPhraseStore.seedPhrase.length > 0) {
       setSeedPhrase(seedPhraseStore.seedPhrase.split(" "));
-      setBrandNMnemonic({
+      setBranNMnemonic({
         mnemonic: seedPhraseStore.seedPhrase,
         bran: seedPhraseStore.bran,
       });
@@ -55,7 +55,7 @@ const GenerateSeedPhrase = () => {
       try {
         const branAndMnemonic = await Agent.agent.getBranAndMnemonic();
         setSeedPhrase(branAndMnemonic.mnemonic.split(" "));
-        setBrandNMnemonic(branAndMnemonic);
+        setBranNMnemonic(branAndMnemonic);
       } catch (e) {
         showError("Unable to get mnemonic", e, dispatch);
       }
@@ -103,8 +103,8 @@ const GenerateSeedPhrase = () => {
     const data: DataProps = {
       store: { stateCache },
       state: {
-        seedPhrase: brandNMnemonic?.mnemonic,
-        bran: brandNMnemonic?.bran,
+        seedPhrase: branNMnemonic?.mnemonic,
+        bran: branNMnemonic?.bran,
       },
     };
     const { nextPath, updateRedux } = getNextRoute(


### PR DESCRIPTION
## Description

When you recover a wallet, the agent status wasn't being set to true like when you fresh onboard. It's a bit trickier here because when you recover, you sync the DB from KERIA so you need to initialise Redux too with `loadDatabase` so I added something in Redux for this.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1829)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).
  - Not sure if necessary here.