### PR TITLE
fix(ui): Forgot operations password - modal still open

### DIFF
--- a/src/ui/components/VerifyPassword/VerifyPassword.tsx
+++ b/src/ui/components/VerifyPassword/VerifyPassword.tsx
@@ -2,8 +2,10 @@ import { IonButton } from "@ionic/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Agent } from "../../../core/agent/agent";
 import { MiscRecordId } from "../../../core/agent/agent.types";
-import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
+import { KeyStoreKeys } from "../../../core/storage";
 import { i18n } from "../../../i18n";
+import { useAppDispatch } from "../../../store/hooks";
+import { showError as showErrorMessage } from "../../utils/error";
 import { Alert } from "../Alert";
 import { CustomInput } from "../CustomInput";
 import { ErrorMessage, MESSAGE_MILLISECONDS } from "../ErrorMessage";
@@ -12,8 +14,6 @@ import { ForgotType } from "../ForgotAuthInfo/ForgotAuthInfo.types";
 import { OptionModal } from "../OptionsModal";
 import "./VerifyPassword.scss";
 import { VerifyPasswordProps } from "./VerifyPassword.types";
-import { showError as showErrorMessage } from "../../utils/error";
-import { useAppDispatch } from "../../../store/hooks";
 
 const VerifyPassword = ({
   isOpen,
@@ -204,11 +204,9 @@ const VerifyPassword = ({
       />
       <ForgotAuthInfo
         isOpen={openRecoveryAuth}
-        onClose={(shouldCloseParent) => {
+        onClose={() => {
           setOpenRecoveryAuth(false);
-          if (shouldCloseParent) {
-            resetModal();
-          }
+          resetModal();
         }}
         type={ForgotType.Password}
       />


### PR DESCRIPTION
## Description

Close verify password modal after recover password.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1897)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/7ace0a5b-1ac6-463f-82c8-44ceb1ba9464

