### PR TITLE
feat: salt and hash passcode and password

### DIFF
--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -379,7 +379,7 @@ class Agent {
 
     const appPasscode = await SecureStorage.get(KeyStoreKeys.APP_PASSCODE);
     if (!appPasscode) {
-      await SecureStorage.set(
+      await this.auth.storeSecret(
         KeyStoreKeys.APP_PASSCODE,
         APP_PASSSCODE_DEV_MODE
       );

--- a/src/core/agent/services/authService.test.ts
+++ b/src/core/agent/services/authService.test.ts
@@ -6,7 +6,7 @@ import { AuthService } from "./authService";
 import { BasicRecord } from "../../agent/records";
 import { KeyStoreKeys, SecureStorage } from "../../storage";
 
-jest.mock("../../storage/SecureStorage");
+jest.mock("../../storage/secureStorage");
 
 const identifiersListMock = jest.fn();
 const identifiersGetMock = jest.fn();

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -111,16 +111,6 @@ jest.mock("@capacitor/device", () => ({
   },
 }));
 
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: jest.fn((options: { key: string }) => {
-      return Promise.resolve({ value: "value" });
-    }),
-    set: jest.fn(),
-    remove: jest.fn(),
-  },
-}));
-
 const setStyleMock = jest.fn();
 jest.mock("@capacitor/status-bar", () => ({
   ...jest.requireActual("@capacitor/status-bar"),

--- a/src/ui/components/AppWrapper/AppWrapper.test.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.test.tsx
@@ -141,16 +141,6 @@ jest.mock("../../../core/agent/agent", () => ({
   },
 }));
 
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: jest.fn((options: { key: string }) => {
-      return Promise.resolve({ value: "value" });
-    }),
-    set: jest.fn(),
-    remove: jest.fn(),
-  },
-}));
-
 describe("App Wrapper", () => {
   test("renders children components", async () => {
     const { getByText } = render(

--- a/src/ui/components/ArchivedCredentials/ArchivedCredentials.test.tsx
+++ b/src/ui/components/ArchivedCredentials/ArchivedCredentials.test.tsx
@@ -33,14 +33,10 @@ jest.mock("../../../core/agent/agent", () => ({
       keriaNotifications: {
         deleteNotificationRecordById: () => deleteNotificationMock(),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
-  },
-}));
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: () => "111111",
   },
 }));
 
@@ -74,8 +70,6 @@ describe("Archived and revoked credentials", () => {
   const dispatchMock = jest.fn();
 
   beforeEach(() => {
-    jest.resetAllMocks();
-
     mockedStore = {
       ...mockStore(initialStateEmpty),
       dispatch: dispatchMock,

--- a/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.test.tsx
@@ -19,12 +19,6 @@ jest.mock("@ionic/react", () => ({
     isOpen ? <div {...props}>{children}</div> : null,
 }));
 
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: (options: { key: string }) => Promise.resolve({ value: "111111" }),
-  },
-}));
-
 const mockGetMultisigConnection = jest.fn((args) => Promise.resolve([]));
 
 jest.mock("../../../core/agent/agent", () => ({

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
@@ -49,6 +49,9 @@ jest.mock("../../../../core/agent/agent", () => ({
         deleteIdentifier: () => deleteIdentifier(),
         markIdentifierPendingDelete: () => markIdentifierPendingDelete(),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
   },
 }));
@@ -62,13 +65,6 @@ jest.mock("react-router-dom", () => ({
       historyPushMock(args);
     },
   }),
-}));
-
-jest.mock("../../../../core/storage", () => ({
-  ...jest.requireActual("../../../../core/storage"),
-  SecureStorage: {
-    get: () => "111111",
-  },
 }));
 
 describe("Create group identifier - Setup Connection", () => {

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
@@ -50,12 +50,6 @@ jest.mock("../../../core/agent/agent", () => ({
   },
 }));
 
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: (options: { key: string }) => Promise.resolve({ value: "111111" }),
-  },
-}));
-
 const addKeyboardEventMock = jest.fn();
 
 jest.mock("@capacitor/keyboard", () => ({

--- a/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
+++ b/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
@@ -48,6 +48,9 @@ jest.mock("../../../core/agent/agent", () => ({
       keriaNotifications: {
         deleteNotificationRecordById: () => deleteNotificationRecordById(),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
   },
 }));
@@ -70,13 +73,6 @@ jest.mock("@ionic/react", () => ({
   ...jest.requireActual("@ionic/react"),
   IonModal: ({ children, isOpen, ...props }: any) =>
     isOpen ? <div data-testid={props["data-testid"]}>{children}</div> : null,
-}));
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: () => "111111",
-  },
 }));
 
 const mockStore = configureStore();

--- a/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.test.tsx
+++ b/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.test.tsx
@@ -11,9 +11,6 @@ import { ForgotType } from "./ForgotAuthInfo.types";
 
 const SEED_PHRASE_LENGTH = 18;
 
-const secureStorageGetFunc = jest.fn();
-const secureStorageSetFunc = jest.fn();
-const secureStorageDeleteFunc = jest.fn();
 const verifySeedPhraseFnc = jest.fn();
 
 const createOrUpdateBasicStore = jest.fn((arg: unknown) =>
@@ -30,16 +27,11 @@ jest.mock("../../../core/agent/agent", () => ({
         createOrUpdateBasicRecord: (arg: unknown) =>
           createOrUpdateBasicStore(arg),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(false),
+        storeSecret: jest.fn(),
+      },
     },
-  },
-}));
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: (...args: unknown[]) => secureStorageGetFunc(...args),
-    set: (...args: unknown[]) => secureStorageSetFunc(...args),
-    delete: (...args: unknown[]) => secureStorageDeleteFunc(...args),
   },
 }));
 

--- a/src/ui/components/RecoverySeedPhraseModule/RecoverySeedPhraseModule.test.tsx
+++ b/src/ui/components/RecoverySeedPhraseModule/RecoverySeedPhraseModule.test.tsx
@@ -8,9 +8,6 @@ import { RecoverySeedPhraseModule } from "./RecoverySeedPhraseModule";
 
 const SEED_PHRASE_LENGTH = 18;
 
-const secureStorageGetFunc = jest.fn();
-const secureStorageSetFunc = jest.fn();
-const secureStorageDeleteFunc = jest.fn();
 const verifySeedPhraseFnc = jest.fn();
 
 jest.mock("../../../core/agent/agent", () => ({
@@ -18,15 +15,6 @@ jest.mock("../../../core/agent/agent", () => ({
     agent: {
       isMnemonicValid: () => verifySeedPhraseFnc(),
     },
-  },
-}));
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: (...args: unknown[]) => secureStorageGetFunc(...args),
-    set: (...args: unknown[]) => secureStorageSetFunc(...args),
-    delete: (...args: unknown[]) => secureStorageDeleteFunc(...args),
   },
 }));
 

--- a/src/ui/components/VerifyPasscode/VerifyPasscode.test.tsx
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn();
+
 import { AnyAction, Store } from "@reduxjs/toolkit";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
@@ -30,6 +32,9 @@ jest.mock("../../../core/agent/agent", () => ({
       },
       connections: {
         getConnectionShortDetailById: jest.fn(() => Promise.resolve([])),
+      },
+      auth: {
+        verifySecret: verifySecretMock,
       },
     },
   },
@@ -78,6 +83,7 @@ describe("Verify Passcode on Cards Details page", () => {
       dispatch: dispatchMock,
     };
   });
+
   test("Render passcode", async () => {
     const mockStore = configureStore();
     const dispatchMock = jest.fn();

--- a/src/ui/components/VerifyPasscode/VerifyPasscode.tsx
+++ b/src/ui/components/VerifyPasscode/VerifyPasscode.tsx
@@ -1,6 +1,5 @@
 import { IonModal } from "@ionic/react";
 import { useEffect, useState } from "react";
-import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
 import { i18n } from "../../../i18n";
 import { Alert } from "../Alert";
 import { ErrorMessage, MESSAGE_MILLISECONDS } from "../ErrorMessage";
@@ -12,6 +11,8 @@ import { PasscodeModule } from "../PasscodeModule";
 import { ResponsivePageLayout } from "../layout/ResponsivePageLayout";
 import "./VerifyPasscode.scss";
 import { VerifyPasscodeProps } from "./VerifyPasscode.types";
+import { Agent } from "../../../core/agent/agent";
+import { KeyStoreKeys } from "../../../core/storage";
 
 const VerifyPasscode = ({
   isOpen,
@@ -39,7 +40,8 @@ const VerifyPasscode = ({
     if (passcode.length < 6) {
       setPasscode(passcode + digit);
       if (passcode.length === 5) {
-        verifyPasscode(passcode + digit)
+        Agent.agent.auth
+          .verifySecret(KeyStoreKeys.APP_PASSCODE, passcode + digit)
           .then((verified) => {
             if (verified) {
               onVerify();
@@ -67,12 +69,6 @@ const VerifyPasscode = ({
       }, MESSAGE_MILLISECONDS);
     }
   }, [passcodeIncorrect]);
-
-  const verifyPasscode = async (pass: string) => {
-    const storedPass = await SecureStorage.get(KeyStoreKeys.APP_PASSCODE);
-    if (!storedPass) return false;
-    return storedPass === pass;
-  };
 
   const resetPasscode = () => {
     setOpenRecoveryAuth(true);

--- a/src/ui/components/VerifyPassword/VerifyPassword.test.tsx
+++ b/src/ui/components/VerifyPassword/VerifyPassword.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn();
+
 import { IonInput } from "@ionic/react";
 import { ionFireEvent } from "@ionic/react-test-utils";
 import { AnyAction, Store } from "@reduxjs/toolkit";
@@ -32,15 +34,10 @@ jest.mock("../../../core/agent/agent", () => ({
       basicStorage: {
         findById: jest.fn(),
       },
+      auth: {
+        verifySecret: verifySecretMock,
+      },
     },
-  },
-}));
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: () => jest.fn(),
-    delete: () => jest.fn(),
   },
 }));
 
@@ -115,6 +112,7 @@ describe("Verify Password", () => {
   });
 
   test("Verify failed", async () => {
+    verifySecretMock.mockResolvedValue(false);
     jest.spyOn(Agent.agent.basicStorage, "findById").mockResolvedValue(
       new BasicRecord({
         id: "id",
@@ -170,6 +168,7 @@ describe("Verify Password", () => {
   });
 
   test("Verify success", async () => {
+    verifySecretMock.mockResolvedValue(true);
     jest.spyOn(SecureStorage, "get").mockResolvedValue("1111");
     jest.spyOn(Agent.agent.basicStorage, "findById").mockResolvedValue(
       new BasicRecord({

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
@@ -66,16 +66,10 @@ jest.mock("../../../core/agent/agent", () => ({
       basicStorage: {
         deleteById: jest.fn(() => Promise.resolve()),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
-  },
-}));
-
-const getMock = jest.fn((arg: unknown) => Promise.resolve({ value: "111111" }));
-
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: (options: { key: string }) => getMock(options.key),
-    remove: jest.fn(),
   },
 }));
 

--- a/src/ui/pages/Connections/Connections.test.tsx
+++ b/src/ui/pages/Connections/Connections.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn();
+
 import { ionFireEvent } from "@ionic/react-test-utils";
 import { AnyAction, Store } from "@reduxjs/toolkit";
 import { fireEvent, render, waitFor } from "@testing-library/react";
@@ -29,6 +31,9 @@ jest.mock("../../../core/agent/agent", () => ({
         deleteStaleLocalConnectionById: () => deleteConnectionByIdMock(),
         getConnectionShortDetailById: jest.fn(() => Promise.resolve([])),
       },
+      auth: {
+        verifySecret: verifySecretMock,
+      },
     },
   },
 }));
@@ -39,13 +44,6 @@ jest.mock("react-qrcode-logo", () => {
     QRCode: () => <div></div>,
   };
 });
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: () => "111111",
-  },
-}));
 
 jest.mock("@ionic/react", () => {
   const { forwardRef } = jest.requireActual("react");
@@ -122,6 +120,8 @@ describe("Connections page", () => {
       ...mockStore(initialStateFull),
       dispatch: dispatchMock,
     };
+
+    verifySecretMock.mockResolvedValue(true);
   });
 
   test("Render connections page empty", async () => {
@@ -463,6 +463,8 @@ describe("Connections page from Credentials tab", () => {
       ...mockStore(initialStateFull),
       dispatch: dispatchMock,
     };
+
+    verifySecretMock.mockResolvedValue(true);
   });
 
   test("It allows to create an Identifier when no Identifiers are available", async () => {

--- a/src/ui/pages/CreatePassword/CreatePassword.test.tsx
+++ b/src/ui/pages/CreatePassword/CreatePassword.test.tsx
@@ -72,21 +72,19 @@ jest.mock("../../../core/agent/agent", () => ({
         createOrUpdateBasicRecord: (arg: unknown) =>
           createOrUpdateBasicRecordMock(arg),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+        storeSecret: jest.fn(),
+      },
     },
   },
 }));
 
-const secureStorageGetFunc = jest.fn((...arg: unknown[]) =>
-  Promise.resolve("Passssssss1@")
-);
-const secureStorageSetFunc = jest.fn();
 const secureStorageDeleteFunc = jest.fn();
 
 jest.mock("../../../core/storage", () => ({
   ...jest.requireActual("../../../core/storage"),
   SecureStorage: {
-    get: (...args: unknown[]) => secureStorageGetFunc(...args),
-    set: (...args: unknown[]) => secureStorageSetFunc(...args),
     delete: (...args: unknown[]) => secureStorageDeleteFunc(...args),
   },
 }));

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
@@ -113,15 +113,6 @@ jest.mock("../../components/CustomInput", () => ({
   },
 }));
 
-const secureStorageDeleteFunc = jest.fn();
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    delete: (...args: unknown[]) => secureStorageDeleteFunc(...args),
-  },
-}));
-
 describe("SSI agent page", () => {
   const mockStore = configureStore();
   const dispatchMock = jest.fn();

--- a/src/ui/pages/Credentials/Credentials.test.tsx
+++ b/src/ui/pages/Credentials/Credentials.test.tsx
@@ -43,6 +43,9 @@ jest.mock("../../../core/agent/agent", () => ({
         save: jest.fn(),
         createOrUpdateBasicRecord: () => Promise.resolve(),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
   },
 }));
@@ -51,13 +54,6 @@ jest.mock("@ionic/react", () => ({
   ...jest.requireActual("@ionic/react"),
   IonModal: ({ children, isOpen, ...props }: any) =>
     isOpen ? <div data-testid={props["data-testid"]}>{children}</div> : null,
-}));
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: () => "111111",
-  },
 }));
 
 const initialStateEmpty = {
@@ -196,7 +192,6 @@ describe("Creds Tab", () => {
   const dispatchMock = jest.fn();
 
   beforeEach(() => {
-    jest.resetAllMocks();
     const mockStore = configureStore();
     const dispatchMock = jest.fn();
 

--- a/src/ui/pages/Identifiers/Identifiers.test.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn();
+
 import { IonReactMemoryRouter } from "@ionic/react-router";
 import { AnyAction, Store } from "@reduxjs/toolkit";
 import {
@@ -61,14 +63,10 @@ jest.mock("../../../core/agent/agent", () => ({
         save: jest.fn(),
         createOrUpdateBasicRecord: () => Promise.resolve(),
       },
+      auth: {
+        verifySecret: verifySecretMock,
+      },
     },
-  },
-}));
-
-jest.mock("../../../core/storage", () => ({
-  ...jest.requireActual("../../../core/storage"),
-  SecureStorage: {
-    get: () => "111111",
   },
 }));
 
@@ -134,6 +132,8 @@ describe("Identifiers Tab", () => {
 
     store.dispatch(setIdentifiersCache([]));
     store.dispatch(setIdentifiersFilters(IdentifiersFilters.All));
+
+    verifySecretMock.mockResolvedValue(true);
   });
 
   test("Renders favourites in Identifiers", () => {

--- a/src/ui/pages/IncomingRequest/IncomingRequest.test.tsx
+++ b/src/ui/pages/IncomingRequest/IncomingRequest.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn().mockResolvedValue(true);
+
 import { mockIonicReact, waitForIonicReact } from "@ionic/react-test-utils";
 import { act } from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
@@ -18,12 +20,13 @@ mockIonicReact();
 
 const mockApprovalCallback = jest.fn((status: boolean) => status);
 
-const mockGet = jest.fn((arg: unknown) => Promise.resolve({ value: "111111" }));
-
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: (options: { key: string }) => mockGet(options.key),
-    set: jest.fn(),
+jest.mock("../../../core/agent/agent", () => ({
+  Agent: {
+    agent: {
+      auth: {
+        verifySecret: verifySecretMock,
+      },
+    },
   },
 }));
 
@@ -199,7 +202,10 @@ describe("Sign request", () => {
     await passcodeFiller(getByText, getByTestId, "1", 6);
 
     await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith(KeyStoreKeys.APP_PASSCODE);
+      expect(verifySecretMock).toHaveBeenCalledWith(
+        KeyStoreKeys.APP_PASSCODE,
+        "111111"
+      );
     });
 
     await waitFor(() => {

--- a/src/ui/pages/LockPage/LockPage.tsx
+++ b/src/ui/pages/LockPage/LockPage.tsx
@@ -4,7 +4,6 @@ import { Keyboard } from "@capacitor/keyboard";
 import i18n from "i18next";
 import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
-import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
 import { PublicRoutes, RoutePath } from "../../../routes/paths";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import { getBiometricsCacheCache } from "../../../store/reducers/biometricsCache";
@@ -35,6 +34,8 @@ import { usePrivacyScreen } from "../../hooks/privacyScreenHook";
 import { useBiometricAuth } from "../../hooks/useBiometricsHook";
 import "./LockPage.scss";
 import { showError } from "../../utils/error";
+import { Agent } from "../../../core/agent/agent";
+import { KeyStoreKeys } from "../../../core/storage";
 
 const LockPageContainer = () => {
   const pageId = "lock-page";
@@ -97,7 +98,10 @@ const LockPageContainer = () => {
     if (updatedPasscode.length <= 6) setPasscode(updatedPasscode);
 
     if (updatedPasscode.length === 6) {
-      const verified = await verifyPasscode(updatedPasscode);
+      const verified = await Agent.agent.auth.verifySecret(
+        KeyStoreKeys.APP_PASSCODE,
+        updatedPasscode
+      );
 
       if (verified) {
         await resetLoginAttempt();
@@ -115,14 +119,6 @@ const LockPageContainer = () => {
     if (passcode.length >= 1) {
       setPasscode(passcode.substring(0, passcode.length - 1));
     }
-  };
-
-  const verifyPasscode = async (pass: string) => {
-    const storedPass = await SecureStorage.get(KeyStoreKeys.APP_PASSCODE);
-    if (!storedPass) {
-      return false;
-    }
-    return storedPass === pass;
   };
 
   const handleBiometrics = async () => {

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -25,6 +25,9 @@ jest.mock("../../../../../core/agent/agent", () => ({
         getAllPeerConnectionMetadata: jest.fn(),
         deletePeerConnectionMetadataRecord: jest.fn(),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
   },
 }));
@@ -47,17 +50,6 @@ jest.mock("@ionic/react", () => ({
       {children}
     </div>
   ),
-}));
-
-jest.mock("../../../../../core/storage", () => ({
-  ...jest.requireActual("../../../../../core/storage"),
-  SecureStorage: {
-    get: (key: string) => {
-      return "111111";
-    },
-    remove: () => jest.fn(),
-    set: () => jest.fn(),
-  },
 }));
 
 const mockStore = configureStore();

--- a/src/ui/pages/Menu/components/Profile/Profile.test.tsx
+++ b/src/ui/pages/Menu/components/Profile/Profile.test.tsx
@@ -27,15 +27,6 @@ jest.mock("../../../../../core/agent/agent", () => ({
   },
 }));
 
-jest.mock("../../../../../core/storage", () => ({
-  ...jest.requireActual("../../../../../core/storage"),
-  SecureStorage: {
-    get: () => {
-      return "Frank";
-    },
-  },
-}));
-
 jest.mock("@ionic/react", () => ({
   ...jest.requireActual("@ionic/react"),
   IonModal: ({ children }: { children: any }) => children,

--- a/src/ui/pages/Menu/components/Settings/Settings.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.test.tsx
@@ -32,15 +32,6 @@ jest.mock("@ionic/react", () => ({
   ),
 }));
 
-jest.mock("../../../../../core/storage", () => ({
-  ...jest.requireActual("../../../../../core/storage"),
-  SecureStorage: {
-    get: (key: string) => {
-      return "111111";
-    },
-  },
-}));
-
 const browserMock = jest.fn(({ link }: { link: string }) =>
   Promise.resolve(link)
 );
@@ -91,15 +82,14 @@ jest.mock("../../../../../core/agent/agent", () => ({
         update: jest.fn(),
         createOrUpdateBasicRecord: jest.fn(),
       },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
   },
 }));
 
 describe("Settings page", () => {
-  beforeEach(() => {
-    jest.resetModules();
-  });
-
   test("Renders Settings page", () => {
     const { getByText } = render(
       <Provider store={store}>

--- a/src/ui/pages/Menu/components/Settings/components/ChangePin/ChangePin.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/components/ChangePin/ChangePin.test.tsx
@@ -1,14 +1,16 @@
+const verifySecretMock = jest.fn();
+const storeSecretMock = jest.fn();
+
 import { BiometryType } from "@aparajita/capacitor-biometric-auth/dist/esm/definitions";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { Provider } from "react-redux";
-import { KeyStoreKeys, SecureStorage } from "../../../../../../../core/storage";
+import { KeyStoreKeys } from "../../../../../../../core/storage";
 import EN_TRANSLATIONS from "../../../../../../../locales/en/en.json";
 import { store } from "../../../../../../../store";
 import { passcodeFiller } from "../../../../../../utils/passcodeFiller";
 import { ChangePin } from "./ChangePin";
 
-const setKeyStoreSpy = jest.spyOn(SecureStorage, "set").mockResolvedValue();
 const mockSetIsOpen = jest.fn();
 
 jest.mock("../../../../../../../core/agent/agent", () => ({
@@ -19,6 +21,10 @@ jest.mock("../../../../../../../core/agent/agent", () => ({
         save: jest.fn(),
         update: jest.fn(),
         createOrUpdateBasicRecord: jest.fn(),
+      },
+      auth: {
+        verifySecret: verifySecretMock,
+        storeSecret: storeSecretMock,
       },
     },
   },
@@ -63,6 +69,7 @@ describe("ChangePin Modal", () => {
       handleBiometricAuth: jest.fn(() => Promise.resolve(true)),
       setBiometricsIsEnabled: jest.fn(),
     }));
+    verifySecretMock.mockResolvedValue(false);
   });
 
   test("Renders ChangePin Modal and initial UI components", async () => {
@@ -171,7 +178,7 @@ describe("ChangePin Modal", () => {
     await passcodeFiller(getByText, getByTestId, "1", 6);
 
     await waitFor(() => {
-      expect(setKeyStoreSpy).toBeCalledWith(
+      expect(storeSecretMock).toBeCalledWith(
         KeyStoreKeys.APP_PASSCODE,
         "111111"
       );

--- a/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
@@ -7,7 +7,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { Agent } from "../../../../../../../core/agent/agent";
 import { BasicRecord } from "../../../../../../../core/agent/records";
-import { KeyStoreKeys } from "../../../../../../../core/storage";
 import TRANSLATIONS from "../../../../../../../locales/en/en.json";
 import { RoutePath } from "../../../../../../../routes";
 import { CustomInputProps } from "../../../../../../components/CustomInput/CustomInput.types";
@@ -20,11 +19,6 @@ const deletePasswordMock = jest.fn();
 jest.mock("../../../../../../../core/storage", () => ({
   ...jest.requireActual("../../../../../../../core/storage"),
   SecureStorage: {
-    get: jest.fn((type: KeyStoreKeys) => {
-      if (type === KeyStoreKeys.APP_OP_PASSWORD)
-        return Promise.resolve("Password@123");
-      return Promise.resolve("111111");
-    }),
     delete: () => deletePasswordMock(),
   },
 }));
@@ -37,6 +31,9 @@ jest.mock("../../../../../../../core/agent/agent", () => ({
         save: jest.fn(),
         update: jest.fn(),
         createOrUpdateBasicRecord: jest.fn(),
+      },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
       },
     },
   },

--- a/src/ui/pages/Menu/components/Settings/components/RecoverySeedPhrase/RecoverySeedPhrase.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/components/RecoverySeedPhrase/RecoverySeedPhrase.test.tsx
@@ -3,28 +3,19 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { KeyStoreKeys } from "../../../../../../../core/storage";
 import TRANSLATIONS from "../../../../../../../locales/en/en.json";
 import { RoutePath } from "../../../../../../../routes";
 import { OperationType } from "../../../../../../globals/types";
 import { passcodeFiller } from "../../../../../../utils/passcodeFiller";
 import { RecoverySeedPhrase } from "./RecoverySeedPhrase";
 
-jest.mock("../../../../../../../core/storage", () => ({
-  ...jest.requireActual("../../../../../../../core/storage"),
-  SecureStorage: {
-    get: jest.fn((type: KeyStoreKeys) => {
-      if (type === KeyStoreKeys.APP_OP_PASSWORD)
-        return Promise.resolve("Password@123");
-      return Promise.resolve("111111");
-    }),
-  },
-}));
-
 jest.mock("../../../../../../../core/agent/agent", () => ({
   Agent: {
     agent: {
       getMnemonic: jest.fn(() => Promise.resolve("")),
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
     },
   },
 }));

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn().mockResolvedValue(true);
+
 import { IonReactMemoryRouter } from "@ionic/react-router";
 import { ionFireEvent, mockIonicReact } from "@ionic/react-test-utils";
 import { fireEvent, render, waitFor } from "@testing-library/react";
@@ -24,18 +26,6 @@ import { ACDC } from "../CredentialRequest.types";
 import { ChooseCredential } from "./ChooseCredential";
 
 mockIonicReact();
-
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: jest.fn((options: { key: string }) => {
-      if (options.key === KeyStoreKeys.APP_PASSCODE) {
-        return { value: "111111" };
-      }
-      return null;
-    }),
-    set: jest.fn(),
-  },
-}));
 
 const deleteNotificationMock = jest.fn((id: string) => Promise.resolve(id));
 const offerAcdcFromApplyMock = jest.fn(
@@ -68,6 +58,9 @@ jest.mock("../../../../../../core/agent/agent", () => ({
       },
       connections: {
         getConnectionShortDetailById: jest.fn(),
+      },
+      auth: {
+        verifySecret: verifySecretMock,
       },
     },
   },
@@ -469,7 +462,10 @@ describe("Credential request - choose request", () => {
     passcodeFiller(getByText, getByTestId, "1", 6);
 
     await waitFor(() => {
-      expect(SecureStorage.get).toHaveBeenCalledWith(KeyStoreKeys.APP_PASSCODE);
+      expect(verifySecretMock).toHaveBeenCalledWith(
+        KeyStoreKeys.APP_PASSCODE,
+        "111111"
+      );
     });
 
     await waitFor(() => {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -1,9 +1,4 @@
-import {
-  fireEvent,
-  getAllByTestId,
-  render,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -21,14 +16,6 @@ jest.mock("@ionic/react", () => ({
     isOpen ? <div data-testid={props["data-testid"]}>{children}</div> : null,
 }));
 
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: jest.fn((options: { key: string }) => {
-      return Promise.resolve({ value: "111111" });
-    }),
-  },
-}));
-
 const deleteNotificationMock = jest.fn((id: string) => Promise.resolve(id));
 const joinMultisigOfferMock = jest.fn();
 
@@ -42,6 +29,9 @@ jest.mock("../../../../../../core/agent/agent", () => ({
       ipexCommunications: {
         joinMultisigOffer: () => joinMultisigOfferMock(),
         getOfferedCredentialSaid: jest.fn(() => "cred-id"),
+      },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
       },
     },
   },

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/MultiSigRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/MultiSigRequest.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn().mockResolvedValue(true);
+
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -18,15 +20,6 @@ import { KeyStoreKeys } from "../../../../../core/storage";
 import { passcodeFiller } from "../../../../utils/passcodeFiller";
 
 mockIonicReact();
-
-const mockGet = jest.fn((arg: unknown) => Promise.resolve({ value: "111111" }));
-
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: (options: { key: string }) => mockGet(options.key),
-    set: jest.fn(),
-  },
-}));
 
 const multisigIcpDetails = {
   sender: {
@@ -64,6 +57,9 @@ jest.mock("../../../../../core/agent/agent", () => ({
       multiSigs: {
         getMultisigIcpDetails: () => getMultiSignMock(),
         joinGroup: (...params: unknown[]) => joinGroupMock(...params),
+      },
+      auth: {
+        verifySecret: verifySecretMock,
       },
     },
   },
@@ -180,7 +176,10 @@ describe("Multisign request", () => {
     passcodeFiller(getByText, getByTestId, "1", 6);
 
     await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith(KeyStoreKeys.APP_PASSCODE);
+      expect(verifySecretMock).toHaveBeenCalledWith(
+        KeyStoreKeys.APP_PASSCODE,
+        "111111"
+      );
     });
 
     await waitFor(() => {

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.test.tsx
@@ -1,3 +1,5 @@
+const verifySecretMock = jest.fn().mockResolvedValue(true);
+
 import { BiometryType } from "@aparajita/capacitor-biometric-auth";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
@@ -20,15 +22,6 @@ import { passcodeFillerWithAct } from "../../../../utils/passcodeFiller";
 import { ReceiveCredential } from "./ReceiveCredential";
 
 jest.useFakeTimers();
-
-const mockGet = jest.fn((arg: unknown) => Promise.resolve({ value: "111111" }));
-
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: (options: { key: string }) => mockGet(options.key),
-    set: jest.fn(),
-  },
-}));
 
 const deleteNotificationMock = jest.fn((id: string) => Promise.resolve(id));
 const admitAcdcFromGrantMock = jest.fn(
@@ -60,6 +53,9 @@ jest.mock("../../../../../core/agent/agent", () => ({
       },
       connections: {
         getOobi: jest.fn(),
+      },
+      auth: {
+        verifySecret: verifySecretMock,
       },
     },
   },
@@ -207,7 +203,10 @@ describe("Receive credential", () => {
     await passcodeFillerWithAct(getByText, getByTestId, "1", 6);
 
     await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith(KeyStoreKeys.APP_PASSCODE);
+      expect(verifySecretMock).toHaveBeenCalledWith(
+        KeyStoreKeys.APP_PASSCODE,
+        "111111"
+      );
     });
 
     await waitFor(() => {

--- a/src/ui/pages/WalletConnect/WalletConnect.test.tsx
+++ b/src/ui/pages/WalletConnect/WalletConnect.test.tsx
@@ -67,12 +67,6 @@ jest.mock("@ionic/react", () => ({
   ),
 }));
 
-jest.mock("@evva/capacitor-secure-storage-plugin", () => ({
-  SecureStoragePlugin: {
-    get: (options: { key: string }) => Promise.resolve({ value: "111111" }),
-  },
-}));
-
 describe("Wallet Connect Stage One", () => {
   const initialState = {
     stateCache: {


### PR DESCRIPTION
## Description

Originally we decided against this as both are stored encrypted by the secure enclave or TEE. The oversight is that both need to be in memory for login, so an attacker attaching a debugger etc on a rooted device can read the values.

To not introduce too much complexity in the UI, this is done by the auth service as it originally should have been done. I would like to move more functionality too going forward. For example, the seed should not be pulled into memory before initial login.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1848)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).
