### PR TITLE
fix(ui): Forgot operations password - skip button

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -723,6 +723,7 @@
     "change": "New password",
     "cancel": "Cancel",
     "description": "Add an extra layer of security for sensitive actions in your wallet by creating an optional password.",
+    "learnmore": "Learn More",
     "input": {
       "first": {
         "symbolguide": "Symbol guide",

--- a/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.test.tsx
+++ b/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.test.tsx
@@ -103,7 +103,7 @@ describe("Forgot Passcode Page", () => {
 
     const onCloseMock = jest.fn();
 
-    const { getByTestId, getByText, findByText } = render(
+    const { getByTestId, getByText, findByText, queryByText } = render(
       <Provider store={storeMocked}>
         <ForgotAuthInfo
           isOpen
@@ -122,6 +122,8 @@ describe("Forgot Passcode Page", () => {
     expect(
       getByText(EN_TRANSLATIONS.forgotauth.passcode.description)
     ).toBeVisible();
+
+    expect(queryByText(EN_TRANSLATIONS.createpassword.button.skip)).toBeNull();
 
     for (let i = 0; i < SEED_PHRASE_LENGTH; i++) {
       act(() => {

--- a/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.tsx
+++ b/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.tsx
@@ -128,7 +128,7 @@ const ForgotAuthInfo = ({
             testId={pageId}
             description={`${i18n.t("forgotauth.newpassword.description")}`}
             onCreateSuccess={handleCreatePasswordSuccess}
-            isOnboarding={true}
+            isOnboarding={false}
           />
         )}
       </ScrollablePageLayout>

--- a/src/ui/components/PasswordModule/PasswordModule.tsx
+++ b/src/ui/components/PasswordModule/PasswordModule.tsx
@@ -231,7 +231,7 @@ const PasswordModule = forwardRef<PasswordModuleRef, PasswordModuleProps>(
                       className="learn-more"
                       onClick={openSymbolModal}
                     >
-                      Learn More
+                      {i18n.t("createpassword.learnmore")}
                     </span>
                   )
                 }

--- a/src/ui/pages/CreatePassword/CreatePassword.test.tsx
+++ b/src/ui/pages/CreatePassword/CreatePassword.test.tsx
@@ -334,4 +334,45 @@ describe("Create Password Page", () => {
       });
     });
   });
+
+  test("Hidden skip button", async () => {
+    const initialStateNoPassword = {
+      stateCache: {
+        routes: [{ path: RoutePath.CREATE_PASSWORD }],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+          passwordIsSet: false,
+          passwordIsSkipped: false,
+        },
+        toastMsgs: [],
+      },
+    };
+
+    const mockStore = configureStore();
+    const dispatchMock = jest.fn();
+    const storeMocked = {
+      ...mockStore(initialStateNoPassword),
+      dispatch: dispatchMock,
+    };
+
+    const handleClear = jest.fn();
+    const setPasswordIsSet = jest.fn();
+    const { queryByText } = render(
+      <MemoryRouter>
+        <Provider store={storeMocked}>
+          <CreatePassword
+            handleClear={handleClear}
+            setPasswordIsSet={setPasswordIsSet}
+            userAction={{
+              current: "enable",
+            }}
+          />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    expect(queryByText(EN_TRANSLATIONS.createpassword.button.skip)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Description

Hidden skip button on create password screen when recovery password.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1898)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/8933ca08-bcd2-4595-ac5b-483180d048e2

