### PR TITLE
feat(ui): Should not be stuck after dismissing verify password modal

### DIFF
--- a/src/ui/components/CredentialDetailModule/CredentialDetailModule.tsx
+++ b/src/ui/components/CredentialDetailModule/CredentialDetailModule.tsx
@@ -27,6 +27,7 @@ import {
   setNotificationsCache,
 } from "../../../store/reducers/notificationsCache";
 import {
+  getAuthentication,
   setCurrentOperation,
   setToastMsg,
 } from "../../../store/reducers/stateCache";
@@ -69,6 +70,8 @@ const CredentialDetailModule = ({
   const dispatch = useAppDispatch();
   const credsCache = useAppSelector(getCredsCache);
   const favouritesCredsCache = useAppSelector(getFavouritesCredsCache);
+  const passwordAuthentication =
+    useAppSelector(getAuthentication).passwordIsSet;
   const notifications = useAppSelector(getNotificationsCache);
   const [optionsIsOpen, setOptionsIsOpen] = useState(false);
   const [alertDeleteArchiveIsOpen, setAlertDeleteArchiveIsOpen] =
@@ -393,7 +396,7 @@ const CredentialDetailModule = ({
   };
 
   const handleAuthentication = () => {
-    setHidden(true);
+    setHidden(!passwordAuthentication);
     setVerifyIsOpen(true);
   };
 

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
@@ -25,6 +25,7 @@ import {
   removeIdentifierCache,
 } from "../../../store/reducers/identifiersCache";
 import {
+  getAuthentication,
   getStateCache,
   setCurrentOperation,
   setCurrentRoute,
@@ -63,6 +64,8 @@ const IdentifierDetailModule = ({
   const favouritesIdentifiersData = useAppSelector(
     getFavouritesIdentifiersCache
   );
+  const passwordAuthentication =
+    useAppSelector(getAuthentication).passwordIsSet;
   const [shareIsOpen, setShareIsOpen] = useState(false);
   const [identifierOptionsIsOpen, setIdentifierOptionsIsOpen] = useState(false);
   const [alertIsOpen, setAlertIsOpen] = useState(false);
@@ -122,14 +125,15 @@ const IdentifierDetailModule = ({
 
   const handleDelete = async () => {
     handleDone?.(false);
+    setHidden(true);
 
     try {
       setVerifyIsOpen(false);
       const filterId = cardData
         ? cardData.id
         : cloudError
-        ? identifierDetailId
-        : undefined;
+          ? identifierDetailId
+          : undefined;
 
       await deleteIdentifier();
       dispatch(setToastMsg(ToastMsgType.IDENTIFIER_DELETED));
@@ -213,7 +217,7 @@ const IdentifierDetailModule = ({
   };
 
   const handleAuthentication = () => {
-    setHidden(true);
+    setHidden(!passwordAuthentication);
     setVerifyIsOpen(true);
   };
 

--- a/src/ui/components/VerifyPassword/VerifyPassword.tsx
+++ b/src/ui/components/VerifyPassword/VerifyPassword.tsx
@@ -142,6 +142,7 @@ const VerifyPassword = ({
         customClasses="verify-password-modal"
         onDismiss={() => resetModal()}
         header={headerOptions}
+        backdropDismiss={false}
       >
         <form className="password-input-container">
           <CustomInput

--- a/src/ui/components/VerifyPassword/VerifyPassword.tsx
+++ b/src/ui/components/VerifyPassword/VerifyPassword.tsx
@@ -142,7 +142,6 @@ const VerifyPassword = ({
         customClasses="verify-password-modal"
         onDismiss={() => resetModal()}
         header={headerOptions}
-        backdropDismiss={false}
       >
         <form className="password-input-container">
           <CustomInput

--- a/src/ui/components/layout/ResponsiveModal/ResponsiveModal.tsx
+++ b/src/ui/components/layout/ResponsiveModal/ResponsiveModal.tsx
@@ -7,6 +7,7 @@ const ResponsiveModal = ({
   modalIsOpen,
   customClasses,
   children,
+  backdropDismiss,
   onDismiss,
 }: ResponsiveModalProps) => {
   return (
@@ -17,6 +18,7 @@ const ResponsiveModal = ({
       data-testid={componentId}
       className={`responsive-modal ${customClasses}`}
       onDidDismiss={onDismiss}
+      backdropDismiss={backdropDismiss}
     >
       <div className={`responsive-modal-content ${componentId}-content`}>
         {children}

--- a/src/ui/components/layout/ResponsiveModal/ResponsiveModal.types.ts
+++ b/src/ui/components/layout/ResponsiveModal/ResponsiveModal.types.ts
@@ -5,6 +5,7 @@ interface ResponsiveModalProps {
   modalIsOpen: boolean;
   customClasses?: string;
   children?: ReactNode;
+  backdropDismiss?: boolean;
   onDismiss: () => void;
 }
 


### PR DESCRIPTION
## Description

Disable backdrop dismiss on verify password modal

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1879)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/f1388d47-f0e7-403a-bc6c-2147984a5240

#### Android

https://github.com/user-attachments/assets/384a8d3b-2af7-4613-a863-879f30cc22f4
