### PR TITLE
fix(ui): If I cancel while enabling biometrics, it still gets enabled

### DIFF
--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -17,7 +17,10 @@ import {
   AndroidSettings,
   IOSSettings,
 } from "capacitor-native-settings";
-import { BiometryErrorType } from "@aparajita/capacitor-biometric-auth";
+import {
+  BiometryError,
+  BiometryErrorType,
+} from "@aparajita/capacitor-biometric-auth";
 import { Browser } from "@capacitor/browser";
 import { i18n } from "../../../../../i18n";
 import pJson from "../../../../../../package.json";
@@ -149,7 +152,7 @@ const Settings = ({ switchView }: SettingsProps) => {
   const biometricAuth = async () => {
     try {
       const result = await handleBiometricAuth();
-      if (result) handleToggleBiometricAuth();
+      if (result === true) handleToggleBiometricAuth();
     } catch (e) {
       showError("Unable to enable/disable biometric auth", e, dispatch);
     }


### PR DESCRIPTION
## Description

Fix issue about biometrics still enable after user cancel

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1896)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/16904208-f765-4b40-adb6-07c3cfa05d0b

