### PR TITLE
feat(ui): Add warning if trying to enable biometrics when it's off in phone settings

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1316,6 +1316,11 @@
             "security": {
               "title": "Security",
               "biometry": "Biometric authentication",
+              "biometricsalert": {
+                "message": "In order to use biometrics you need to enable this in your settings. Would you like to do this?",
+                "ok": "Go to settings",
+                "cancel": "Setup later"
+              },
               "changepin": {
                 "title": "Change passcode",
                 "createpasscode": "Create new passcode",

--- a/src/ui/pages/Menu/components/Settings/Settings.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.test.tsx
@@ -322,6 +322,22 @@ describe("Settings page", () => {
     });
 
     await waitFor(() => {
+      expect(
+        getByText(
+          EN_TRANSLATIONS.tabs.menu.tab.settings.sections.security
+            .biometricsalert.message
+        )
+      );
+    });
+
+    fireEvent.click(
+      getByText(
+        EN_TRANSLATIONS.tabs.menu.tab.settings.sections.security.biometricsalert
+          .ok
+      )
+    );
+
+    await waitFor(() => {
       expect(openSettingMock).toBeCalledTimes(1);
     });
   });

--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -125,16 +125,16 @@ const Settings = ({ switchView }: SettingsProps) => {
   };
 
   const handleBiometricUpdate = () => {
-    if (biometricsCache.enabled) {
-      handleToggleBiometricAuth();
-      return;
-    }
-
     if (
       !biometricInfo?.strongBiometryIsAvailable &&
       biometricInfo?.code === BiometryErrorType.biometryNotEnrolled
     ) {
       setOpenBiometricAlert(true);
+      return;
+    }
+
+    if (biometricsCache.enabled) {
+      handleToggleBiometricAuth();
       return;
     }
 

--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -16,7 +16,7 @@ import {
   lockClosedOutline,
   logoDiscord,
 } from "ionicons/icons";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import pJson from "../../../../../../package.json";
 import { Agent } from "../../../../../core/agent/agent";
@@ -42,17 +42,18 @@ import { ChangePin } from "./components/ChangePin";
 import { SettingsItem } from "./components/SettingsItem";
 import "./Settings.scss";
 import { OptionIndex, OptionProps, SettingsProps } from "./Settings.types";
+import { usePrivacyScreen } from "../../../../hooks/privacyScreenHook";
 
 const Settings = ({ switchView }: SettingsProps) => {
   const dispatch = useAppDispatch();
   const biometricsCache = useSelector(getBiometricsCacheCache);
   const [option, setOption] = useState<number | null>(null);
   const { biometricInfo, handleBiometricAuth } = useBiometricAuth();
-  const inBiometricSetup = useRef(false);
   const [verifyIsOpen, setVerifyIsOpen] = useState(false);
   const [changePinIsOpen, setChangePinIsOpen] = useState(false);
   const { disablePrivacy, enablePrivacy } = usePrivacyScreen();
   const [openBiometricAlert, setOpenBiometricAlert] = useState(false);
+  const { enablePrivacy, disablePrivacy } = usePrivacyScreen(false);
 
   const securityItems: OptionProps[] = [
     {
@@ -126,8 +127,6 @@ const Settings = ({ switchView }: SettingsProps) => {
   };
 
   const handleBiometricUpdate = () => {
-    inBiometricSetup.current = false;
-
     if (biometricsCache.enabled) {
       handleToggleBiometricAuth();
       return;
@@ -159,16 +158,8 @@ const Settings = ({ switchView }: SettingsProps) => {
     NativeSettings.open({
       optionAndroid: AndroidSettings.Security,
       optionIOS: IOSSettings.TouchIdPasscode,
-    }).then((result) => {
-      inBiometricSetup.current = result.status;
     });
   };
-
-  useEffect(() => {
-    if (biometricInfo?.strongBiometryIsAvailable && inBiometricSetup.current) {
-      handleBiometricUpdate();
-    }
-  }, [biometricInfo]);
 
   const handleChangePin = () => {
     setVerifyIsOpen(true);

--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -28,6 +28,7 @@ import {
   getBiometricsCacheCache,
   setEnableBiometricsCache,
 } from "../../../../../store/reducers/biometricsCache";
+import { Alert } from "../../../../components/Alert";
 import { Verification } from "../../../../components/Verification";
 import {
   DISCORD_LINK,
@@ -51,6 +52,7 @@ const Settings = ({ switchView }: SettingsProps) => {
   const [verifyIsOpen, setVerifyIsOpen] = useState(false);
   const [changePinIsOpen, setChangePinIsOpen] = useState(false);
   const { disablePrivacy, enablePrivacy } = usePrivacyScreen();
+  const [openBiometricAlert, setOpenBiometricAlert] = useState(false);
 
   const securityItems: OptionProps[] = [
     {
@@ -135,13 +137,7 @@ const Settings = ({ switchView }: SettingsProps) => {
       !biometricInfo?.strongBiometryIsAvailable &&
       biometricInfo?.code === BiometryErrorType.biometryNotEnrolled
     ) {
-      NativeSettings.open({
-        optionAndroid: AndroidSettings.Security,
-        optionIOS: IOSSettings.TouchIdPasscode,
-      }).then((result) => {
-        inBiometricSetup.current = result.status;
-      });
-
+      setOpenBiometricAlert(true);
       return;
     }
 
@@ -157,6 +153,15 @@ const Settings = ({ switchView }: SettingsProps) => {
     } catch (e) {
       showError("Unable to enable/disable biometric auth", e, dispatch);
     }
+  };
+
+  const openSetting = () => {
+    NativeSettings.open({
+      optionAndroid: AndroidSettings.Security,
+      optionIOS: IOSSettings.TouchIdPasscode,
+    }).then((result) => {
+      inBiometricSetup.current = result.status;
+    });
   };
 
   useEffect(() => {
@@ -221,6 +226,10 @@ const Settings = ({ switchView }: SettingsProps) => {
     setOption(null);
   };
 
+  const closeAlert = () => {
+    setOpenBiometricAlert(false);
+  };
+
   return (
     <>
       <div className="settings-section-title">
@@ -269,6 +278,23 @@ const Settings = ({ switchView }: SettingsProps) => {
       <ChangePin
         isOpen={changePinIsOpen}
         setIsOpen={setChangePinIsOpen}
+      />
+      <Alert
+        isOpen={openBiometricAlert}
+        setIsOpen={setOpenBiometricAlert}
+        dataTestId="biometric-enable-alert"
+        headerText={i18n.t(
+          "tabs.menu.tab.settings.sections.security.biometricsalert.message"
+        )}
+        confirmButtonText={`${i18n.t(
+          "tabs.menu.tab.settings.sections.security.biometricsalert.ok"
+        )}`}
+        cancelButtonText={`${i18n.t(
+          "tabs.menu.tab.settings.sections.security.biometricsalert.cancel"
+        )}`}
+        actionConfirm={openSetting}
+        actionCancel={closeAlert}
+        actionDismiss={closeAlert}
       />
     </>
   );

--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -127,7 +127,8 @@ const Settings = ({ switchView }: SettingsProps) => {
   const handleBiometricUpdate = () => {
     if (
       !biometricInfo?.strongBiometryIsAvailable &&
-      biometricInfo?.code === BiometryErrorType.biometryNotEnrolled
+      (biometricInfo?.code === BiometryErrorType.biometryNotEnrolled ||
+        biometricInfo?.code === BiometryErrorType.biometryNotAvailable)
     ) {
       setOpenBiometricAlert(true);
       return;

--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -16,7 +16,7 @@ import {
   lockClosedOutline,
   logoDiscord,
 } from "ionicons/icons";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useSelector } from "react-redux";
 import pJson from "../../../../../../package.json";
 import { Agent } from "../../../../../core/agent/agent";
@@ -42,7 +42,6 @@ import { ChangePin } from "./components/ChangePin";
 import { SettingsItem } from "./components/SettingsItem";
 import "./Settings.scss";
 import { OptionIndex, OptionProps, SettingsProps } from "./Settings.types";
-import { usePrivacyScreen } from "../../../../hooks/privacyScreenHook";
 
 const Settings = ({ switchView }: SettingsProps) => {
   const dispatch = useAppDispatch();
@@ -53,7 +52,6 @@ const Settings = ({ switchView }: SettingsProps) => {
   const [changePinIsOpen, setChangePinIsOpen] = useState(false);
   const { disablePrivacy, enablePrivacy } = usePrivacyScreen();
   const [openBiometricAlert, setOpenBiometricAlert] = useState(false);
-  const { enablePrivacy, disablePrivacy } = usePrivacyScreen(false);
 
   const securityItems: OptionProps[] = [
     {


### PR DESCRIPTION
## Description

Add warning if trying to enable biometrics when it's off in phone settings

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1840)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/870a7842-d69f-4381-9c2a-173e120bd6b7

#### Android

https://github.com/user-attachments/assets/95ee4929-a10b-45fb-a6f6-e889e5d5a758
