### PR TITLE
feat(core): idempotent processing of notifications and operations

### DIFF
--- a/.github/workflows/gh-verify-pr.yaml
+++ b/.github/workflows/gh-verify-pr.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: Run unit tests
       env:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ In this section, you'll find detailed PDF documents outlining the various user f
 # Getting Started
 
 ## Requirements
-- Node.js: Version 18.20.4.
+- Node.js: Version 20.
 - npm: Compatible with the Node.js version.
 - Xcode: For iOS emulation (latest version recommended).
 - Android Studio: For Android emulation (latest version recommended).

--- a/src/core/__fixtures__/agent/keriaNotificationFixtures.ts
+++ b/src/core/__fixtures__/agent/keriaNotificationFixtures.ts
@@ -1,5 +1,6 @@
 import { ExchangeRoute, NotificationRoute } from "../../agent/agent.types";
 import { CredentialStatus } from "../../agent/services/credentialService.types";
+import { MultiSigRoute } from "../../agent/services/multiSig.types";
 
 const credentialMetadataMock = {
   type: "CredentialMetadataRecord",
@@ -201,6 +202,10 @@ const multisigExnOfferForPresenting = {
 
 const multisigExnApplyForPresenting = {
   exn: {
+    r: MultiSigRoute.EXN,
+    a: {
+      gid: "EE8_Xc0ZUh_sUJLtmBpVSEr-RFS2mRUIpFyL-pmvtPvP",
+    },
     e: {
       exn: {
         p: "EAe_JgQ636ic-k34aUQMjDFPp6Zd350gEsQA6HePBU5W",
@@ -254,7 +259,7 @@ const multisigExnGrant = {
 
 const notificationMultisigRpyProp = {
   i: "string",
-  dt: "string",
+  dt: "2023-06-12T14:07:53.224866+00:00",
   r: false,
   a: {
     r: NotificationRoute.MultiSigRpy,
@@ -265,7 +270,7 @@ const notificationMultisigRpyProp = {
 
 const notificationMultisigExnProp = {
   i: "string",
-  dt: "string",
+  dt: "2023-06-12T14:07:53.224866+00:00",
   r: false,
   a: {
     r: NotificationRoute.MultiSigExn,
@@ -276,7 +281,7 @@ const notificationMultisigExnProp = {
 
 const notificationMultisigIcpProp = {
   i: "string",
-  dt: "string",
+  dt: "2023-06-12T14:07:53.224866+00:00",
   r: false,
   a: {
     r: NotificationRoute.MultiSigIcp,
@@ -287,7 +292,7 @@ const notificationMultisigIcpProp = {
 
 const notificationIpexGrantProp = {
   i: "string",
-  dt: "string",
+  dt: "2023-06-12T14:07:53.224866+00:00",
   r: false,
   a: {
     r: NotificationRoute.ExnIpexGrant,
@@ -309,7 +314,7 @@ const notificationIpexAgreeProp = {
 
 const notificationIpexApplyProp = {
   i: "string",
-  dt: "string",
+  dt: "2023-06-12T14:07:53.224866+00:00",
   r: false,
   a: {
     r: NotificationRoute.ExnIpexApply,
@@ -335,7 +340,7 @@ const credentialStateIssued = {
 
 const notificationIpexOfferProp = {
   i: "string",
-  dt: "string",
+  dt: "2023-06-12T14:07:53.224866+00:00",
   r: false,
   a: {
     r: NotificationRoute.ExnIpexOffer,
@@ -351,6 +356,36 @@ const groupIdentifierMetadataRecord = {
   multisigManageAid: "EAL7pX9Hklc_iq7pkVYSjAilCfQX3sr5RbX76AxYs2UH",
   createdAt: new Date(),
   updatedAt: new Date(),
+};
+
+const hab = {
+  name: "00:Display name",
+  prefix: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_z8",
+  state: {
+    vn: [1, 0],
+    i: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_z8",
+    s: "0",
+    p: "",
+    d: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_z8",
+    f: "0",
+    dt: "2024-08-09T07:23:52.839894+00:00",
+    et: "icp",
+    kt: "1",
+    k: ["DM_vaN_p23a0DpK7brjTgaVWvIuL84G5UwNxY6M-Mv8Y"],
+    nt: "1",
+    n: ["EOvYVOWhxNxjlm5NYaxX0ivrZ7TqU9syRZPQdU1Yykzk"],
+    bt: "3",
+    b: [],
+    c: [],
+    ee: {
+      s: "0",
+      d: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_z8",
+      br: [],
+      ba: [],
+    },
+    di: "",
+  },
+  icp_dt: "2024-08-09T07:23:52.839894+00:00",
 };
 
 export {
@@ -372,4 +407,5 @@ export {
   credentialStateIssued,
   notificationIpexOfferProp,
   groupIdentifierMetadataRecord,
+  hab,
 };

--- a/src/core/__fixtures__/agent/multiSigFixtures.ts
+++ b/src/core/__fixtures__/agent/multiSigFixtures.ts
@@ -38,6 +38,7 @@ const multisigMetadataRecord = {
 } as IdentifierMetadataRecord;
 
 const getMemberIdentifierResponse = {
+  name: "00:groupid:groupName",
   prefix: memberMetadataRecord.id,
   state: {
     vn: [1, 0],

--- a/src/core/__fixtures__/agent/multiSigFixtures.ts
+++ b/src/core/__fixtures__/agent/multiSigFixtures.ts
@@ -67,6 +67,7 @@ const getMemberIdentifierResponse = {
 };
 
 const getMultisigIdentifierResponse = {
+  name: "00:group",
   prefix: "ELWFo-DV4GujnvcwwIbzTzjc-nIf0ijv6W1ecajvQYBY",
   state: {
     vn: [1, 0],
@@ -370,7 +371,7 @@ const mHab = {
 
 const multisigExnIpexGrantSerder = {
   kind: "JSON",
-  raw: '{"v":"KERI10JSON00025f_","t":"exn","d":"EFnDzHLeULKSm_jbQSIN427yWWFr82OBkkxg3iUf2FUW","i":"EGUORQAs0r1mup1OmX1H23PITDV7td-o2XGdMVL6lmmk","p":"","dt":"2024-08-02T03:53:30.133000+00:00","r":"/multisig/exn","q":{},"a":{"gid":"EPIKswKD9AiVxIqU4QLn14qpNuiAfgVGzoK-HVU0znjC"},"e":{"exn":{"v":"KERI10JSON000111_","t":"exn","d":"EMTArfbjevIfB-fbxzsepKO35RWHN2gQxTTU5Lov2Dld","i":"EPIKswKD9AiVxIqU4QLn14qpNuiAfgVGzoK-HVU0znjC","p":"EH-_9IgodejkwXi2Hw--A53rVYcO6bDYnBrbpCId8LOu","dt":"2024-08-02T03:53:29.400000+00:00","r":"/ipex/admit","q":{},"a":{"m":""},"e":{}},"d":"ECxCLDUf8A1y62wf7YkWAcj5RN-KVzNaxRefzgE7oIjq"}}',
+  raw: "{\"v\":\"KERI10JSON00025f_\",\"t\":\"exn\",\"d\":\"EFnDzHLeULKSm_jbQSIN427yWWFr82OBkkxg3iUf2FUW\",\"i\":\"EGUORQAs0r1mup1OmX1H23PITDV7td-o2XGdMVL6lmmk\",\"p\":\"\",\"dt\":\"2024-08-02T03:53:30.133000+00:00\",\"r\":\"/multisig/exn\",\"q\":{},\"a\":{\"gid\":\"EPIKswKD9AiVxIqU4QLn14qpNuiAfgVGzoK-HVU0znjC\"},\"e\":{\"exn\":{\"v\":\"KERI10JSON000111_\",\"t\":\"exn\",\"d\":\"EMTArfbjevIfB-fbxzsepKO35RWHN2gQxTTU5Lov2Dld\",\"i\":\"EPIKswKD9AiVxIqU4QLn14qpNuiAfgVGzoK-HVU0znjC\",\"p\":\"EH-_9IgodejkwXi2Hw--A53rVYcO6bDYnBrbpCId8LOu\",\"dt\":\"2024-08-02T03:53:29.400000+00:00\",\"r\":\"/ipex/admit\",\"q\":{},\"a\":{\"m\":\"\"},\"e\":{}},\"d\":\"ECxCLDUf8A1y62wf7YkWAcj5RN-KVzNaxRefzgE7oIjq\"}}",
   ked: {
     v: "KERI10JSON00066c_",
     t: "exn",

--- a/src/core/agent/agent.test.ts
+++ b/src/core/agent/agent.test.ts
@@ -303,7 +303,6 @@ describe("Recovery of DB from cloud sync", () => {
 
     await agent.recoverKeriaAgent(mockSeedPhrase, mockConnectUrl);
 
-    const now = new Date();
     expect(SignifyClient).toHaveBeenCalledWith(
       mockConnectUrl,
       expectedBran,
@@ -318,14 +317,12 @@ describe("Recovery of DB from cloud sync", () => {
     expect(mockSignifyClient.connect).toHaveBeenCalled();
     expect(
       mockBasicStorageService.createOrUpdateBasicRecord
-    ).toHaveBeenCalledWith({
-      _tags: {},
-      content: { syncing: false },
-      createdAt: now,
-      id: MiscRecordId.CLOUD_RECOVERY_STATUS,
-      type: "BasicRecord",
-      updatedAt: undefined,
-    });
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: MiscRecordId.CLOUD_RECOVERY_STATUS,
+        content: { syncing: false },
+      })
+    );
     expect(SecureStorage.set).toHaveBeenCalledWith(
       KeyStoreKeys.SIGNIFY_BRAN,
       expectedBran

--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -165,17 +165,17 @@ interface AgentUrls {
 
 enum NotificationRoute {
   // "Real" notifications from KERIA
-  ExnIpexGrant = "/exn/ipex/grant",
-  MultiSigExn = "/multisig/exn",
   MultiSigIcp = "/multisig/icp",
   MultiSigRot = "/multisig/rot",
+  MultiSigExn = "/multisig/exn",
   MultiSigRpy = "/multisig/rpy",
   ExnIpexApply = "/exn/ipex/apply",
-  ExnIpexAgree = "/exn/ipex/agree",
   ExnIpexOffer = "/exn/ipex/offer",
+  ExnIpexAgree = "/exn/ipex/agree",
+  ExnIpexGrant = "/exn/ipex/grant",
   // Notifications from our wallet to give further feedback to the user
   LocalAcdcRevoked = "/local/acdc/revoked",
-  LocalSign = "/local/signrequest/",
+  LocalSign = "/local/signrequest",
 }
 
 enum ExchangeRoute {

--- a/src/core/agent/records/credentialMetadataRecord.test.ts
+++ b/src/core/agent/records/credentialMetadataRecord.test.ts
@@ -1,4 +1,4 @@
-import { memberIdentifierRecord } from "../../__fixtures__/agent/multSigFixtures";
+import { memberIdentifierRecord } from "../../__fixtures__/agent/multiSigFixtures";
 import { CredentialStatus } from "../services/credentialService.types";
 import { IdentifierType } from "../services/identifier.types";
 import { CredentialMetadataRecord } from "./credentialMetadataRecord";

--- a/src/core/agent/records/credentialStorage.test.ts
+++ b/src/core/agent/records/credentialStorage.test.ts
@@ -1,4 +1,4 @@
-import { memberIdentifierRecord } from "../../__fixtures__/agent/multSigFixtures";
+import { memberIdentifierRecord } from "../../__fixtures__/agent/multiSigFixtures";
 import { CredentialStatus } from "../services/credentialService.types";
 import { IdentifierType } from "../services/identifier.types";
 import { CredentialMetadataRecord } from "./credentialMetadataRecord";

--- a/src/core/agent/services/connectionService.test.ts
+++ b/src/core/agent/services/connectionService.test.ts
@@ -650,6 +650,9 @@ describe("Connection service of agent", () => {
   test("should update KERIA contact directly if waiting for completion", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     jest.spyOn(Date.prototype, "getTime").mockReturnValueOnce(0);
+    contactGetMock.mockRejectedValueOnce(
+      new Error("Not Found - 404 - not found")
+    );
 
     await connectionService.resolveOobi(
       `${oobiPrefix}test?name=alias&groupId=1234`,

--- a/src/core/agent/services/connectionService.ts
+++ b/src/core/agent/services/connectionService.ts
@@ -257,8 +257,10 @@ class ConnectionService extends AgentService {
           throw error;
         }
       });
+
     const notes: Array<ConnectionNoteDetails> = [];
     const historyItems: Array<ConnectionHistoryItem> = [];
+
     Object.keys(connection).forEach((key) => {
       if (
         key.startsWith(KeriaContactKeyPrefix.CONNECTION_NOTE) &&
@@ -485,26 +487,19 @@ class ConnectionService extends AgentService {
         const groupCreationId = new URL(url).searchParams.get("groupId") ?? "";
         const createdAt = new Date((operation.response as State).dt);
 
-        const updateContact = async () => {
-          await signifyClient.update(connectionId, {
-            alias,
-            groupCreationId,
-            createdAt,
-            oobi: url,
-          });
-        };
-
         try {
-          const contact = await signifyClient.get(connectionId);
-          if (!contact) {
-            await updateContact();
-          }
+          await signifyClient.get(connectionId);
         } catch (error) {
           if (
             error instanceof Error &&
             /404/gi.test(error.message.split(" - ")[1])
           ) {
-            await updateContact();
+            await signifyClient.update(connectionId, {
+              alias,
+              groupCreationId,
+              createdAt,
+              oobi: url,
+            });
           } else {
             throw error;
           }

--- a/src/core/agent/services/credentialService.test.ts
+++ b/src/core/agent/services/credentialService.test.ts
@@ -5,7 +5,7 @@ import { CoreEventEmitter } from "../event";
 import { Agent } from "../agent";
 import { CredentialStatus } from "./credentialService.types";
 import { IdentifierType } from "./identifier.types";
-import { memberIdentifierRecord } from "../../__fixtures__/agent/multSigFixtures";
+import { memberIdentifierRecord } from "../../__fixtures__/agent/multiSigFixtures";
 import { EventTypes } from "../event.types";
 
 const identifiersListMock = jest.fn();

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -1403,7 +1403,9 @@ describe("Single sig service of agent", () => {
         done: true,
       }),
     });
+
     await identifierService.rotateIdentifier(identifierId);
+
     expect(rotateIdentifierMock).toHaveBeenCalledWith(identifierId);
   });
 
@@ -1413,6 +1415,7 @@ describe("Single sig service of agent", () => {
       .fn()
       .mockResolvedValue(keriMetadataRecord);
     getIdentifiersMock.mockResolvedValue(identifierStateKeria);
+
     await expect(
       identifierService.getSigner(keriMetadataRecord.id)
     ).rejects.toThrowError(IdentifierService.FAILED_TO_OBTAIN_KEY_MANAGER);
@@ -1429,6 +1432,7 @@ describe("Single sig service of agent", () => {
       await identifierService.getSigner(keriMetadataRecord.id)
     ).toStrictEqual(mockSigner);
   });
+
   test("getIdentifier should throw an error when KERIA is offline", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(false);
     await expect(identifierService.getIdentifier("id")).rejects.toThrowError(

--- a/src/core/agent/services/ipexCommunicationService.test.ts
+++ b/src/core/agent/services/ipexCommunicationService.test.ts
@@ -41,13 +41,14 @@ import {
   gHab,
   mHab,
   memberIdentifierRecord,
-} from "../../__fixtures__/agent/multSigFixtures";
+} from "../../__fixtures__/agent/multiSigFixtures";
 import {
   ConnectionHistoryType,
   KeriaContactKeyPrefix,
 } from "./connectionService.types";
 import { MultiSigRoute } from "./multiSig.types";
 import { NotificationRecord } from "../records";
+import { StorageMessage } from "../../storage/storage.types";
 
 const notificationStorage = jest.mocked({
   open: jest.fn(),
@@ -151,7 +152,6 @@ const ipexSubmitOfferMock = jest.fn().mockResolvedValue({
 const ipexSubmitGrantMock = jest
   .fn()
   .mockResolvedValue({ name: "opName", done: true });
-const deleteNotificationMock = jest.fn((id: string) => Promise.resolve(id));
 const ipexSubmitAdmitMock = jest.fn().mockResolvedValue({
   name: "opName",
   done: true,
@@ -279,6 +279,7 @@ const agentServicesProps = {
 
 jest.mock("../../../core/agent/agent", () => ({
   Agent: {
+    MISSING_DATA_ON_KERIA: "Missing data error msg mock",
     agent: {},
   },
 }));
@@ -307,7 +308,7 @@ beforeAll(() => {
   originalFetch = global.fetch;
   global.fetch = jest.fn().mockResolvedValue({
     text: () =>
-      '{"v":"KERI10JSON00012b_","t":"icp","d":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"0","kt":"1","k":["DGKzvhMMz2_MYhXyV5lGso_akvBYpGnOG5fTD299IsmO"],"nt":"1","n":["EBhg4MS4f4GZpuNZxk1D4mln9sv9l30rbtsk17AVOEmh"],"bt":"0","b":[],"c":[],"a":[]}-VAn-AABAADt-Cs8HoN9KBS5Kk23JCAaJzOl1InvbZ4FT0AQ0muKe6pSr8QvUJNNFTUImZg8XtBFqT75AY184rX3mKPKKgYI-EAB0AAAAAAAAAAAAAAAAAAAAAAA1AAG2025-01-21T13c24c58d219360p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"1","p":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","a":[{"i":"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l","s":"0","d":"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l"}]}-VAn-AABAADGIyEdPqQ4wJw6KWgFOF3guadzJYWTzy9EjDbxqnBEBmUIiGquNZvNtk--gDOYcOf_EsgIsmfZ8jwIvP0xICgL-EAB0AAAAAAAAAAAAAAAAAAAAAAB1AAG2025-01-21T13c24c59d693615p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"2","p":"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL","a":[{"i":"EMcWk38kBLvGdKH2b93HMujB_Xx5-ugwD-vrQJVVIJIl","s":"0","d":"EIlV2FfP39_0EOLUKDi2_ljF9FMty8OCp9myBepidVij"}]}-VAn-AABAACDrd4dm-E3OT2IlRwu4A3M7OzLkOgsoYi2-FPfS9Tmwr3awoCP2R-718qVHHUPNCb0MsnzQ2rTqVnNEw0QLWUB-EAB0AAAAAAAAAAAAAAAAAAAAAAC1AAG2025-01-21T13c47c06d452176p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"3","p":"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG","a":[{"i":"EDR-8z0CviOyrntUK3pyabMTiIuKn0AXGhQvD0C12gkX","s":"0","d":"EGCPj1fDEsyLgRAXwDoD9qrX6lJkwxXfBx0XNoDHtMLl"}]}-VAn-AABAAD6qIPXPrbqhKNPDRuU91_-EzQi01V53f1RFw0AV1sMe4JBjQmOdIwn4-FW88Lo-oht6e7C7sObbgk3-aJbQS4H-EAB0AAAAAAAAAAAAAAAAAAAAAAD1AAG2025-01-21T14c03c51d890362p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"4","p":"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S","a":[{"i":"EGsSqpbkJ-0SQnhyS-1FxNChZ7p1NV6yTXPPHIdyvjkZ","s":"0","d":"EMNJNkHlDqyrOHWbafUGPpHVrvvj5VbrCZML_ZgXk-Rk"}]}-VAn-AABAAAVj_8Zldpds_naKbRyuIOef3RKABaF23AHjkEKfc_Gb2j1559uY6NA8BV6ZmCKQU1_mpJbLbtaBMes-Oub2yUL-EAB0AAAAAAAAAAAAAAAAAAAAAAE1AAG2025-01-21T14c11c23d141088p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EC0Gh5X0JGSEkhUllR5sINwapxeAzYoKOWwP9UU7KdLn","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"5","p":"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx","a":[{"i":"ENMi3aqTIgCSuXROeMywH7VFuUD1-ubK3EMlumKkRkc7","s":"0","d":"EKdvQCM1oSTgjcPezvOw2YanOe8Wdi6wkbViE6vHpEjg"}]}-VAn-AABAABAaL6bwARu41XPQHGnHXuxmvPrIPP8vkghXhQbOTd07xdRZ5X2_kjMXu4UsHNyQcR7mNOht0kPeUPmafGx23EP-EAB0AAAAAAAAAAAAAAAAAAAAAAF1AAG2025-01-21T14c14c51d268032p00c00{"v":"KERI10JSON00012b_","t":"icp","d":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"0","kt":"1","k":["DGKzvhMMz2_MYhXyV5lGso_akvBYpGnOG5fTD299IsmO"],"nt":"1","n":["EBhg4MS4f4GZpuNZxk1D4mln9sv9l30rbtsk17AVOEmh"],"bt":"0","b":[],"c":[],"a":[]}-VAn-AABAADt-Cs8HoN9KBS5Kk23JCAaJzOl1InvbZ4FT0AQ0muKe6pSr8QvUJNNFTUImZg8XtBFqT75AY184rX3mKPKKgYI-EAB0AAAAAAAAAAAAAAAAAAAAAAA1AAG2025-01-21T13c24c58d219360p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"1","p":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","a":[{"i":"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l","s":"0","d":"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l"}]}-VAn-AABAADGIyEdPqQ4wJw6KWgFOF3guadzJYWTzy9EjDbxqnBEBmUIiGquNZvNtk--gDOYcOf_EsgIsmfZ8jwIvP0xICgL-EAB0AAAAAAAAAAAAAAAAAAAAAAB1AAG2025-01-21T13c24c59d693615p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"2","p":"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL","a":[{"i":"EMcWk38kBLvGdKH2b93HMujB_Xx5-ugwD-vrQJVVIJIl","s":"0","d":"EIlV2FfP39_0EOLUKDi2_ljF9FMty8OCp9myBepidVij"}]}-VAn-AABAACDrd4dm-E3OT2IlRwu4A3M7OzLkOgsoYi2-FPfS9Tmwr3awoCP2R-718qVHHUPNCb0MsnzQ2rTqVnNEw0QLWUB-EAB0AAAAAAAAAAAAAAAAAAAAAAC1AAG2025-01-21T13c47c06d452176p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"3","p":"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG","a":[{"i":"EDR-8z0CviOyrntUK3pyabMTiIuKn0AXGhQvD0C12gkX","s":"0","d":"EGCPj1fDEsyLgRAXwDoD9qrX6lJkwxXfBx0XNoDHtMLl"}]}-VAn-AABAAD6qIPXPrbqhKNPDRuU91_-EzQi01V53f1RFw0AV1sMe4JBjQmOdIwn4-FW88Lo-oht6e7C7sObbgk3-aJbQS4H-EAB0AAAAAAAAAAAAAAAAAAAAAAD1AAG2025-01-21T14c03c51d890362p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"4","p":"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S","a":[{"i":"EGsSqpbkJ-0SQnhyS-1FxNChZ7p1NV6yTXPPHIdyvjkZ","s":"0","d":"EMNJNkHlDqyrOHWbafUGPpHVrvvj5VbrCZML_ZgXk-Rk"}]}-VAn-AABAAAVj_8Zldpds_naKbRyuIOef3RKABaF23AHjkEKfc_Gb2j1559uY6NA8BV6ZmCKQU1_mpJbLbtaBMes-Oub2yUL-EAB0AAAAAAAAAAAAAAAAAAAAAAE1AAG2025-01-21T14c11c23d141088p00c00{"v":"KERI10JSON00013a_","t":"ixn","d":"EC0Gh5X0JGSEkhUllR5sINwapxeAzYoKOWwP9UU7KdLn","i":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","s":"5","p":"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx","a":[{"i":"ENMi3aqTIgCSuXROeMywH7VFuUD1-ubK3EMlumKkRkc7","s":"0","d":"EKdvQCM1oSTgjcPezvOw2YanOe8Wdi6wkbViE6vHpEjg"}]}-VAn-AABAABAaL6bwARu41XPQHGnHXuxmvPrIPP8vkghXhQbOTd07xdRZ5X2_kjMXu4UsHNyQcR7mNOht0kPeUPmafGx23EP-EAB0AAAAAAAAAAAAAAAAAAAAAAF1AAG2025-01-21T14c14c51d268032p00c00{"v":"KERI10JSON0000f9_","t":"rpy","d":"ELrQF_D6YFL_2SU7RbDOrTYRtGj0v_GlOmi-YWVyChol","dt":"2025-01-21T13:24:59.001000+00:00","r":"/loc/scheme","a":{"eid":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","url":"http://127.0.0.1:3001","scheme":"http"}}-VA0-FABEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--80AAAAAAAAAAAAAAAAAAAAAAAEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8-AABAAA8QzT_XDXtB_5bK8P-dVrCZIlQ69WniFPWkGmGthK683v1E2ymGA7RlkXogXtIEHekVjdl0Tg5r6lr5aREjxcL{"v":"KERI10JSON000113_","t":"rpy","d":"EA5z8Q3g-llvOK86bvE1QAceLb7g0FzcY9INn4Ch0Hu5","dt":"2025-01-21T13:24:58.660000+00:00","r":"/end/role/add","a":{"cid":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8","role":"indexer","eid":"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8"}}-VA0-FABEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--80AAAAAAAAAAAAAAAAAAAAAAAEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8-AABAADCsrTysi5_3hhzgP9VUyilJIPE8x-8Yi-lNtyB28tbc0a_S3igdY_v0yLg14tTzOyQn9sv3rGZEt4ZKb4-xl8D',
+      "{\"v\":\"KERI10JSON00012b_\",\"t\":\"icp\",\"d\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"0\",\"kt\":\"1\",\"k\":[\"DGKzvhMMz2_MYhXyV5lGso_akvBYpGnOG5fTD299IsmO\"],\"nt\":\"1\",\"n\":[\"EBhg4MS4f4GZpuNZxk1D4mln9sv9l30rbtsk17AVOEmh\"],\"bt\":\"0\",\"b\":[],\"c\":[],\"a\":[]}-VAn-AABAADt-Cs8HoN9KBS5Kk23JCAaJzOl1InvbZ4FT0AQ0muKe6pSr8QvUJNNFTUImZg8XtBFqT75AY184rX3mKPKKgYI-EAB0AAAAAAAAAAAAAAAAAAAAAAA1AAG2025-01-21T13c24c58d219360p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"1\",\"p\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"a\":[{\"i\":\"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l\",\"s\":\"0\",\"d\":\"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l\"}]}-VAn-AABAADGIyEdPqQ4wJw6KWgFOF3guadzJYWTzy9EjDbxqnBEBmUIiGquNZvNtk--gDOYcOf_EsgIsmfZ8jwIvP0xICgL-EAB0AAAAAAAAAAAAAAAAAAAAAAB1AAG2025-01-21T13c24c59d693615p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"2\",\"p\":\"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL\",\"a\":[{\"i\":\"EMcWk38kBLvGdKH2b93HMujB_Xx5-ugwD-vrQJVVIJIl\",\"s\":\"0\",\"d\":\"EIlV2FfP39_0EOLUKDi2_ljF9FMty8OCp9myBepidVij\"}]}-VAn-AABAACDrd4dm-E3OT2IlRwu4A3M7OzLkOgsoYi2-FPfS9Tmwr3awoCP2R-718qVHHUPNCb0MsnzQ2rTqVnNEw0QLWUB-EAB0AAAAAAAAAAAAAAAAAAAAAAC1AAG2025-01-21T13c47c06d452176p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"3\",\"p\":\"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG\",\"a\":[{\"i\":\"EDR-8z0CviOyrntUK3pyabMTiIuKn0AXGhQvD0C12gkX\",\"s\":\"0\",\"d\":\"EGCPj1fDEsyLgRAXwDoD9qrX6lJkwxXfBx0XNoDHtMLl\"}]}-VAn-AABAAD6qIPXPrbqhKNPDRuU91_-EzQi01V53f1RFw0AV1sMe4JBjQmOdIwn4-FW88Lo-oht6e7C7sObbgk3-aJbQS4H-EAB0AAAAAAAAAAAAAAAAAAAAAAD1AAG2025-01-21T14c03c51d890362p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"4\",\"p\":\"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S\",\"a\":[{\"i\":\"EGsSqpbkJ-0SQnhyS-1FxNChZ7p1NV6yTXPPHIdyvjkZ\",\"s\":\"0\",\"d\":\"EMNJNkHlDqyrOHWbafUGPpHVrvvj5VbrCZML_ZgXk-Rk\"}]}-VAn-AABAAAVj_8Zldpds_naKbRyuIOef3RKABaF23AHjkEKfc_Gb2j1559uY6NA8BV6ZmCKQU1_mpJbLbtaBMes-Oub2yUL-EAB0AAAAAAAAAAAAAAAAAAAAAAE1AAG2025-01-21T14c11c23d141088p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EC0Gh5X0JGSEkhUllR5sINwapxeAzYoKOWwP9UU7KdLn\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"5\",\"p\":\"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx\",\"a\":[{\"i\":\"ENMi3aqTIgCSuXROeMywH7VFuUD1-ubK3EMlumKkRkc7\",\"s\":\"0\",\"d\":\"EKdvQCM1oSTgjcPezvOw2YanOe8Wdi6wkbViE6vHpEjg\"}]}-VAn-AABAABAaL6bwARu41XPQHGnHXuxmvPrIPP8vkghXhQbOTd07xdRZ5X2_kjMXu4UsHNyQcR7mNOht0kPeUPmafGx23EP-EAB0AAAAAAAAAAAAAAAAAAAAAAF1AAG2025-01-21T14c14c51d268032p00c00{\"v\":\"KERI10JSON00012b_\",\"t\":\"icp\",\"d\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"0\",\"kt\":\"1\",\"k\":[\"DGKzvhMMz2_MYhXyV5lGso_akvBYpGnOG5fTD299IsmO\"],\"nt\":\"1\",\"n\":[\"EBhg4MS4f4GZpuNZxk1D4mln9sv9l30rbtsk17AVOEmh\"],\"bt\":\"0\",\"b\":[],\"c\":[],\"a\":[]}-VAn-AABAADt-Cs8HoN9KBS5Kk23JCAaJzOl1InvbZ4FT0AQ0muKe6pSr8QvUJNNFTUImZg8XtBFqT75AY184rX3mKPKKgYI-EAB0AAAAAAAAAAAAAAAAAAAAAAA1AAG2025-01-21T13c24c58d219360p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"1\",\"p\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"a\":[{\"i\":\"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l\",\"s\":\"0\",\"d\":\"EHm5kvOMHAdKkLBYazkUG54cyusm8d6SODrnJ2ZOP9-l\"}]}-VAn-AABAADGIyEdPqQ4wJw6KWgFOF3guadzJYWTzy9EjDbxqnBEBmUIiGquNZvNtk--gDOYcOf_EsgIsmfZ8jwIvP0xICgL-EAB0AAAAAAAAAAAAAAAAAAAAAAB1AAG2025-01-21T13c24c59d693615p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"2\",\"p\":\"EE_oRQa2Lq6g9C4jItfGPa9BMFsnmSPgS8_oB747-KHL\",\"a\":[{\"i\":\"EMcWk38kBLvGdKH2b93HMujB_Xx5-ugwD-vrQJVVIJIl\",\"s\":\"0\",\"d\":\"EIlV2FfP39_0EOLUKDi2_ljF9FMty8OCp9myBepidVij\"}]}-VAn-AABAACDrd4dm-E3OT2IlRwu4A3M7OzLkOgsoYi2-FPfS9Tmwr3awoCP2R-718qVHHUPNCb0MsnzQ2rTqVnNEw0QLWUB-EAB0AAAAAAAAAAAAAAAAAAAAAAC1AAG2025-01-21T13c47c06d452176p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"3\",\"p\":\"EHfvjSm2o673Ps3dPy6FI_80OjvJicpwZG6FMQoARllG\",\"a\":[{\"i\":\"EDR-8z0CviOyrntUK3pyabMTiIuKn0AXGhQvD0C12gkX\",\"s\":\"0\",\"d\":\"EGCPj1fDEsyLgRAXwDoD9qrX6lJkwxXfBx0XNoDHtMLl\"}]}-VAn-AABAAD6qIPXPrbqhKNPDRuU91_-EzQi01V53f1RFw0AV1sMe4JBjQmOdIwn4-FW88Lo-oht6e7C7sObbgk3-aJbQS4H-EAB0AAAAAAAAAAAAAAAAAAAAAAD1AAG2025-01-21T14c03c51d890362p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"4\",\"p\":\"EJRetyFJqp1yRs3hbleyAnqE3VqQQC2o4L3JDhIL0j2S\",\"a\":[{\"i\":\"EGsSqpbkJ-0SQnhyS-1FxNChZ7p1NV6yTXPPHIdyvjkZ\",\"s\":\"0\",\"d\":\"EMNJNkHlDqyrOHWbafUGPpHVrvvj5VbrCZML_ZgXk-Rk\"}]}-VAn-AABAAAVj_8Zldpds_naKbRyuIOef3RKABaF23AHjkEKfc_Gb2j1559uY6NA8BV6ZmCKQU1_mpJbLbtaBMes-Oub2yUL-EAB0AAAAAAAAAAAAAAAAAAAAAAE1AAG2025-01-21T14c11c23d141088p00c00{\"v\":\"KERI10JSON00013a_\",\"t\":\"ixn\",\"d\":\"EC0Gh5X0JGSEkhUllR5sINwapxeAzYoKOWwP9UU7KdLn\",\"i\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"s\":\"5\",\"p\":\"EBVYE7oXrSUvo2wNSTzXOK28SMEg6v_qrh2s_8Jk7Jdx\",\"a\":[{\"i\":\"ENMi3aqTIgCSuXROeMywH7VFuUD1-ubK3EMlumKkRkc7\",\"s\":\"0\",\"d\":\"EKdvQCM1oSTgjcPezvOw2YanOe8Wdi6wkbViE6vHpEjg\"}]}-VAn-AABAABAaL6bwARu41XPQHGnHXuxmvPrIPP8vkghXhQbOTd07xdRZ5X2_kjMXu4UsHNyQcR7mNOht0kPeUPmafGx23EP-EAB0AAAAAAAAAAAAAAAAAAAAAAF1AAG2025-01-21T14c14c51d268032p00c00{\"v\":\"KERI10JSON0000f9_\",\"t\":\"rpy\",\"d\":\"ELrQF_D6YFL_2SU7RbDOrTYRtGj0v_GlOmi-YWVyChol\",\"dt\":\"2025-01-21T13:24:59.001000+00:00\",\"r\":\"/loc/scheme\",\"a\":{\"eid\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"url\":\"http://127.0.0.1:3001\",\"scheme\":\"http\"}}-VA0-FABEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--80AAAAAAAAAAAAAAAAAAAAAAAEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8-AABAAA8QzT_XDXtB_5bK8P-dVrCZIlQ69WniFPWkGmGthK683v1E2ymGA7RlkXogXtIEHekVjdl0Tg5r6lr5aREjxcL{\"v\":\"KERI10JSON000113_\",\"t\":\"rpy\",\"d\":\"EA5z8Q3g-llvOK86bvE1QAceLb7g0FzcY9INn4Ch0Hu5\",\"dt\":\"2025-01-21T13:24:58.660000+00:00\",\"r\":\"/end/role/add\",\"a\":{\"cid\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\",\"role\":\"indexer\",\"eid\":\"EKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8\"}}-VA0-FABEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--80AAAAAAAAAAAAAAAAAAAAAAAEKxN8WjtIewcbCp_cGih5Dd42PJ-IZ8KTPbc5Xx5q--8-AABAADCsrTysi5_3hhzgP9VUyilJIPE8x-8Yi-lNtyB28tbc0a_S3igdY_v0yLg14tTzOyQn9sv3rGZEt4ZKb4-xl8D",
   }) as jest.Mock;
 });
 
@@ -325,7 +326,6 @@ describe("Receive individual ACDC actions", () => {
   test("Can accept ACDC from individual identifier and remove notification", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
     const id = "uuid";
-
     notificationStorage.findById = jest.fn().mockResolvedValue({
       type: "NotificationRecord",
       id: id,
@@ -358,21 +358,6 @@ describe("Receive individual ACDC actions", () => {
       "sigs",
       "aend",
     ]);
-
-    const connectionNote = {
-      id: "note:id",
-      title: "title",
-      message: "message",
-    };
-    signifyClient.contacts().update = jest.fn().mockReturnValue(
-      Promise.resolve({
-        alias: "alias",
-        oobi: "oobi",
-        id: "id",
-        [`${KeriaContactKeyPrefix.CONNECTION_NOTE}:id`]:
-          JSON.stringify(connectionNote),
-      })
-    );
     markNotificationMock.mockResolvedValueOnce({ status: "done" });
 
     await ipexCommunicationService.admitAcdcFromGrant(id);
@@ -395,6 +380,86 @@ describe("Receive individual ACDC actions", () => {
         status: CredentialStatus.PENDING,
       },
     });
+    expect(ipexAdmitMock).toBeCalledWith({
+      datetime: expect.any(String),
+      message: "",
+      senderName: "identifierId",
+      recipient: "EC9bQGHShmp2Juayqp0C5XcheBiHyc1p54pZ_Op-B95x",
+      grantSaid: "EIDUavcmyHBseNZAdAHR3SF8QMfX1kSJ3Ct0OqS0-HCW",
+    });
+    expect(ipexSubmitAdmitMock).toBeCalledWith(
+      "identifierId",
+      { ked: { d: "admit-said" } },
+      "sigs",
+      "aend",
+      ["EC9bQGHShmp2Juayqp0C5XcheBiHyc1p54pZ_Op-B95x"]
+    );
+    expect(operationPendingStorage.save).toBeCalledWith({
+      id: "opName",
+      recordType: OperationPendingRecordType.ExchangeReceiveCredential,
+    });
+    expect(notificationStorage.update).toBeCalledWith(
+      expect.objectContaining({
+        id,
+        route: NotificationRoute.ExnIpexGrant,
+        linkedRequest: {
+          accepted: true,
+          current: "admit-said",
+        },
+        hidden: true,
+      })
+    );
+  });
+
+  test("Can accept ACDC from individual identifier even if already exists (idempotent)", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
+    const id = "uuid";
+    notificationStorage.findById = jest.fn().mockResolvedValue({
+      type: "NotificationRecord",
+      id: id,
+      createdAt: DATETIME,
+      a: {
+        r: NotificationRoute.ExnIpexGrant,
+        d: "EIDUavcmyHBseNZAdAHR3SF8QMfX1kSJ3Ct0OqS0-HCW",
+      },
+      route: NotificationRoute.ExnIpexGrant,
+      read: true,
+      linkedRequest: { accepted: false },
+      connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
+      updatedAt: DATETIME,
+    });
+    getExchangeMock = jest.fn().mockReturnValue(grantForIssuanceExnMessage);
+    identifierStorage.getIdentifierMetadata = jest.fn().mockResolvedValue({
+      id: "identifierId",
+    });
+    schemaGetMock.mockResolvedValue(QVISchema);
+    credentialStorage.getCredentialMetadata = jest.fn().mockResolvedValue({
+      id: "id",
+    });
+    eventEmitter.emit = jest.fn();
+    saveOperationPendingMock.mockResolvedValue({
+      id: "opName",
+      recordType: OperationPendingRecordType.ExchangeReceiveCredential,
+    });
+    ipexAdmitMock.mockResolvedValue([
+      { ked: { d: "admit-said" } },
+      "sigs",
+      "aend",
+    ]);
+    markNotificationMock.mockResolvedValueOnce({ status: "done" });
+    credentialStorage.saveCredentialMetadataRecord.mockRejectedValueOnce(
+      new Error(StorageMessage.RECORD_ALREADY_EXISTS_ERROR_MSG)
+    );
+
+    await ipexCommunicationService.admitAcdcFromGrant(id);
+
+    expect(credentialStorage.saveCredentialMetadataRecord).toBeCalledWith({
+      ...credentialRecordProps,
+      identifierId: "identifierId",
+      identifierType: "individual",
+      createdAt: new Date(credentialRecordProps.issuanceDate),
+    });
+    expect(eventEmitter.emit).not.toBeCalled();
     expect(ipexAdmitMock).toBeCalledWith({
       datetime: expect.any(String),
       message: "",
@@ -772,6 +837,130 @@ describe("Receive group ACDC actions", () => {
         status: CredentialStatus.PENDING,
       },
     });
+    expect(notificationStorage.update).toBeCalledWith(
+      expect.objectContaining({
+        id: "id",
+        route: NotificationRoute.ExnIpexGrant,
+        linkedRequest: {
+          accepted: true,
+          current: "EL3A2jk9gvmVe4ROISB2iWmM8yPSNwQlmar6-SFVWSPW",
+        },
+      })
+    );
+    expect(operationPendingStorage.save).toBeCalledWith({
+      id: "opName",
+      recordType: OperationPendingRecordType.ExchangeReceiveCredential,
+    });
+    expect(notificationStorage.deleteById).not.toBeCalled();
+  });
+
+  test("Can join group admit of an ACDC even if ACDC already exists (idempotent)", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
+
+    notificationStorage.findById = jest.fn().mockResolvedValue({
+      type: "NotificationRecord",
+      id: "id",
+      createdAt: DATETIME,
+      a: {
+        r: NotificationRoute.ExnIpexGrant,
+        d: "EIDUavcmyHBseNZAdAHR3SF8QMfX1kSJ3Ct0OqS0-HCW",
+      },
+      route: NotificationRoute.ExnIpexGrant,
+      read: true,
+      linkedRequest: {
+        accepted: false,
+        current: "EL3A2jk9gvmVe4ROISB2iWmM8yPSNwQlmar6-SFVWSPW",
+      },
+      connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
+      updatedAt: DATETIME,
+    });
+    getExchangeMock
+      .mockReturnValueOnce(multisigExnAdmitForIssuance)
+      .mockReturnValueOnce(grantForIssuanceExnMessage);
+    identifierStorage.getIdentifierMetadata = jest
+      .fn()
+      .mockResolvedValue(groupIdentifierMetadataRecord);
+    multisigService.getMultisigParticipants.mockResolvedValue({
+      ourIdentifier: {
+        id: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_z8",
+        displayName: "Identifier 2",
+        createdAt: "2024-09-23T08:53:11.981Z",
+        theme: 0,
+        groupMetadata: {
+          groupId: "group-id",
+          groupInitiator: true,
+          groupCreated: true,
+        },
+      },
+      multisigMembers: [
+        {
+          aid: "ELmrDKf0Yq54Yq7cyrHwHZlA4lBB8ZVX9c8Ea3h2VJFF",
+          ends: [],
+        },
+        {
+          aid: "EGaEIhOGSTPccSMvnXvfvOVyC1C5AFq62GLTrRKVZBS5",
+          ends: [],
+        },
+      ],
+    });
+    getManagerMock.mockReturnValue({
+      sign: () => [
+        "ABDEouKAUhCDedOkqA5oxlMO4OB1C8p5M4G-_DLJWPf-ZjegTK-OxN4s6veE_7hXXuFzX4boq6evbLs5vFiVl-MB",
+      ],
+    });
+    identifiersGetMock = jest
+      .fn()
+      .mockResolvedValueOnce(gHab)
+      .mockResolvedValueOnce(mHab);
+    createExchangeMessageMock.mockResolvedValue([
+      ipexSubmitAdmitSerder,
+      ipexSubmitAdmitSig,
+      ipexSubmitAdmitEnd,
+    ]);
+    schemaGetMock.mockResolvedValue(QVISchema);
+    ipexAdmitMock.mockResolvedValue([
+      ipexAdmitSerder,
+      ipexAdmitSig,
+      ipexAdmitEnd,
+    ]);
+    eventEmitter.emit = jest.fn();
+    saveOperationPendingMock.mockResolvedValueOnce({
+      id: "opName",
+      recordType: OperationPendingRecordType.ExchangeReceiveCredential,
+    });
+
+    (Saider.saidify as jest.Mock).mockImplementation(
+      jest.fn().mockReturnValue([{} as Saider, ipexGrantSerder.ked])
+    );
+    (Serder as jest.Mock).mockImplementation(
+      jest.fn().mockReturnValue({
+        ked: { d: "EKJEr0WbRERI1j2GjjfuReOIHjBSjC0tXguEaNYo5Hl6" },
+      })
+    );
+    credentialStorage.saveCredentialMetadataRecord.mockRejectedValueOnce(
+      new Error(StorageMessage.RECORD_ALREADY_EXISTS_ERROR_MSG)
+    );
+
+    await ipexCommunicationService.joinMultisigAdmit("id");
+
+    expect(getManagerMock).toBeCalledWith(gHab);
+    expect(ipexSubmitAdmitMock).toBeCalledWith(
+      "EC1cyV3zLnGs4B9AYgoGNjXESyQZrBWygz3jLlRD30bR",
+      ipexSubmitAdmitSerder,
+      ipexSubmitAdmitSig,
+      ipexSubmitAdmitEnd,
+      [
+        "ELmrDKf0Yq54Yq7cyrHwHZlA4lBB8ZVX9c8Ea3h2VJFF",
+        "EGaEIhOGSTPccSMvnXvfvOVyC1C5AFq62GLTrRKVZBS5",
+      ]
+    );
+    expect(credentialStorage.saveCredentialMetadataRecord).toBeCalledWith({
+      ...credentialRecordProps,
+      identifierId: "EC1cyV3zLnGs4B9AYgoGNjXESyQZrBWygz3jLlRD30bR",
+      identifierType: "group",
+      createdAt: new Date(credentialRecordProps.issuanceDate),
+    });
+    expect(eventEmitter.emit).not.toBeCalled();
     expect(notificationStorage.update).toBeCalledWith(
       expect.objectContaining({
         id: "id",
@@ -1317,7 +1506,7 @@ describe("Offer ACDC group actions", () => {
           "d",
         ],
       },
-      "EJ84hiNC0ts71HARE1ZkcnYAFJP0s-RiLNyzupnk7edn"
+      "ELmrDKf0Yq54Yq7cyrHwHZlA4lBB8ZVX9c8Ea3h2VJFF"
     );
     expect(ipexSubmitOfferMock).toBeCalledWith(
       "EC1cyV3zLnGs4B9AYgoGNjXESyQZrBWygz3jLlRD30bR",
@@ -1901,34 +2090,6 @@ describe("Grant ACDC group actions", () => {
     );
   });
 
-  test("Cannot join group to present ACDC twice", async () => {
-    await expect(
-      ipexCommunicationService.joinMultisigGrant(
-        multisigExnGrant,
-        new NotificationRecord({
-          id: "note-id",
-          createdAt: DATETIME,
-          a: {
-            r: NotificationRoute.ExnIpexAgree,
-            d: "EIDUavcmyHBseNZAdAHR3SF8QMfX1kSJ3Ct0OqS0-HCW",
-          },
-          route: NotificationRoute.ExnIpexAgree,
-          read: true,
-          linkedRequest: {
-            accepted: true,
-            current: "current-grant-said",
-          },
-          connectionId: "EEFjBBDcUM2IWpNF7OclCme_bE76yKE3hzULLzTOFE8E",
-        })
-      )
-    ).rejects.toThrowError(IpexCommunicationService.IPEX_ALREADY_REPLIED);
-
-    expect(ipexSubmitGrantMock).not.toBeCalled();
-    expect(notificationStorage.save).not.toBeCalled();
-    expect(operationPendingStorage.save).not.toBeCalled();
-    expect(eventEmitter.emit).not.toBeCalled();
-  });
-
   test("Cannot join group to offer ACDC if there is no current offer", async () => {
     await expect(
       ipexCommunicationService.joinMultisigGrant(
@@ -2135,6 +2296,20 @@ describe("IPEX communication service of agent", () => {
     expect(connections.resolveOobi).toBeCalledTimes(1);
   });
 
+  test("Should return early without error if there's no existing connection", async () => {
+    connections.getConnectionById.mockRejectedValueOnce(
+      new Error(Agent.MISSING_DATA_ON_KERIA)
+    );
+
+    await ipexCommunicationService.createLinkedIpexMessageRecord(
+      admitForIssuanceExnMessage,
+      ConnectionHistoryType.CREDENTIAL_ISSUANCE
+    );
+
+    expect(updateContactMock).not.toBeCalled();
+    expect(connections.resolveOobi).not.toBeCalled();
+  });
+
   test("Should throw error if history type invalid", async () => {
     schemaGetMock.mockResolvedValueOnce(QVISchema);
     getExchangeMock.mockResolvedValueOnce(agreeForPresentingExnMessage);
@@ -2143,7 +2318,7 @@ describe("IPEX communication service of agent", () => {
         agreeForPresentingExnMessage,
         "invalid" as any
       )
-    ).rejects.toThrowError("Invalid history type");
+    ).rejects.toThrowError(IpexCommunicationService.INVALID_HISTORY_TYPE);
   });
 
   test("Should throw error if schemas.get has an unexpected error", async () => {

--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -8,7 +8,6 @@ import {
   Serder,
   Siger,
 } from "signify-ts";
-import { ConfigurationService } from "../../configuration";
 import {
   ExchangeRoute,
   ExnMessage,
@@ -46,6 +45,8 @@ import {
   ConnectionHistoryType,
   KeriaContactKeyPrefix,
 } from "./connectionService.types";
+import { Agent } from "../agent";
+import { StorageMessage } from "../../storage/storage.types";
 
 class IpexCommunicationService extends AgentService {
   static readonly ISSUEE_NOT_FOUND_LOCALLY =
@@ -59,6 +60,7 @@ class IpexCommunicationService extends AgentService {
     "IPEX message has already been responded to or proposed to group";
   static readonly NO_CURRENT_IPEX_MSG_TO_JOIN =
     "Cannot join IPEX message as there is no current exn to join from the group leader";
+  static readonly INVALID_HISTORY_TYPE = "Invalid history type";
 
   protected readonly identifierStorage: IdentifierStorage;
   protected readonly credentialStorage: CredentialStorage;
@@ -130,22 +132,36 @@ class IpexCommunicationService extends AgentService {
     allSchemaSaids.push(schemaSaid);
 
     const schema = await this.props.signifyClient.schemas().get(schemaSaid);
-    const credential = await this.saveAcdcMetadataRecord(
-      holder,
-      grantExn.exn.e.acdc.d,
-      grantExn.exn.e.acdc.a.dt,
-      schema.title,
-      grantExn.exn.i,
-      schemaSaid
-    );
+    try {
+      const credential = await this.saveAcdcMetadataRecord(
+        holder,
+        grantExn.exn.e.acdc.d,
+        grantExn.exn.e.acdc.a.dt,
+        schema.title,
+        grantExn.exn.i,
+        schemaSaid
+      );
 
-    this.props.eventEmitter.emit<AcdcStateChangedEvent>({
-      type: EventTypes.AcdcStateChanged,
-      payload: {
-        credential,
-        status: CredentialStatus.PENDING,
-      },
-    });
+      this.props.eventEmitter.emit<AcdcStateChangedEvent>({
+        type: EventTypes.AcdcStateChanged,
+        payload: {
+          credential,
+          status: CredentialStatus.PENDING,
+        },
+      });
+    } catch (error) {
+      // Ignore this as we might have failed before we deleted the notification and need to retry in the UI
+      if (
+        !(
+          error instanceof Error &&
+          error.message.startsWith(
+            StorageMessage.RECORD_ALREADY_EXISTS_ERROR_MSG
+          )
+        )
+      ) {
+        throw error;
+      }
+    }
 
     let op: Operation;
     if (holder.multisigManageAid) {
@@ -183,7 +199,6 @@ class IpexCommunicationService extends AgentService {
       id: op.name,
       recordType: OperationPendingRecordType.ExchangeReceiveCredential,
     });
-
     await this.notificationStorage.update(grantNoteRecord);
   }
 
@@ -372,13 +387,13 @@ class IpexCommunicationService extends AgentService {
       "-a-i": exchange.exn.rp,
       ...(Object.keys(attributes).length > 0
         ? {
-            ...Object.fromEntries(
-              Object.entries(attributes).map(([key, value]) => [
-                "-a-" + key,
-                value,
-              ])
-            ),
-          }
+          ...Object.fromEntries(
+            Object.entries(attributes).map(([key, value]) => [
+              "-a-" + key,
+              value,
+            ])
+          ),
+        }
         : {}),
     };
 
@@ -471,12 +486,30 @@ class IpexCommunicationService extends AgentService {
     message: ExnMessage,
     historyType: ConnectionHistoryType
   ): Promise<void> {
-    let schemaSaid;
     const connectionId =
       historyType === ConnectionHistoryType.CREDENTIAL_PRESENTED ||
       historyType === ConnectionHistoryType.CREDENTIAL_ISSUANCE
         ? message.exn.rp
         : message.exn.i;
+
+    const connection = await this.connections
+      .getConnectionById(connectionId)
+      .catch((error) => {
+        if (
+          error instanceof Error &&
+          error.message.startsWith(Agent.MISSING_DATA_ON_KERIA)
+        ) {
+          return undefined;
+        }
+        throw error;
+      });
+
+    // Handles case where we receive IPEX messages from unknown or previously deleted connections
+    if (!connection) {
+      return;
+    }
+
+    let schemaSaid;
     if (message.exn.r === ExchangeRoute.IpexGrant) {
       schemaSaid = message.exn.e.acdc.s;
     } else if (message.exn.r === ExchangeRoute.IpexApply) {
@@ -491,10 +524,12 @@ class IpexCommunicationService extends AgentService {
       schemaSaid = previousExchange.exn.e.acdc.s;
     }
 
-    const issuerOobi = (await this.connections.getConnectionById(connectionId))
-      .serviceEndpoints[0];
     await this.connections.resolveOobi(
-      await this.getSchemaUrl(issuerOobi, connectionId, schemaSaid),
+      await this.getSchemaUrl(
+        connection.serviceEndpoints[0],
+        connectionId,
+        schemaSaid
+      ),
       true
     );
     const schema = await this.props.signifyClient.schemas().get(schemaSaid);
@@ -502,18 +537,18 @@ class IpexCommunicationService extends AgentService {
     let prefix;
     let key;
     switch (historyType) {
-      case ConnectionHistoryType.CREDENTIAL_REVOKED:
-        prefix = KeriaContactKeyPrefix.HISTORY_REVOKE;
-        key = message.exn.e.acdc.d;
-        break;
-      case ConnectionHistoryType.CREDENTIAL_ISSUANCE:
-      case ConnectionHistoryType.CREDENTIAL_REQUEST_PRESENT:
-      case ConnectionHistoryType.CREDENTIAL_PRESENTED:
-        prefix = KeriaContactKeyPrefix.HISTORY_IPEX;
-        key = message.exn.d;
-        break;
-      default:
-        throw new Error("Invalid history type");
+    case ConnectionHistoryType.CREDENTIAL_REVOKED:
+      prefix = KeriaContactKeyPrefix.HISTORY_REVOKE;
+      key = message.exn.e.acdc.d;
+      break;
+    case ConnectionHistoryType.CREDENTIAL_ISSUANCE:
+    case ConnectionHistoryType.CREDENTIAL_REQUEST_PRESENT:
+    case ConnectionHistoryType.CREDENTIAL_PRESENTED:
+      prefix = KeriaContactKeyPrefix.HISTORY_IPEX;
+      key = message.exn.d;
+      break;
+    default:
+      throw new Error(IpexCommunicationService.INVALID_HISTORY_TYPE);
     }
     const historyItem: ConnectionHistoryItem = {
       id: message.exn.d,
@@ -577,22 +612,36 @@ class IpexCommunicationService extends AgentService {
     );
 
     const schema = await this.props.signifyClient.schemas().get(schemaSaid);
-    const credential = await this.saveAcdcMetadataRecord(
-      holder,
-      credentialId,
-      grantExn.exn.e.acdc.a.dt,
-      schema.title,
-      connectionId,
-      schemaSaid
-    );
+    try {
+      const credential = await this.saveAcdcMetadataRecord(
+        holder,
+        credentialId,
+        grantExn.exn.e.acdc.a.dt,
+        schema.title,
+        connectionId,
+        schemaSaid
+      );
 
-    this.props.eventEmitter.emit<AcdcStateChangedEvent>({
-      type: EventTypes.AcdcStateChanged,
-      payload: {
-        credential,
-        status: CredentialStatus.PENDING,
-      },
-    });
+      this.props.eventEmitter.emit<AcdcStateChangedEvent>({
+        type: EventTypes.AcdcStateChanged,
+        payload: {
+          credential,
+          status: CredentialStatus.PENDING,
+        },
+      });
+    } catch (error) {
+      // Ignore this as we might have failed before we deleted the notification and need to retry in the UI
+      if (
+        !(
+          error instanceof Error &&
+          error.message.startsWith(
+            StorageMessage.RECORD_ALREADY_EXISTS_ERROR_MSG
+          )
+        )
+      ) {
+        throw error;
+      }
+    }
 
     await this.operationPendingStorage.save({
       id: op.name,
@@ -652,10 +701,6 @@ class IpexCommunicationService extends AgentService {
     multiSigExn: ExnMessage,
     agreeNoteRecord: NotificationRecord
   ): Promise<void> {
-    if (agreeNoteRecord.linkedRequest.accepted) {
-      throw new Error(IpexCommunicationService.IPEX_ALREADY_REPLIED);
-    }
-
     if (!agreeNoteRecord.linkedRequest.current) {
       throw new Error(IpexCommunicationService.NO_CURRENT_IPEX_MSG_TO_JOIN);
     }
@@ -739,7 +784,7 @@ class IpexCommunicationService extends AgentService {
           MultiSigRoute.EXN,
           { gid: gHab["prefix"] },
           gembeds,
-          discloseePrefix
+          recp[0]
         );
     } else {
       const time = new Date().toISOString().replace("Z", "000+00:00");
@@ -900,6 +945,7 @@ class IpexCommunicationService extends AgentService {
     const credentialState = await this.props.signifyClient
       .credentials()
       .state(exchange.exn.e.acdc.ri, exchange.exn.e.acdc.d);
+
     const schemaSaid = exchange.exn.e.acdc.s;
     const schema = await this.props.signifyClient
       .schemas()
@@ -919,6 +965,7 @@ class IpexCommunicationService extends AgentService {
           throw error;
         }
       });
+
     return {
       id: exchange.exn.e.acdc.d,
       schema: exchange.exn.e.acdc.s,
@@ -1142,7 +1189,7 @@ class IpexCommunicationService extends AgentService {
     const indexerOobiResult = await (
       await fetch(`${agentBase}/indexer/${prefix}`)
     ).text();
-    const schemaBase = indexerOobiResult.split('"url":"')[1].split('"')[0];
+    const schemaBase = indexerOobiResult.split("\"url\":\"")[1].split("\"")[0];
 
     return `${schemaBase}/oobi/${said}`;
   }

--- a/src/core/storage/ionicStorage/ionicStorage.ts
+++ b/src/core/storage/ionicStorage/ionicStorage.ts
@@ -10,7 +10,7 @@ import { deserializeRecord } from "../utils";
 import { BasicRecord } from "../../agent/records";
 
 class IonicStorage<T extends BaseRecord> implements StorageService<T> {
-  private static readonly SESION_IS_NOT_INITIALIZED =
+  private static readonly SESSION_IS_NOT_INITIALIZED =
     "Session is not initialized";
 
   private session?: Storage;
@@ -125,7 +125,7 @@ class IonicStorage<T extends BaseRecord> implements StorageService<T> {
 
   private checkSession(session?: Storage) {
     if (!session) {
-      throw new Error(IonicStorage.SESION_IS_NOT_INITIALIZED);
+      throw new Error(IonicStorage.SESSION_IS_NOT_INITIALIZED);
     }
   }
 

--- a/src/core/storage/sqliteStorage/sqliteStorage.ts
+++ b/src/core/storage/sqliteStorage/sqliteStorage.ts
@@ -12,8 +12,7 @@ import { deserializeRecord } from "../utils";
 import { BasicRecord } from "../../agent/records";
 
 class SqliteStorage<T extends BaseRecord> implements StorageService<T> {
-  static readonly SESION_IS_NOT_INITIALIZED = "Session is not initialized";
-
+  static readonly SESSION_IS_NOT_INITIALIZED = "Session is not initialized";
   static readonly INSERT_ITEM_TAG_SQL =
     "INSERT INTO items_tags (item_id, name, value, type) VALUES (?,?,?,?)";
   static readonly DELETE_ITEM_TAGS_SQL =
@@ -302,7 +301,7 @@ class SqliteStorage<T extends BaseRecord> implements StorageService<T> {
 
   private checkSession(session?: SQLiteDBConnection) {
     if (!session) {
-      throw new Error(SqliteStorage.SESION_IS_NOT_INITIALIZED);
+      throw new Error(SqliteStorage.SESSION_IS_NOT_INITIALIZED);
     }
   }
 }

--- a/src/store/reducers/credsArchivedCache/credsArchivedCache.test.ts
+++ b/src/store/reducers/credsArchivedCache/credsArchivedCache.test.ts
@@ -10,7 +10,7 @@ import {
   CredentialStatus,
 } from "../../../core/agent/services/credentialService.types";
 import { IdentifierType } from "../../../core/agent/services/identifier.types";
-import { memberIdentifierRecord } from "../../../core/__fixtures__/agent/multSigFixtures";
+import { memberIdentifierRecord } from "../../../core/__fixtures__/agent/multiSigFixtures";
 
 describe("credsArchivedCacheSlice", () => {
   const initialState = {

--- a/src/store/reducers/credsCache/credsCache.test.ts
+++ b/src/store/reducers/credsCache/credsCache.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../../../core/agent/services/credentialService.types";
 import { IdentifierType } from "../../../core/agent/services/identifier.types";
 import { FavouriteIdentifier } from "../identifiersCache/identifiersCache.types";
-import { multisigMetadataRecord } from "../../../core/__fixtures__/agent/multSigFixtures";
+import { multisigMetadataRecord } from "../../../core/__fixtures__/agent/multiSigFixtures";
 import { CredentialsFilters } from "../../../ui/pages/Credentials/Credentials.types";
 
 describe("credsCacheSlice", () => {

--- a/src/ui/__fixtures__/credsFix.ts
+++ b/src/ui/__fixtures__/credsFix.ts
@@ -1,4 +1,4 @@
-import { memberIdentifierRecord } from "../../core/__fixtures__/agent/multSigFixtures";
+import { memberIdentifierRecord } from "../../core/__fixtures__/agent/multiSigFixtures";
 import {
   ConnectionDetails,
   ConnectionStatus,

--- a/src/ui/__fixtures__/filteredCredsFix.ts
+++ b/src/ui/__fixtures__/filteredCredsFix.ts
@@ -1,4 +1,4 @@
-import { memberIdentifierRecord } from "../../core/__fixtures__/agent/multSigFixtures";
+import { memberIdentifierRecord } from "../../core/__fixtures__/agent/multiSigFixtures";
 import {
   CredentialShortDetails,
   CredentialStatus,

--- a/src/ui/__fixtures__/shortCredsFix.ts
+++ b/src/ui/__fixtures__/shortCredsFix.ts
@@ -1,4 +1,4 @@
-import { memberIdentifierRecord } from "../../core/__fixtures__/agent/multSigFixtures";
+import { memberIdentifierRecord } from "../../core/__fixtures__/agent/multiSigFixtures";
 import {
   CredentialShortDetails,
   CredentialStatus,

--- a/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
@@ -174,10 +174,12 @@ describe("Manage password", () => {
       fireEvent.click(getByTestId("settings-item-toggle-password"));
     });
 
-    const text = await findByText(
-      TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword.page
-        .alert.enablemessage
-    );
+    const text = await waitFor(async () => {
+      return await findByText(
+        TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
+          .page.alert.enablemessage
+      );
+    });
 
     await waitFor(() => {
       expect(text).toBeVisible();
@@ -187,6 +189,10 @@ describe("Manage password", () => {
       fireEvent.click(
         getAllByTestId("alert-cancel-enable-password-confirm-button")[0]
       );
+    });
+
+    await waitFor(() => {
+      expect(getByText("1")).toBeVisible();
     });
 
     await passcodeFiller(getByText, getByTestId, "1", 6);

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -562,7 +562,7 @@ describe("Credential request information: multisig", () => {
 
     act(() => {
       fireEvent.click(
-        getByTestId("multisig-request-alert-decline-confirm-button")
+        getAllByTestId("multisig-request-alert-decline-confirm-button")[0]
       );
     });
 

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -184,7 +184,6 @@ const ReceiveCredential = ({
   }, [
     dispatch,
     getMultiSigMemberStatus,
-    handleBack,
     identifiersData,
     notificationDetails.a.d,
   ]);
@@ -309,12 +308,12 @@ const ReceiveCredential = ({
   const primaryButtonText = isRevoked
     ? undefined
     : `${i18n.t(
-        displayInitiatorNotAcceptedAlert
-          ? "tabs.notifications.details.buttons.ok"
-          : maxThreshold
+      displayInitiatorNotAcceptedAlert
+        ? "tabs.notifications.details.buttons.ok"
+        : maxThreshold
           ? "tabs.notifications.details.buttons.addcred"
           : "tabs.notifications.details.buttons.accept"
-      )}`;
+    )}`;
 
   const secondaryButtonText =
     maxThreshold || isRevoked || displayInitiatorNotAcceptedAlert


### PR DESCRIPTION
## Description

It's important that if we start processing a notification or long running operation completion that it's idempotent so we can re-process it if needs be. This PR has some fixes to improve that, as well as covers many edge cases such as receiving notifications after deleting an identifier, or other out of order notifications.

I've made some adjustments to ensure that if we restore a wallet, we recover into a good state as well as possible.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1446)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).
