### PR TITLE
fix(core): store missing oobi for contact

### DIFF
--- a/src/core/agent/services/connectionService.test.ts
+++ b/src/core/agent/services/connectionService.test.ts
@@ -647,10 +647,24 @@ describe("Connection service of agent", () => {
     });
   });
 
+  test("should update KERIA contact directly if waiting for completion", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
+    jest.spyOn(Date.prototype, "getTime").mockReturnValueOnce(0);
+
+    await connectionService.resolveOobi(
+      `${oobiPrefix}test?name=alias&groupId=1234`,
+      true
+    );
+
+    expect(updateContactMock).toBeCalledWith("id", {
+      alias: "alias",
+      createdAt: expect.any(Date),
+      groupCreationId: "1234",
+      oobi: `${oobiPrefix}test?name=alias&groupId=1234`,
+    });
+  });
+
   test("should throw if oobi is not resolving and we explicitly wait for completion", async () => {
-    signifyClient.operations().get = jest
-      .fn()
-      .mockResolvedValue({ done: false });
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     jest.spyOn(Date.prototype, "getTime").mockReturnValueOnce(0);
     await expect(

--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -489,6 +489,7 @@ class ConnectionService extends AgentService {
             alias,
             groupCreationId: new URL(url).searchParams.get("groupId") ?? "",
             createdAt: new Date((operation.response as State).dt),
+            oobi: url,
           });
         }
       }

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -2216,6 +2216,7 @@ describe("Long running operation tracker", () => {
       pending: true,
       createdAt: new Date(),
       alias: "CF Credential Issuance",
+      oobi: "http://oobi.com/",
     };
     connectionStorage.findById.mockResolvedValueOnce(connectionMock);
     const operationRecord = {
@@ -2225,19 +2226,21 @@ describe("Long running operation tracker", () => {
       recordType: "oobi",
       updatedAt: new Date("2024-08-01T10:36:17.814Z"),
     } as OperationPendingRecord;
-
     contactGetMock.mockResolvedValueOnce(null);
 
     await keriaNotificationService.processOperation(operationRecord);
+
     expect(connectionStorage.update).toBeCalledWith({
       id: connectionMock.id,
       pending: false,
       createdAt: operationMock.response.dt,
       alias: connectionMock.alias,
+      oobi: "http://oobi.com/",
     });
     expect(contactsUpdateMock).toBeCalledWith(connectionMock.id, {
       alias: "CF Credential Issuance",
       createdAt: operationMock.response.dt,
+      oobi: "http://oobi.com/",
     });
     expect(eventEmitter.emit).toHaveBeenNthCalledWith(1, {
       type: EventTypes.ConnectionStateChanged,

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -1083,6 +1083,7 @@ class KeriaNotificationService extends AgentService {
                 .update((operation.response as State).i, {
                   alias: connectionRecord.alias,
                   createdAt: new Date((operation.response as State).dt),
+                  oobi: connectionRecord.oobi,
                 });
             }
 


### PR DESCRIPTION
## Description

Now that we aren't passing the alias to KERIA when resolving the OOBI, the contact isn't auto created.

When creating the contact, we weren't storing the OOBI like before so this fixes that. It's needed when e.g. resolving new schemas etc.