### PR TITLE
build: npm audit and revised notes after investigating further

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,22 +1,14 @@
 {
   "1100267": {
     "active": true,
-    "notes": "Ignored since is related just to appium e2e"
-  },
-  "1101088": {
-    "active": true,
-    "notes": "Ignored since is related to nodemon server from dev dep"
+    "notes": "This is a ReDOS vulnerability for email inputs in Appium drivers, so not applicable."
   },
   "1101851": {
     "active": true,
-    "notes": "Ignored since is related just to appium e2e"
+    "notes": "SSRF attacks are not relevant to our usage of Meerkat."
   },
   "1102339": {
     "active": true,
-    "notes": "Ignored since is related to webpack build"
-  },
-  "1102341": {
-    "active": true,
-    "notes": "Ignored since is related to wdio/cli"
+    "notes": "Serialization here is used in webpack build plugins to parse options etc, this vulnerability is more relevant if used to parse inputs from users."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,27 +179,22 @@
       }
     },
     "node_modules/@appium/base-driver": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.15.0.tgz",
-      "integrity": "sha512-r7021rZ/oty9LGJShRhZ8tXYQmxb0clHJJz2KBXvTcEwcV9dBMc7JAlL+Fz5i7cvryzTef396IEZMRp2VgmmQg==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.16.2.tgz",
+      "integrity": "sha512-vuQf9XQKGAMl5d5pM63FOrnRJUSVjw6J5kPXApfnkTJovwyV9SViYptnCB/TcahjX2bHQ+fUka82MWzHKPzpHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^6.0.3",
-        "@appium/types": "^0.24.0",
+        "@appium/support": "^6.0.6",
+        "@appium/types": "^0.25.1",
         "@colors/colors": "1.6.0",
-        "@types/async-lock": "1.4.2",
-        "@types/bluebird": "3.5.42",
-        "@types/express": "5.0.0",
-        "@types/lodash": "4.17.14",
-        "@types/method-override": "3.0.0",
-        "@types/serve-favicon": "2.5.7",
         "async-lock": "1.4.1",
         "asyncbox": "3.0.0",
         "axios": "1.7.9",
         "bluebird": "3.7.2",
         "body-parser": "1.20.3",
         "express": "4.21.2",
+        "fastest-levenshtein": "1.0.16",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
         "lru-cache": "10.4.3",
@@ -208,7 +203,7 @@
         "path-to-regexp": "8.2.0",
         "serve-favicon": "2.5.0",
         "source-map-support": "0.5.21",
-        "type-fest": "4.31.0",
+        "type-fest": "4.35.0",
         "validate.js": "0.13.1"
       },
       "engines": {
@@ -226,28 +221,15 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@appium/base-driver/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@appium/base-plugin": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.3.0.tgz",
-      "integrity": "sha512-AdSbA8+GsEtkeXBoiw48oYGG8svyAP/PPxU4/S5QLdXEPIh3llOmLCj27CAe81WRgnlOwqIWSulLv8t9f0pDKQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-2.3.3.tgz",
+      "integrity": "sha512-wPGgTfG02O2HzCcUWbEuN4fjjs/zoA3Il/tcbaT6rnZYAbOAW2uC4B6l+eqisFRLepj1p8djf0XQyPAVyeIZzw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/base-driver": "^9.15.0",
-        "@appium/support": "^6.0.3"
+        "@appium/base-driver": "^9.16.2",
+        "@appium/support": "^6.0.6"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -255,29 +237,28 @@
       }
     },
     "node_modules/@appium/docutils": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.29.tgz",
-      "integrity": "sha512-PTot864x7HxtfCQ2SLzI2LPuYOZ0qTGb9saZtv5OfD+2nt5t77SyIhzPGpn7XSrVMCyCWU3Dn5BtbPx9X0s4Fw==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.32.tgz",
+      "integrity": "sha512-8kGYxaasCQYlYZrOD++hIPvKMgFuxjvtcATSL2bszRZvzWq6cXmVUS4guym/RzXtlAYq6NrTqshY8x5xKcSi3w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^6.0.3",
-        "@appium/tsconfig": "^0.3.3",
+        "@appium/support": "^6.0.6",
+        "@appium/tsconfig": "^0.3.4",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
-        "@types/which": "3.0.4",
         "chalk": "4.1.2",
-        "consola": "3.3.3",
+        "consola": "3.4.0",
         "diff": "7.0.0",
         "json5": "2.2.3",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",
         "read-pkg": "5.2.0",
-        "semver": "7.6.3",
+        "semver": "7.7.1",
         "source-map-support": "0.5.21",
         "teen_process": "2.2.3",
-        "type-fest": "4.31.0",
-        "typescript": "5.7.2",
+        "type-fest": "4.35.0",
+        "typescript": "5.7.3",
         "yaml": "2.7.0",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -301,9 +282,9 @@
       }
     },
     "node_modules/@appium/docutils/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -311,33 +292,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@appium/docutils/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@appium/docutils/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@appium/logger": {
@@ -365,13 +319,12 @@
       "license": "ISC"
     },
     "node_modules/@appium/schema": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.7.1.tgz",
-      "integrity": "sha512-HCK0FqYOe96gYw7xb3mlZf9uIqgUwbrMJUedJnLfynvlrRsUe2/uXhYuBPENMn89mkeoZMThgAEEVarDH0sCaQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.8.1.tgz",
+      "integrity": "sha512-3yzfQ/K7RMGnfYDgFG7JdCPsjjN3eS33n2SBeGJtd28mDtgO7EzcmtiUBQjbkxyu0Q7h8KOexiqndvgTCgHeGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/json-schema": "7.0.15",
         "json-schema": "0.4.0",
         "source-map-support": "0.5.21"
       },
@@ -381,38 +334,23 @@
       }
     },
     "node_modules/@appium/support": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@appium/support/-/support-6.0.3.tgz",
-      "integrity": "sha512-9WCO5JyxHEStdIJ3ZwyaLXXt+TGraEcDikB9p9x3+eBgAYP+nSbL/mFT5vHhaaoBP7DjfSmBmfY37fW7pdyRfA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-6.0.6.tgz",
+      "integrity": "sha512-qgj1uxHF7Suqi8wdWFBrG12dhLMAthpX973L7JHutM2jneynoIUaKtSXdd6zg0ZG/9clfY0C/06pIQTQljj+Lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^1.6.1",
-        "@appium/tsconfig": "^0.3.3",
-        "@appium/types": "^0.24.0",
+        "@appium/tsconfig": "^0.3.4",
+        "@appium/types": "^0.25.1",
         "@colors/colors": "1.6.0",
-        "@types/archiver": "6.0.3",
-        "@types/base64-stream": "1.0.5",
-        "@types/find-root": "1.1.4",
-        "@types/jsftp": "2.1.5",
-        "@types/klaw": "3.0.6",
-        "@types/lockfile": "1.0.4",
-        "@types/mv": "2.1.4",
-        "@types/ncp": "2.0.8",
-        "@types/pluralize": "0.0.33",
-        "@types/semver": "7.5.8",
-        "@types/shell-quote": "1.7.5",
-        "@types/supports-color": "8.1.3",
-        "@types/teen_process": "2.0.4",
-        "@types/uuid": "10.0.0",
-        "@types/which": "3.0.4",
         "archiver": "7.0.1",
         "axios": "1.7.9",
         "base64-stream": "1.0.0",
         "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
         "bplist-parser": "0.3.2",
-        "form-data": "4.0.1",
+        "form-data": "4.0.2",
         "get-stream": "6.0.1",
         "glob": "10.4.5",
         "jsftp": "2.1.3",
@@ -423,20 +361,19 @@
         "moment": "2.30.1",
         "mv": "2.1.1",
         "ncp": "2.0.0",
-        "opencv-bindings": "4.5.5",
         "pkg-dir": "5.0.0",
         "plist": "3.1.0",
         "pluralize": "8.0.0",
         "read-pkg": "5.2.0",
         "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.3",
-        "semver": "7.6.3",
+        "semver": "7.7.1",
         "shell-quote": "1.8.2",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
         "teen_process": "2.2.3",
-        "type-fest": "4.31.0",
-        "uuid": "11.0.4",
+        "type-fest": "4.35.0",
+        "uuid": "11.1.0",
         "which": "4.0.0",
         "yauzl": "3.2.0"
       },
@@ -460,9 +397,9 @@
       }
     },
     "node_modules/@appium/support/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -513,23 +450,10 @@
         "@img/sharp-win32-x64": "0.33.5"
       }
     },
-    "node_modules/@appium/support/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@appium/support/node_modules/uuid": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.4.tgz",
-      "integrity": "sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -541,9 +465,9 @@
       }
     },
     "node_modules/@appium/tsconfig": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.3.tgz",
-      "integrity": "sha512-Lk2M2NWVY2M8SIE1PTDVvj1NEuV4lze8yzPDSmklhkJSPDPrOCx7PkDziyjIycQBXy0ficd5CNwNDvdOD1Ym2w==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.4.tgz",
+      "integrity": "sha512-tX719/ekarAWmJb+AaG6//8+3qQITshTgTZor0EbdEwA2KG3bGPwMIoCp10np6/qFr+sMZC0CbuKJruHSCDhhw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -555,35 +479,20 @@
       }
     },
     "node_modules/@appium/types": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.24.0.tgz",
-      "integrity": "sha512-1OkU1Gzi6rmt3P2KabYKMBsTazbnrV14nNoSw1vVGxK1qJ7pRo8OlcR+6eEDsxTD/+6uY9qzOdkYdEPZAksrKA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.25.1.tgz",
+      "integrity": "sha512-2Lu5qwFNQa+iPw98XdB5/7tXKO7dugZHXfAsF050wgJkJJ4kDemVFJ4yr1YqM7DYmgqZnt+k0EfzshLODCHXTA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^1.6.1",
-        "@appium/schema": "^0.7.1",
-        "@appium/tsconfig": "^0.3.3",
-        "@types/express": "5.0.0",
-        "@types/ws": "8.5.13",
-        "type-fest": "4.31.0"
+        "@appium/schema": "^0.8.1",
+        "@appium/tsconfig": "^0.3.4",
+        "type-fest": "4.35.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
-      }
-    },
-    "node_modules/@appium/types/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3313,9 +3222,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3330,9 +3239,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
       "cpu": [
         "arm"
       ],
@@ -3347,9 +3256,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
       "cpu": [
         "arm64"
       ],
@@ -3364,9 +3273,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
       "cpu": [
         "x64"
       ],
@@ -3381,9 +3290,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
       "cpu": [
         "arm64"
       ],
@@ -3398,9 +3307,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
       "cpu": [
         "x64"
       ],
@@ -3415,9 +3324,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
       "cpu": [
         "arm64"
       ],
@@ -3432,9 +3341,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
       "cpu": [
         "x64"
       ],
@@ -3449,9 +3358,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
       "cpu": [
         "arm"
       ],
@@ -3466,9 +3375,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
       "cpu": [
         "arm64"
       ],
@@ -3483,9 +3392,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
       "cpu": [
         "ia32"
       ],
@@ -3500,9 +3409,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
       "cpu": [
         "loong64"
       ],
@@ -3517,9 +3426,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
       "cpu": [
         "mips64el"
       ],
@@ -3534,9 +3443,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
       "cpu": [
         "ppc64"
       ],
@@ -3551,9 +3460,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
       "cpu": [
         "riscv64"
       ],
@@ -3568,9 +3477,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
       "cpu": [
         "s390x"
       ],
@@ -3585,9 +3494,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
       "cpu": [
         "x64"
       ],
@@ -3601,10 +3510,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
       "cpu": [
         "x64"
       ],
@@ -3619,9 +3545,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
       "cpu": [
         "arm64"
       ],
@@ -3636,9 +3562,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
       "cpu": [
         "x64"
       ],
@@ -3653,9 +3579,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
       "cpu": [
         "x64"
       ],
@@ -3670,9 +3596,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
       "cpu": [
         "arm64"
       ],
@@ -3687,9 +3613,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
       "cpu": [
         "ia32"
       ],
@@ -3704,9 +3630,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
       "cpu": [
         "x64"
       ],
@@ -6502,34 +6428,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/archiver": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
-      "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/readdir-glob": "*"
-      }
-    },
-    "node_modules/@types/argparse": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.17.tgz",
-      "integrity": "sha512-fueJssTf+4dW4HODshEGkIZbkLKHzgu1FvCI4cTc/MKum/534Euo3SrN+ilq8xgyHnOjtmg33/hee8iXLRg1XA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/async-lock": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
-      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6577,23 +6479,6 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
-    },
-    "node_modules/@types/base64-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/base64-stream/-/base64-stream-1.0.5.tgz",
-      "integrity": "sha512-gXuo/a7pQ1EXlR5ksM2MccBLl6UUgAgnzR01r/QoHnkaSNinmzSdaGcCq5NAxn72dZ5A1zNYQIl+J9hPsBgBrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
-      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -6691,13 +6576,6 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
-    },
-    "node_modules/@types/find-root": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/find-root/-/find-root-1.1.4.tgz",
-      "integrity": "sha512-2EXK/+gVhVgtt4JqThbEncORvpYJKzi9tQGmI3EkU2jTgMzQsrPm/hbd5xe5uPdeFzIW5gh2PRvvPjaUsI8vpg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "8.1.5",
@@ -6821,16 +6699,6 @@
         "parse5": "^7.0.0"
       }
     },
-    "node_modules/@types/jsftp": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/jsftp/-/jsftp-2.1.5.tgz",
-      "integrity": "sha512-g2W6f06wXWVYZw3f/z/N5VHRK69kb1nFaNcRnxs6YxwLph+G7ebd0+Aobd3jWu43oZuyHgycpJZPn+YdIU6qRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6844,40 +6712,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/klaw": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/klaw/-/klaw-3.0.6.tgz",
-      "integrity": "sha512-BErW5TrTz4nzt/c3VRGf0Bug4JyQJ1o807F4mAfXfvOzFZ8SKgFeHJ0T28Y1KtqlMEB+cUgN7S7CsyQDQ/qxqg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/lockfile": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/method-override": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/method-override/-/method-override-3.0.0.tgz",
-      "integrity": "sha512-7XFHR6j7JljprBpzzRZatakUXm1kEGAM3PL/GSsGRHtDvOAKYCdmnXX/5YSl1eQrpJymGs9tRekSWEGaG+Ntjw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/express": "*"
-      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -6910,23 +6744,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/mv": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mv/-/mv-2.1.4.tgz",
-      "integrity": "sha512-MgEHBpXnQo44Q43j8G0Bvp/Yi8LYbC8hxKrRFMgDEDZMmzDKZLgiyMWtW49B37ko+QupgZ3G5rtPUnOGe5ixLw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/ncp": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.8.tgz",
-      "integrity": "sha512-pLNWVLCVWBLVM4F2OPjjK6FWFtByFKD7LhHryF+MbVLws7ENj09mKxRFlhkGPOXfJuaBAG+2iADKJsZwnAbYDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
@@ -6948,13 +6765,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/pluralize": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
-      "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7021,16 +6831,6 @@
         "@types/react-router": "*"
       }
     },
-    "node_modules/@types/readdir-glob": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
-      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/redux-mock-store": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.5.0.tgz",
@@ -7076,16 +6876,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/serve-favicon": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.7.tgz",
-      "integrity": "sha512-z9TNUQXdQ+W/OJMP1e3KOYUZ99qJS4+ZfFOIrPGImcayqKoyifbJSEFkVq1MCKBbqjMZpjPj3B5ilrQAR2+TOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
     "node_modules/@types/serve-index": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
@@ -7107,13 +6897,6 @@
         "@types/node": "*",
         "@types/send": "*"
       }
-    },
-    "node_modules/@types/shell-quote": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
-      "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
@@ -7145,23 +6928,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/supports-color": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
-      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/teen_process": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/teen_process/-/teen_process-2.0.4.tgz",
-      "integrity": "sha512-AJT0syZovEDa4j17szoRJX5BE2RxD3FVp6SownH43mF16TPnsV0zhtsvFGlgs5QkgsNpoooNnF+HjMow7Jd3jA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
@@ -7204,13 +6970,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/which": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
-      "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8658,26 +8417,21 @@
       }
     },
     "node_modules/appium": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/appium/-/appium-2.15.0.tgz",
-      "integrity": "sha512-sCwWxFAfp+Mgl7oCGOK0PvkWgwFqgYbxGYJSVB54HNE4rQItsKV75WPfWTuqVLX1Y9gbE+d5/95RJq5uWXUkgQ==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/appium/-/appium-2.16.2.tgz",
+      "integrity": "sha512-Vxhm4SqhbidJApU8iDsNaxJtuvxnIyJcglaXAJqcoLP/uKeDTY3Im1vYcDd8vb5ZJkjt3+gvXh+6SyUyM/Cmtw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/base-driver": "^9.15.0",
-        "@appium/base-plugin": "^2.3.0",
-        "@appium/docutils": "^1.0.29",
+        "@appium/base-driver": "^9.16.2",
+        "@appium/base-plugin": "^2.3.3",
+        "@appium/docutils": "^1.0.32",
         "@appium/logger": "^1.6.1",
-        "@appium/schema": "^0.7.1",
-        "@appium/support": "^6.0.3",
-        "@appium/types": "^0.24.0",
+        "@appium/schema": "^0.8.1",
+        "@appium/support": "^6.0.6",
+        "@appium/types": "^0.25.1",
         "@sidvind/better-ajv-errors": "3.0.1",
-        "@types/argparse": "2.0.17",
-        "@types/bluebird": "3.5.42",
-        "@types/semver": "7.5.8",
-        "@types/teen_process": "2.0.4",
-        "@types/wrap-ansi": "3.0.0",
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "argparse": "2.0.1",
@@ -8685,17 +8439,16 @@
         "asyncbox": "3.0.0",
         "axios": "1.7.9",
         "bluebird": "3.7.2",
-        "cross-env": "7.0.3",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "lru-cache": "10.4.3",
         "ora": "5.4.1",
         "package-changed": "3.0.0",
         "resolve-from": "5.0.0",
-        "semver": "7.6.3",
+        "semver": "7.7.1",
         "source-map-support": "0.5.21",
         "teen_process": "2.2.3",
-        "type-fest": "4.31.0",
+        "type-fest": "4.35.0",
         "winston": "3.17.0",
         "wrap-ansi": "7.0.0",
         "ws": "8.18.0",
@@ -8763,9 +8516,9 @@
       }
     },
     "node_modules/appium-chromedriver": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-7.0.3.tgz",
-      "integrity": "sha512-QB5s6ZZrKnC3laR9preX9hA4PezA9DsOs2DKfLNXJJQyo7kI7jKTxwOON9+6cnpGKMnLMBim0UelG9k3u+2b2w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-7.0.6.tgz",
+      "integrity": "sha512-+ycgTuznlRbnvRr8uJBG7adhBcG7sov9FYaPxdg119EGsazaIc2MT8d/2MPBOh8Y9ms8SOf8RL26kXMsImIEpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8802,14 +8555,14 @@
       }
     },
     "node_modules/appium-chromium-driver": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/appium-chromium-driver/-/appium-chromium-driver-1.5.0.tgz",
-      "integrity": "sha512-m131/pKwQD8s07m4jKxEqjDv0vrXi/3yts1I0GfGo1Wc5MY3HlCiqdrZhC0nptdRYfAwSevUGBGcJ48Q6DldBg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/appium-chromium-driver/-/appium-chromium-driver-1.5.1.tgz",
+      "integrity": "sha512-0g+UlVlm6cppuYISkPSrlGV287hiXAoFZUcLUPnhYo4YzwGMrTIOgR8VDck7ny/bNZ8wu8iGdZfUC2IgfolFmQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "appium-chromedriver": "^7.0.0",
+        "appium-chromedriver": "^7.0.6",
         "bluebird": "^3.7.2",
         "lodash": "^4.17.21"
       },
@@ -8822,27 +8575,22 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/@appium/base-driver": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.15.0.tgz",
-      "integrity": "sha512-r7021rZ/oty9LGJShRhZ8tXYQmxb0clHJJz2KBXvTcEwcV9dBMc7JAlL+Fz5i7cvryzTef396IEZMRp2VgmmQg==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.16.2.tgz",
+      "integrity": "sha512-vuQf9XQKGAMl5d5pM63FOrnRJUSVjw6J5kPXApfnkTJovwyV9SViYptnCB/TcahjX2bHQ+fUka82MWzHKPzpHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^6.0.3",
-        "@appium/types": "^0.24.0",
+        "@appium/support": "^6.0.6",
+        "@appium/types": "^0.25.1",
         "@colors/colors": "1.6.0",
-        "@types/async-lock": "1.4.2",
-        "@types/bluebird": "3.5.42",
-        "@types/express": "5.0.0",
-        "@types/lodash": "4.17.14",
-        "@types/method-override": "3.0.0",
-        "@types/serve-favicon": "2.5.7",
         "async-lock": "1.4.1",
         "asyncbox": "3.0.0",
         "axios": "1.7.9",
         "bluebird": "3.7.2",
         "body-parser": "1.20.3",
         "express": "4.21.2",
+        "fastest-levenshtein": "1.0.16",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
         "lru-cache": "10.4.3",
@@ -8851,7 +8599,7 @@
         "path-to-regexp": "8.2.0",
         "serve-favicon": "2.5.0",
         "source-map-support": "0.5.21",
-        "type-fest": "4.31.0",
+        "type-fest": "4.35.0",
         "validate.js": "0.13.1"
       },
       "engines": {
@@ -8880,13 +8628,12 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/@appium/schema": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.7.1.tgz",
-      "integrity": "sha512-HCK0FqYOe96gYw7xb3mlZf9uIqgUwbrMJUedJnLfynvlrRsUe2/uXhYuBPENMn89mkeoZMThgAEEVarDH0sCaQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.8.1.tgz",
+      "integrity": "sha512-3yzfQ/K7RMGnfYDgFG7JdCPsjjN3eS33n2SBeGJtd28mDtgO7EzcmtiUBQjbkxyu0Q7h8KOexiqndvgTCgHeGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/json-schema": "7.0.15",
         "json-schema": "0.4.0",
         "source-map-support": "0.5.21"
       },
@@ -8896,38 +8643,23 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/@appium/support": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@appium/support/-/support-6.0.3.tgz",
-      "integrity": "sha512-9WCO5JyxHEStdIJ3ZwyaLXXt+TGraEcDikB9p9x3+eBgAYP+nSbL/mFT5vHhaaoBP7DjfSmBmfY37fW7pdyRfA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-6.0.6.tgz",
+      "integrity": "sha512-qgj1uxHF7Suqi8wdWFBrG12dhLMAthpX973L7JHutM2jneynoIUaKtSXdd6zg0ZG/9clfY0C/06pIQTQljj+Lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^1.6.1",
-        "@appium/tsconfig": "^0.3.3",
-        "@appium/types": "^0.24.0",
+        "@appium/tsconfig": "^0.3.4",
+        "@appium/types": "^0.25.1",
         "@colors/colors": "1.6.0",
-        "@types/archiver": "6.0.3",
-        "@types/base64-stream": "1.0.5",
-        "@types/find-root": "1.1.4",
-        "@types/jsftp": "2.1.5",
-        "@types/klaw": "3.0.6",
-        "@types/lockfile": "1.0.4",
-        "@types/mv": "2.1.4",
-        "@types/ncp": "2.0.8",
-        "@types/pluralize": "0.0.33",
-        "@types/semver": "7.5.8",
-        "@types/shell-quote": "1.7.5",
-        "@types/supports-color": "8.1.3",
-        "@types/teen_process": "2.0.4",
-        "@types/uuid": "10.0.0",
-        "@types/which": "3.0.4",
         "archiver": "7.0.1",
         "axios": "1.7.9",
         "base64-stream": "1.0.0",
         "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
         "bplist-parser": "0.3.2",
-        "form-data": "4.0.1",
+        "form-data": "4.0.2",
         "get-stream": "6.0.1",
         "glob": "10.4.5",
         "jsftp": "2.1.3",
@@ -8938,20 +8670,19 @@
         "moment": "2.30.1",
         "mv": "2.1.1",
         "ncp": "2.0.0",
-        "opencv-bindings": "4.5.5",
         "pkg-dir": "5.0.0",
         "plist": "3.1.0",
         "pluralize": "8.0.0",
         "read-pkg": "5.2.0",
         "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.3",
-        "semver": "7.6.3",
+        "semver": "7.7.1",
         "shell-quote": "1.8.2",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
         "teen_process": "2.2.3",
-        "type-fest": "4.31.0",
-        "uuid": "11.0.4",
+        "type-fest": "4.35.0",
+        "uuid": "11.1.0",
         "which": "4.0.0",
         "yauzl": "3.2.0"
       },
@@ -8964,9 +8695,9 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/@appium/tsconfig": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.3.tgz",
-      "integrity": "sha512-Lk2M2NWVY2M8SIE1PTDVvj1NEuV4lze8yzPDSmklhkJSPDPrOCx7PkDziyjIycQBXy0ficd5CNwNDvdOD1Ym2w==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.4.tgz",
+      "integrity": "sha512-tX719/ekarAWmJb+AaG6//8+3qQITshTgTZor0EbdEwA2KG3bGPwMIoCp10np6/qFr+sMZC0CbuKJruHSCDhhw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8978,18 +8709,16 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/@appium/types": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.24.0.tgz",
-      "integrity": "sha512-1OkU1Gzi6rmt3P2KabYKMBsTazbnrV14nNoSw1vVGxK1qJ7pRo8OlcR+6eEDsxTD/+6uY9qzOdkYdEPZAksrKA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.25.1.tgz",
+      "integrity": "sha512-2Lu5qwFNQa+iPw98XdB5/7tXKO7dugZHXfAsF050wgJkJJ4kDemVFJ4yr1YqM7DYmgqZnt+k0EfzshLODCHXTA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^1.6.1",
-        "@appium/schema": "^0.7.1",
-        "@appium/tsconfig": "^0.3.3",
-        "@types/express": "5.0.0",
-        "@types/ws": "8.5.13",
-        "type-fest": "4.31.0"
+        "@appium/schema": "^0.8.1",
+        "@appium/tsconfig": "^0.3.4",
+        "type-fest": "4.35.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -9138,311 +8867,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/appium-chromium-driver/node_modules/@types/archiver": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
-      "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/readdir-glob": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/async-lock": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
-      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/base64-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/base64-stream/-/base64-stream-1.0.5.tgz",
-      "integrity": "sha512-gXuo/a7pQ1EXlR5ksM2MccBLl6UUgAgnzR01r/QoHnkaSNinmzSdaGcCq5NAxn72dZ5A1zNYQIl+J9hPsBgBrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/bluebird": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
-      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/express": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
-      "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/express-serve-static-core": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.5.tgz",
-      "integrity": "sha512-GLZPrd9ckqEBFMcVM/qRFAP0Hg3qiVEojgEFsx/N/zKXsBzbGF6z5FBDpZ0+Xhp1xr+qRZYjfGr1cWHB9oFHSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/find-root": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/find-root/-/find-root-1.1.4.tgz",
-      "integrity": "sha512-2EXK/+gVhVgtt4JqThbEncORvpYJKzi9tQGmI3EkU2jTgMzQsrPm/hbd5xe5uPdeFzIW5gh2PRvvPjaUsI8vpg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/jsftp": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/jsftp/-/jsftp-2.1.5.tgz",
-      "integrity": "sha512-g2W6f06wXWVYZw3f/z/N5VHRK69kb1nFaNcRnxs6YxwLph+G7ebd0+Aobd3jWu43oZuyHgycpJZPn+YdIU6qRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/klaw": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/klaw/-/klaw-3.0.6.tgz",
-      "integrity": "sha512-BErW5TrTz4nzt/c3VRGf0Bug4JyQJ1o807F4mAfXfvOzFZ8SKgFeHJ0T28Y1KtqlMEB+cUgN7S7CsyQDQ/qxqg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/lockfile": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/method-override": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/method-override/-/method-override-3.0.0.tgz",
-      "integrity": "sha512-7XFHR6j7JljprBpzzRZatakUXm1kEGAM3PL/GSsGRHtDvOAKYCdmnXX/5YSl1eQrpJymGs9tRekSWEGaG+Ntjw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/express": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/mv": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mv/-/mv-2.1.4.tgz",
-      "integrity": "sha512-MgEHBpXnQo44Q43j8G0Bvp/Yi8LYbC8hxKrRFMgDEDZMmzDKZLgiyMWtW49B37ko+QupgZ3G5rtPUnOGe5ixLw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/ncp": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/ncp/-/ncp-2.0.8.tgz",
-      "integrity": "sha512-pLNWVLCVWBLVM4F2OPjjK6FWFtByFKD7LhHryF+MbVLws7ENj09mKxRFlhkGPOXfJuaBAG+2iADKJsZwnAbYDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/node": {
-      "version": "22.10.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-      "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.20.0"
-      }
-    },
     "node_modules/appium-chromium-driver/node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/pluralize": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.33.tgz",
-      "integrity": "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/qs": {
-      "version": "6.9.18",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
-      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/readdir-glob": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
-      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/serve-favicon": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.7.tgz",
-      "integrity": "sha512-z9TNUQXdQ+W/OJMP1e3KOYUZ99qJS4+ZfFOIrPGImcayqKoyifbJSEFkVq1MCKBbqjMZpjPj3B5ilrQAR2+TOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/shell-quote": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
-      "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/supports-color": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
-      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/teen_process": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/teen_process/-/teen_process-2.0.4.tgz",
-      "integrity": "sha512-AJT0syZovEDa4j17szoRJX5BE2RxD3FVp6SownH43mF16TPnsV0zhtsvFGlgs5QkgsNpoooNnF+HjMow7Jd3jA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/which": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
-      "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-chromium-driver/node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/appium-chromium-driver/node_modules/@xmldom/xmldom": {
       "version": "0.9.7",
@@ -9511,9 +8941,9 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/appium-adb": {
-      "version": "12.12.0",
-      "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-12.12.0.tgz",
-      "integrity": "sha512-i6cluDIcScQK1rl+/nKqh88nVgaLW5UjVOhC2BbprGwdK6Qr7aO2ay3VKD7CWCzv7Cbmc3sLkcJh3Kx54ahO6w==",
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-12.12.1.tgz",
+      "integrity": "sha512-CgdvLBBtLkZeObJegsCQo2eUTzuHESkeewbfWROFNtrVmxKS30J9y9YV4h5WIYJbyhgQCJeX+yDa+1gO/ejFjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9534,9 +8964,9 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/appium-chromedriver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-7.0.0.tgz",
-      "integrity": "sha512-zYJjzMkHic1Xa3y/qEaXKOb0nXTD8hmTsCfLRzO7bmHpMJcPAL/3UrINUiIFDqlkIlTkS4DOfZPU4KQum/pgOA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-7.0.6.tgz",
+      "integrity": "sha512-+ycgTuznlRbnvRr8uJBG7adhBcG7sov9FYaPxdg119EGsazaIc2MT8d/2MPBOh8Y9ms8SOf8RL26kXMsImIEpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9829,31 +9259,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/appium-chromium-driver/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/appium-chromium-driver/node_modules/buffer-crc32": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -9882,9 +9287,9 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10384,6 +9789,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/appium-chromium-driver/node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/appium-chromium-driver/node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -10509,6 +9930,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-chromium-driver/node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/appium-chromium-driver/node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -10614,14 +10045,15 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -10850,6 +10282,22 @@
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-chromium-driver/node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -11633,9 +11081,9 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11701,13 +11149,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/appium-chromium-driver/node_modules/opencv-bindings": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/opencv-bindings/-/opencv-bindings-4.5.5.tgz",
-      "integrity": "sha512-FdYE9uqnoPKbAkZFEOpIh6RTtJIz1lz+W27xPCo1Ov6+d0OOgg+Hm9OT2MIGIG8V1Dp3fWlLvi7SIjDOpqO2XA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/appium-chromium-driver/node_modules/p-limit": {
       "version": "3.1.0",
@@ -11966,13 +11407,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/appium-chromium-driver/node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/appium-chromium-driver/node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -12188,9 +11622,9 @@
       "optional": true
     },
     "node_modules/appium-chromium-driver/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12644,14 +12078,13 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/streamx": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
-      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
         "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
@@ -12875,9 +12308,9 @@
       "license": "0BSD"
     },
     "node_modules/appium-chromium-driver/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
+      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -12914,13 +12347,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/appium-chromium-driver/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/appium-chromium-driver/node_modules/unorm": {
       "version": "1.6.0",
@@ -12967,9 +12393,9 @@
       }
     },
     "node_modules/appium-chromium-driver/node_modules/uuid": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.4.tgz",
-      "integrity": "sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -13358,9 +12784,9 @@
       }
     },
     "node_modules/appium-safari-driver": {
-      "version": "3.5.22",
-      "resolved": "https://registry.npmjs.org/appium-safari-driver/-/appium-safari-driver-3.5.22.tgz",
-      "integrity": "sha512-9eQVqNnsqVDk9MEjkL8FvMssQBfHHD80yymmrqj6t5q6Mtykq+oMg4WYsQZDgCdBL8Eoy8ECYCw9GwklNaxrcA==",
+      "version": "3.5.23",
+      "resolved": "https://registry.npmjs.org/appium-safari-driver/-/appium-safari-driver-3.5.23.tgz",
+      "integrity": "sha512-oQf1F+0xH2RGEE7r0bo6pfjdivJ3ZJb5/PGlofLnIrSsoSr5XXVbFJDtfT8wpoQ04ii1TSROIyJ9Z82p4U8xjQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "Apache-2.0",
@@ -13399,13 +12825,12 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/@appium/schema": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.7.1.tgz",
-      "integrity": "sha512-HCK0FqYOe96gYw7xb3mlZf9uIqgUwbrMJUedJnLfynvlrRsUe2/uXhYuBPENMn89mkeoZMThgAEEVarDH0sCaQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.8.1.tgz",
+      "integrity": "sha512-3yzfQ/K7RMGnfYDgFG7JdCPsjjN3eS33n2SBeGJtd28mDtgO7EzcmtiUBQjbkxyu0Q7h8KOexiqndvgTCgHeGQ==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/json-schema": "7.0.15",
         "json-schema": "0.4.0",
         "source-map-support": "0.5.21"
       },
@@ -13415,9 +12840,9 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/@appium/tsconfig": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.3.tgz",
-      "integrity": "sha512-Lk2M2NWVY2M8SIE1PTDVvj1NEuV4lze8yzPDSmklhkJSPDPrOCx7PkDziyjIycQBXy0ficd5CNwNDvdOD1Ym2w==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.4.tgz",
+      "integrity": "sha512-tX719/ekarAWmJb+AaG6//8+3qQITshTgTZor0EbdEwA2KG3bGPwMIoCp10np6/qFr+sMZC0CbuKJruHSCDhhw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13429,18 +12854,16 @@
       }
     },
     "node_modules/appium-safari-driver/node_modules/@appium/types": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.24.0.tgz",
-      "integrity": "sha512-1OkU1Gzi6rmt3P2KabYKMBsTazbnrV14nNoSw1vVGxK1qJ7pRo8OlcR+6eEDsxTD/+6uY9qzOdkYdEPZAksrKA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.25.1.tgz",
+      "integrity": "sha512-2Lu5qwFNQa+iPw98XdB5/7tXKO7dugZHXfAsF050wgJkJJ4kDemVFJ4yr1YqM7DYmgqZnt+k0EfzshLODCHXTA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^1.6.1",
-        "@appium/schema": "^0.7.1",
-        "@appium/tsconfig": "^0.3.3",
-        "@types/express": "5.0.0",
-        "@types/ws": "8.5.13",
-        "type-fest": "4.31.0"
+        "@appium/schema": "^0.8.1",
+        "@appium/tsconfig": "^0.3.4",
+        "type-fest": "4.35.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
@@ -13539,161 +12962,12 @@
       "extraneous": true,
       "license": "MIT"
     },
-    "node_modules/appium-safari-driver/node_modules/@types/bluebird": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
-      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/express": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
-      "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/node": {
-      "version": "22.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
-      "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.20.0"
-      }
-    },
     "node_modules/appium-safari-driver/node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "extraneous": true,
       "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/qs": {
-      "version": "6.9.18",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
-      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/teen_process": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/teen_process/-/teen_process-2.0.4.tgz",
-      "integrity": "sha512-AJT0syZovEDa4j17szoRJX5BE2RxD3FVp6SownH43mF16TPnsV0zhtsvFGlgs5QkgsNpoooNnF+HjMow7Jd3jA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/appium-safari-driver/node_modules/abort-controller": {
       "version": "3.0.0",
@@ -13869,31 +13143,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/appium-safari-driver/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/appium-safari-driver/node_modules/buffer-crc32": {
@@ -14211,6 +13460,16 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "extraneous": true,
       "license": "MIT"
+    },
+    "node_modules/appium-safari-driver/node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/appium-safari-driver/node_modules/find-up": {
       "version": "5.0.0",
@@ -15115,9 +14374,9 @@
       "license": "MIT"
     },
     "node_modules/appium-safari-driver/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -15430,13 +14689,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/appium-safari-driver/node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "extraneous": true,
-      "license": "MIT"
-    },
     "node_modules/appium-safari-driver/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -15445,9 +14697,9 @@
       "license": "0BSD"
     },
     "node_modules/appium-safari-driver/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
+      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
       "extraneous": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -15471,13 +14723,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/appium-safari-driver/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "extraneous": true,
-      "license": "MIT"
-    },
     "node_modules/appium-safari-driver/node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15486,9 +14731,9 @@
       "license": "MIT"
     },
     "node_modules/appium-safari-driver/node_modules/uuid": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.4.tgz",
-      "integrity": "sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -21394,9 +20639,9 @@
       }
     },
     "node_modules/appium-xcuitest-driver": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/appium-xcuitest-driver/-/appium-xcuitest-driver-8.3.1.tgz",
-      "integrity": "sha512-iRBWANLU8miyPX9DLzDZ/x9Sv7GBWVII0xQ/vS6GDVOCUD27PYF16oCX2eTAvcJ+GlzVhxS6dmHVUvyk/cgF7Q==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/appium-xcuitest-driver/-/appium-xcuitest-driver-8.3.2.tgz",
+      "integrity": "sha512-4ZuXQKbz3XFe6D8aXm1QByrP8D5QrB8KglCgML9EP3/9yFQYjj0R8xkJIcd2GrZXrx6V/TbSEPcpSXy5hQA5yA==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "Apache-2.0",
@@ -21406,7 +20651,7 @@
         "appium-ios-device": "^2.8.0",
         "appium-ios-simulator": "^6.2.0",
         "appium-remote-debugger": "^12.1.1",
-        "appium-webdriveragent": "^9.0.3",
+        "appium-webdriveragent": "^9.0.4",
         "appium-xcode": "^5.1.4",
         "async-lock": "^1.4.0",
         "asyncbox": "^3.0.0",
@@ -21433,27 +20678,22 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/base-driver": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.15.0.tgz",
-      "integrity": "sha512-r7021rZ/oty9LGJShRhZ8tXYQmxb0clHJJz2KBXvTcEwcV9dBMc7JAlL+Fz5i7cvryzTef396IEZMRp2VgmmQg==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-9.16.2.tgz",
+      "integrity": "sha512-vuQf9XQKGAMl5d5pM63FOrnRJUSVjw6J5kPXApfnkTJovwyV9SViYptnCB/TcahjX2bHQ+fUka82MWzHKPzpHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^6.0.3",
-        "@appium/types": "^0.24.0",
+        "@appium/support": "^6.0.6",
+        "@appium/types": "^0.25.1",
         "@colors/colors": "1.6.0",
-        "@types/async-lock": "1.4.2",
-        "@types/bluebird": "3.5.42",
-        "@types/express": "5.0.0",
-        "@types/lodash": "4.17.14",
-        "@types/method-override": "3.0.0",
-        "@types/serve-favicon": "2.5.7",
         "async-lock": "1.4.1",
         "asyncbox": "3.0.0",
         "axios": "1.7.9",
         "bluebird": "3.7.2",
         "body-parser": "1.20.3",
         "express": "4.21.2",
+        "fastest-levenshtein": "1.0.16",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
         "lru-cache": "10.4.3",
@@ -21462,7 +20702,7 @@
         "path-to-regexp": "8.2.0",
         "serve-favicon": "2.5.0",
         "source-map-support": "0.5.21",
-        "type-fest": "4.31.0",
+        "type-fest": "4.35.0",
         "validate.js": "0.13.1"
       },
       "engines": {
@@ -21473,50 +20713,29 @@
         "spdy": "4.0.2"
       }
     },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/base-driver/node_modules/@types/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/base-driver/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/docutils": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.29.tgz",
-      "integrity": "sha512-PTot864x7HxtfCQ2SLzI2LPuYOZ0qTGb9saZtv5OfD+2nt5t77SyIhzPGpn7XSrVMCyCWU3Dn5BtbPx9X0s4Fw==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-1.0.32.tgz",
+      "integrity": "sha512-8kGYxaasCQYlYZrOD++hIPvKMgFuxjvtcATSL2bszRZvzWq6cXmVUS4guym/RzXtlAYq6NrTqshY8x5xKcSi3w==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^6.0.3",
-        "@appium/tsconfig": "^0.3.3",
+        "@appium/support": "^6.0.6",
+        "@appium/tsconfig": "^0.3.4",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
-        "@types/which": "3.0.4",
         "chalk": "4.1.2",
-        "consola": "3.3.3",
+        "consola": "3.4.0",
         "diff": "7.0.0",
         "json5": "2.2.3",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",
         "read-pkg": "5.2.0",
-        "semver": "7.6.3",
+        "semver": "7.7.1",
         "source-map-support": "0.5.21",
         "teen_process": "2.2.3",
-        "type-fest": "4.31.0",
-        "typescript": "5.7.2",
+        "type-fest": "4.35.0",
+        "typescript": "5.7.3",
         "yaml": "2.7.0",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -21527,46 +20746,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
-      }
-    },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/docutils/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/docutils/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "extraneous": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/docutils/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/logger": {
@@ -21587,13 +20766,12 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/schema": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.7.1.tgz",
-      "integrity": "sha512-HCK0FqYOe96gYw7xb3mlZf9uIqgUwbrMJUedJnLfynvlrRsUe2/uXhYuBPENMn89mkeoZMThgAEEVarDH0sCaQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-0.8.1.tgz",
+      "integrity": "sha512-3yzfQ/K7RMGnfYDgFG7JdCPsjjN3eS33n2SBeGJtd28mDtgO7EzcmtiUBQjbkxyu0Q7h8KOexiqndvgTCgHeGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/json-schema": "7.0.15",
         "json-schema": "0.4.0",
         "source-map-support": "0.5.21"
       },
@@ -21618,38 +20796,23 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/support": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@appium/support/-/support-6.0.3.tgz",
-      "integrity": "sha512-9WCO5JyxHEStdIJ3ZwyaLXXt+TGraEcDikB9p9x3+eBgAYP+nSbL/mFT5vHhaaoBP7DjfSmBmfY37fW7pdyRfA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-6.0.6.tgz",
+      "integrity": "sha512-qgj1uxHF7Suqi8wdWFBrG12dhLMAthpX973L7JHutM2jneynoIUaKtSXdd6zg0ZG/9clfY0C/06pIQTQljj+Lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^1.6.1",
-        "@appium/tsconfig": "^0.3.3",
-        "@appium/types": "^0.24.0",
+        "@appium/tsconfig": "^0.3.4",
+        "@appium/types": "^0.25.1",
         "@colors/colors": "1.6.0",
-        "@types/archiver": "6.0.3",
-        "@types/base64-stream": "1.0.5",
-        "@types/find-root": "1.1.4",
-        "@types/jsftp": "2.1.5",
-        "@types/klaw": "3.0.6",
-        "@types/lockfile": "1.0.4",
-        "@types/mv": "2.1.4",
-        "@types/ncp": "2.0.8",
-        "@types/pluralize": "0.0.33",
-        "@types/semver": "7.5.8",
-        "@types/shell-quote": "1.7.5",
-        "@types/supports-color": "8.1.3",
-        "@types/teen_process": "2.0.4",
-        "@types/uuid": "10.0.0",
-        "@types/which": "3.0.4",
         "archiver": "7.0.1",
         "axios": "1.7.9",
         "base64-stream": "1.0.0",
         "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
         "bplist-parser": "0.3.2",
-        "form-data": "4.0.1",
+        "form-data": "4.0.2",
         "get-stream": "6.0.1",
         "glob": "10.4.5",
         "jsftp": "2.1.3",
@@ -21660,20 +20823,19 @@
         "moment": "2.30.1",
         "mv": "2.1.1",
         "ncp": "2.0.0",
-        "opencv-bindings": "4.5.5",
         "pkg-dir": "5.0.0",
         "plist": "3.1.0",
         "pluralize": "8.0.0",
         "read-pkg": "5.2.0",
         "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.3",
-        "semver": "7.6.3",
+        "semver": "7.7.1",
         "shell-quote": "1.8.2",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
         "teen_process": "2.2.3",
-        "type-fest": "4.31.0",
-        "uuid": "11.0.4",
+        "type-fest": "4.35.0",
+        "uuid": "11.1.0",
         "which": "4.0.0",
         "yauzl": "3.2.0"
       },
@@ -21685,36 +20847,10 @@
         "sharp": "0.33.5"
       }
     },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/support/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/support/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/tsconfig": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.3.tgz",
-      "integrity": "sha512-Lk2M2NWVY2M8SIE1PTDVvj1NEuV4lze8yzPDSmklhkJSPDPrOCx7PkDziyjIycQBXy0ficd5CNwNDvdOD1Ym2w==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-0.3.4.tgz",
+      "integrity": "sha512-tX719/ekarAWmJb+AaG6//8+3qQITshTgTZor0EbdEwA2KG3bGPwMIoCp10np6/qFr+sMZC0CbuKJruHSCDhhw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21726,35 +20862,20 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@appium/types": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.24.0.tgz",
-      "integrity": "sha512-1OkU1Gzi6rmt3P2KabYKMBsTazbnrV14nNoSw1vVGxK1qJ7pRo8OlcR+6eEDsxTD/+6uY9qzOdkYdEPZAksrKA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-0.25.1.tgz",
+      "integrity": "sha512-2Lu5qwFNQa+iPw98XdB5/7tXKO7dugZHXfAsF050wgJkJJ4kDemVFJ4yr1YqM7DYmgqZnt+k0EfzshLODCHXTA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^1.6.1",
-        "@appium/schema": "^0.7.1",
-        "@appium/tsconfig": "^0.3.3",
-        "@types/express": "5.0.0",
-        "@types/ws": "8.5.13",
-        "type-fest": "4.31.0"
+        "@appium/schema": "^0.8.1",
+        "@appium/tsconfig": "^0.3.4",
+        "type-fest": "4.35.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
-      }
-    },
-    "node_modules/appium-xcuitest-driver/node_modules/@appium/types/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@babel/code-frame": {
@@ -22086,9 +21207,9 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/@types/node": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22376,9 +21497,9 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/appium-webdriveragent/-/appium-webdriveragent-9.0.3.tgz",
-      "integrity": "sha512-xi+ZLy38znTRw+0A+hKxu2q67QTQQeRHB7GVXmZBTW6NeNvMovW+huSODH4vHU+lC2XpzB+lDy2Mx0AkTNyShQ==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/appium-webdriveragent/-/appium-webdriveragent-9.0.4.tgz",
+      "integrity": "sha512-V9du7DGa+p5GIeurxgm2Yx5KY1DLxTbmfkmRQuvW2c+6J1JYPmhOVKkMhpJMXQSIo+j0Pf6MaYNGe1bbOkoLrw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -22721,9 +21842,9 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22926,9 +22047,9 @@
       "license": "MIT"
     },
     "node_modules/appium-xcuitest-driver/node_modules/consola": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.3.3.tgz",
-      "integrity": "sha512-Qil5KwghMzlqd51UXM0b6fyaGHtOC22scxrwrz4A2882LyUMwQjnvaedN1HAeXzphspQ6CpHkzMAWxBTUruDLg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
       "extraneous": true,
       "license": "MIT",
       "engines": {
@@ -23263,6 +22384,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/appium-xcuitest-driver/node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -23388,6 +22525,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -23493,14 +22640,15 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -23729,6 +22877,22 @@
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/appium-xcuitest-driver/node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -25896,6 +25060,19 @@
       "extraneous": true,
       "license": "0BSD"
     },
+    "node_modules/appium-xcuitest-driver/node_modules/type-fest": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
+      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-xcuitest-driver/node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -25976,9 +25153,9 @@
       }
     },
     "node_modules/appium-xcuitest-driver/node_modules/uuid": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.4.tgz",
-      "integrity": "sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -26377,9 +25554,9 @@
       "license": "ISC"
     },
     "node_modules/appium/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -26387,19 +25564,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/appium/node_modules/type-fest": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
-      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/archiver": {
@@ -29071,9 +28235,9 @@
       }
     },
     "node_modules/consola": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.3.3.tgz",
-      "integrity": "sha512-Qil5KwghMzlqd51UXM0b6fyaGHtOC22scxrwrz4A2882LyUMwQjnvaedN1HAeXzphspQ6CpHkzMAWxBTUruDLg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -31762,9 +30926,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -31775,30 +30939,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.1",
-        "@esbuild/android-arm": "0.23.1",
-        "@esbuild/android-arm64": "0.23.1",
-        "@esbuild/android-x64": "0.23.1",
-        "@esbuild/darwin-arm64": "0.23.1",
-        "@esbuild/darwin-x64": "0.23.1",
-        "@esbuild/freebsd-arm64": "0.23.1",
-        "@esbuild/freebsd-x64": "0.23.1",
-        "@esbuild/linux-arm": "0.23.1",
-        "@esbuild/linux-arm64": "0.23.1",
-        "@esbuild/linux-ia32": "0.23.1",
-        "@esbuild/linux-loong64": "0.23.1",
-        "@esbuild/linux-mips64el": "0.23.1",
-        "@esbuild/linux-ppc64": "0.23.1",
-        "@esbuild/linux-riscv64": "0.23.1",
-        "@esbuild/linux-s390x": "0.23.1",
-        "@esbuild/linux-x64": "0.23.1",
-        "@esbuild/netbsd-x64": "0.23.1",
-        "@esbuild/openbsd-arm64": "0.23.1",
-        "@esbuild/openbsd-x64": "0.23.1",
-        "@esbuild/sunos-x64": "0.23.1",
-        "@esbuild/win32-arm64": "0.23.1",
-        "@esbuild/win32-ia32": "0.23.1",
-        "@esbuild/win32-x64": "0.23.1"
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
       }
     },
     "node_modules/escalade": {
@@ -33396,14 +32561,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -40281,13 +39447,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/opencv-bindings": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/opencv-bindings/-/opencv-bindings-4.5.5.tgz",
-      "integrity": "sha512-FdYE9uqnoPKbAkZFEOpIh6RTtJIz1lz+W27xPCo1Ov6+d0OOgg+Hm9OT2MIGIG8V1Dp3fWlLvi7SIjDOpqO2XA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -46611,13 +45770,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
-      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
+      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.23.0",
+        "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
       },
       "bin": {


### PR DESCRIPTION
## Description

`npm audit fix` allowed us to remove `1102341`.

`1100267` and `1102339` are not relevant after proper inspection. Note that we cannot consider a vulnerability safe just because it relates to the build or e2e tests etc, but in this case, those vulnerabilities are not relevant.

From initial inspection, `1101851` is not relevant either and doesn't seem applicable to Meerkat. I will have a further think about this (ticket to track) in case there is some p2p version of the attack - at least our current usage of Meerkat does not seem to be open to this. I've also sent a message to Fabian to discuss.