### PR TITLE
feat: handle failed oobi operations

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -15,7 +15,7 @@ ARG --global PUSH=false
 ARG --global KERIA_DOCKER_IMAGE_REPO=weboftrust/keria
 ARG --global KERIA_DOCKER_IMAGE_TAG=0.2.0-rc1
 ARG --global KERIA_GIT_REPO_URL="https://github.com/cardano-foundation/keria.git"
-ARG --global KERIA_GIT_REF="f9df7379ef64db3f65994807a510b5671f419dbd"
+ARG --global KERIA_GIT_REF="a61521ae84046aabbbd89e6dced87f6aa4cc2a75"
 
 ARG --global KERI_DOCKER_IMAGE_REPO=weboftrust/keri
 ARG --global KERI_DOCKER_IMAGE_TAG=1.1.26

--- a/Earthfile
+++ b/Earthfile
@@ -15,7 +15,7 @@ ARG --global PUSH=false
 ARG --global KERIA_DOCKER_IMAGE_REPO=weboftrust/keria
 ARG --global KERIA_DOCKER_IMAGE_TAG=0.2.0-rc1
 ARG --global KERIA_GIT_REPO_URL="https://github.com/cardano-foundation/keria.git"
-ARG --global KERIA_GIT_REF="6021251bc6a0dd344be75dd9a888611fa0c93764"
+ARG --global KERIA_GIT_REF="f9df7379ef64db3f65994807a510b5671f419dbd"
 
 ARG --global KERI_DOCKER_IMAGE_REPO=weboftrust/keri
 ARG --global KERI_DOCKER_IMAGE_TAG=1.1.26

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   keria:
     container_name: idw-keria
     restart: unless-stopped
-    image: cardanofoundation/cf-idw-keria:0.1.1-PR960-04d7d858-GHRUN13372990297
+    image: cardanofoundation/cf-idw-keria:0.1.1-PR984-d1f2fe0-GHRUN13569242140
     environment:
       - KERI_AGENT_CORS=true
     volumes:

--- a/services/credential-server/src/apis/schema.api.ts
+++ b/services/credential-server/src/apis/schema.api.ts
@@ -5,9 +5,10 @@ async function schemaApi(req: Request, res: Response) {
   const { id } = req.params;
   const data = ACDC_SCHEMAS[id];
   if (!data) {
-    return res.status(404).send("Schema for given SAID not found");
+    res.status(404).send("Schema for given SAID not found");
+    return;
   }
-  return res.send(data);
+  res.send(data);
 }
 
 export { schemaApi };

--- a/services/credential-server/src/apis/shorten.api.ts
+++ b/services/credential-server/src/apis/shorten.api.ts
@@ -7,9 +7,10 @@ function getFullUrl(req: Request, res: Response) {
   const { id } = req.params;
   const fullUrl = getCache(id);
   if (!fullUrl) {
-    return res.status(404).send("Url is invalid or expired");
+    res.status(404).send("Url is invalid or expired");
+    return;
   }
-  return res.send(fullUrl);
+  res.send(fullUrl);
 }
 
 async function createShortenUrl(req: Request, res: Response) {

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   keria:
     container_name: idw-keria
     restart: unless-stopped
-    image: cardanofoundation/cf-idw-keria:0.1.1-PR960-04d7d858-GHRUN13372990297
+    image: cardanofoundation/cf-idw-keria:0.1.1-PR984-d1f2fe0-GHRUN13569242140
     environment:
       - KERI_AGENT_CORS=true
     volumes:

--- a/src/core/__fixtures__/agent/multiSigFixtures.ts
+++ b/src/core/__fixtures__/agent/multiSigFixtures.ts
@@ -1,13 +1,10 @@
 import { CreateIdentifierBody, Tier } from "signify-ts";
-import { ConnectionStatus } from "../../agent/agent.types";
+import { ConnectionStatus , CreationStatus } from "../../agent/agent.types";
 import {
   IdentifierMetadataRecord,
   IdentifierMetadataRecordProps,
 } from "../../agent/records";
-import {
-  CreationStatus,
-  QueuedGroupCreation,
-} from "../../agent/services/identifier.types";
+import { QueuedGroupCreation } from "../../agent/services/identifier.types";
 
 const now = new Date();
 

--- a/src/core/agent/agent.types.ts
+++ b/src/core/agent/agent.types.ts
@@ -4,9 +4,9 @@ import { OperationPendingRecordType } from "./records/operationPendingRecord.typ
 import { ConnectionHistoryType } from "./services/connectionService.types";
 
 enum ConnectionStatus {
-  CONFIRMED = "confirmed",
   PENDING = "pending",
-  ACCEPTED = "accepted",
+  CONFIRMED = "confirmed",
+  FAILED = "failed",
   DELETED = "deleted",
 }
 
@@ -199,6 +199,12 @@ type OperationCallback = ({
   opType: OperationPendingRecordType;
 }) => void;
 
+enum CreationStatus {
+  PENDING = "PENDING",
+  COMPLETE = "COMPLETE",
+  FAILED = "FAILED",
+}
+
 export const OOBI_RE =
   /^\/oobi\/(?<cid>[^/]+)\/(?<role>[^/]+)(?:\/(?<eid>[^/]+))?$/i;
 export const OOBI_AGENT_ONLY_RE =
@@ -212,6 +218,7 @@ export {
   NotificationRoute,
   ExchangeRoute,
   KeriConnectionType,
+  CreationStatus,
 };
 
 export type {

--- a/src/core/agent/records/connectionRecord.ts
+++ b/src/core/agent/records/connectionRecord.ts
@@ -1,4 +1,5 @@
 import { BaseRecord, Tags } from "../../storage/storage.types";
+import { CreationStatus } from "../agent.types";
 import { randomSalt } from "../services/utils";
 
 interface ConnectionRecordStorageProps {
@@ -8,14 +9,14 @@ interface ConnectionRecordStorageProps {
   alias: string;
   oobi: string;
   groupId?: string;
-  pending: boolean;
+  creationStatus?: CreationStatus;
 }
 
 class ConnectionRecord extends BaseRecord {
   alias!: string;
   oobi!: string;
   groupId?: string;
-  pending!: boolean;
+  creationStatus!: CreationStatus;
   pendingDeletion = false;
   static readonly type = "ConnectionRecord";
   readonly type = ConnectionRecord.type;
@@ -28,7 +29,7 @@ class ConnectionRecord extends BaseRecord {
       this.alias = props.alias;
       this.oobi = props.oobi;
       this.groupId = props.groupId;
-      this.pending = props.pending;
+      this.creationStatus = props.creationStatus ?? CreationStatus.PENDING;
       this._tags = props.tags ?? {};
     }
   }
@@ -38,7 +39,7 @@ class ConnectionRecord extends BaseRecord {
       ...this._tags,
       groupId: this.groupId,
       pendingDeletion: this.pendingDeletion,
-      pending: this.pending,
+      creationStatus: this.creationStatus,
     };
   }
 }

--- a/src/core/agent/records/connectionStorage.test.ts
+++ b/src/core/agent/records/connectionStorage.test.ts
@@ -1,4 +1,5 @@
 import { Query, StorageService } from "../../storage/storage.types";
+import { CreationStatus } from "../agent.types";
 import {
   ConnectionRecord,
   ConnectionRecordStorageProps,
@@ -28,7 +29,7 @@ const connectionRecordProps: ConnectionRecordStorageProps = {
   alias: "alias",
   oobi: "oobi",
   tags: {},
-  pending: false,
+  creationStatus: CreationStatus.COMPLETE,
 };
 
 const connectionRecordA = new ConnectionRecord(connectionRecordProps);

--- a/src/core/agent/records/identifierMetadataRecord.ts
+++ b/src/core/agent/records/identifierMetadataRecord.ts
@@ -1,5 +1,5 @@
 import { BaseRecord } from "../../storage/storage.types";
-import { CreationStatus } from "../services/identifier.types";
+import { CreationStatus } from "../agent.types";
 
 interface GroupMetadata {
   groupId: string;
@@ -24,7 +24,7 @@ class IdentifierMetadataRecord extends BaseRecord {
   theme!: number;
   creationStatus!: CreationStatus;
   isDeleted!: boolean;
-  pendingDeletion = false;
+  pendingDeletion!: boolean;
   multisigManageAid?: string;
   groupMetadata?: GroupMetadata;
   sxlt?: string;

--- a/src/core/agent/services/identifier.types.ts
+++ b/src/core/agent/services/identifier.types.ts
@@ -1,11 +1,5 @@
 import { CreateIdentifierBody } from "signify-ts";
-import { ConnectionShortDetails } from "../agent.types";
-
-enum CreationStatus {
-  PENDING = "PENDING",
-  COMPLETE = "COMPLETE",
-  FAILED = "FAILED",
-}
+import { ConnectionShortDetails, CreationStatus } from "../agent.types";
 
 interface GroupMetadata {
   groupId: string;
@@ -86,5 +80,5 @@ export type {
   CreateIdentifierResult,
 };
 
-export { IdentifierType, CreationStatus };
+export { IdentifierType };
 export type { QueuedIdentifierCreation, QueuedGroupProps, QueuedGroupCreation };

--- a/src/core/agent/services/identifierService.test.ts
+++ b/src/core/agent/services/identifierService.test.ts
@@ -1,6 +1,6 @@
 import { PeerConnection } from "../../cardano/walletConnect/peerConnection";
 import { Agent } from "../agent";
-import { ConnectionStatus, MiscRecordId } from "../agent.types";
+import { ConnectionStatus, MiscRecordId , CreationStatus } from "../agent.types";
 import { IdentifierMetadataRecord } from "../records/identifierMetadataRecord";
 import { CoreEventEmitter } from "../event";
 import { IdentifierService } from "./identifierService";
@@ -9,7 +9,6 @@ import { OperationPendingRecordType } from "../records/operationPendingRecord.ty
 import * as utils from "./utils";
 import { BasicRecord } from "../records";
 import { StorageMessage } from "../../storage/storage.types";
-import { CreationStatus } from "./identifier.types";
 
 const listIdentifiersMock = jest.fn();
 const getIdentifierMembersMock = jest.fn();

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -1,21 +1,20 @@
 import { HabState, Operation, Signer } from "signify-ts";
 import {
   CreateIdentifierResult,
-  CreationStatus,
   IdentifierDetails,
   IdentifierShortDetails,
 } from "./identifier.types";
+import { CreationStatus ,
+  AgentServicesProps,
+  IdentifierResult,
+  MiscRecordId,
+} from "../agent.types";
 import {
   IdentifierMetadataRecord,
   IdentifierMetadataRecordProps,
 } from "../records/identifierMetadataRecord";
 import { AgentService } from "./agentService";
 import { OnlineOnly, randomSalt } from "./utils";
-import {
-  AgentServicesProps,
-  IdentifierResult,
-  MiscRecordId,
-} from "../agent.types";
 import { BasicRecord, BasicStorage, IdentifierStorage } from "../records";
 import { OperationPendingStorage } from "../records/operationPendingStorage";
 import { OperationPendingRecordType } from "../records/operationPendingRecord.type";
@@ -516,7 +515,7 @@ class IdentifierService extends AgentService {
           : CreationStatus.COMPLETE
         : CreationStatus.PENDING;
       if (creationStatus === CreationStatus.PENDING) {
-        const pendingOperation = await this.operationPendingStorage.save({
+        await this.operationPendingStorage.save({
           id: op.name,
           recordType: OperationPendingRecordType.Witness,
         });
@@ -585,7 +584,7 @@ class IdentifierService extends AgentService {
           : CreationStatus.COMPLETE
         : CreationStatus.PENDING;
       if (creationStatus === CreationStatus.PENDING) {
-        const pendingOperation = await this.operationPendingStorage.save({
+        await this.operationPendingStorage.save({
           id: op.name,
           recordType: OperationPendingRecordType.Group,
         });

--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -1,5 +1,5 @@
 import { Serder } from "signify-ts";
-import { ConnectionStatus, MiscRecordId } from "../agent.types";
+import { ConnectionStatus, MiscRecordId , CreationStatus } from "../agent.types";
 import { Agent } from "../agent";
 import { CoreEventEmitter } from "../event";
 import { MultiSigService } from "./multiSigService";
@@ -27,7 +27,6 @@ import {
 } from "../../__fixtures__/agent/multiSigFixtures";
 import { OperationPendingRecordType } from "../records/operationPendingRecord.type";
 import { EventTypes } from "../event.types";
-import { CreationStatus } from "./identifier.types";
 import { MultiSigRoute } from "./multiSig.types";
 import { StorageMessage } from "../../storage/storage.types";
 

--- a/src/core/agent/services/multiSigService.ts
+++ b/src/core/agent/services/multiSigService.ts
@@ -12,7 +12,7 @@ import {
   NotificationRoute,
   AgentServicesProps,
   MiscRecordId,
-} from "../agent.types";
+  CreationStatus } from "../agent.types";
 import type {
   ConnectionShortDetails,
   AuthorizationRequestExn,
@@ -26,7 +26,6 @@ import {
 } from "../records";
 import { AgentService } from "./agentService";
 import {
-  CreationStatus,
   MultiSigIcpRequestDetails,
   QueuedGroupCreation,
   QueuedGroupProps,

--- a/src/store/reducers/identifiersCache/identifiersCache.test.ts
+++ b/src/store/reducers/identifiersCache/identifiersCache.test.ts
@@ -20,12 +20,9 @@ import {
   addGroupIdentifierCache,
 } from "./identifiersCache";
 import { RootState } from "../../index";
-import {
-  CreationStatus,
-  IdentifierShortDetails,
-} from "../../../core/agent/services/identifier.types";
+import { IdentifierShortDetails } from "../../../core/agent/services/identifier.types";
+import { CreationStatus , ConnectionStatus } from "../../../core/agent/agent.types";
 import { FavouriteIdentifier, MultiSigGroup } from "./identifiersCache.types";
-import { ConnectionStatus } from "../../../core/agent/agent.types";
 import { IdentifiersFilters } from "../../../ui/pages/Identifiers/Identifiers.types";
 import {
   multisignIdentifierFix,

--- a/src/ui/__fixtures__/connectionsFix.ts
+++ b/src/ui/__fixtures__/connectionsFix.ts
@@ -88,7 +88,7 @@ const connectionsFix: ConnectionDetails[] = [
     label: "Friends' Bank",
     createdAtUTC: "2018-01-14T19:23:24Z",
     logo: CardanoLogo,
-    status: ConnectionStatus.ACCEPTED,
+    status: ConnectionStatus.CONFIRMED,
     serviceEndpoints: [],
     notes: [],
     historyItems: [],

--- a/src/ui/__fixtures__/filteredIdentifierFix.ts
+++ b/src/ui/__fixtures__/filteredIdentifierFix.ts
@@ -1,7 +1,5 @@
-import {
-  CreationStatus,
-  IdentifierShortDetails,
-} from "../../core/agent/services/identifier.types";
+import { IdentifierShortDetails } from "../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../core/agent/agent.types";
 
 const filteredIdentifierFix: IdentifierShortDetails[] = [
   {

--- a/src/ui/__fixtures__/identifierFix.ts
+++ b/src/ui/__fixtures__/identifierFix.ts
@@ -1,7 +1,5 @@
-import {
-  CreationStatus,
-  IdentifierDetails,
-} from "../../core/agent/services/identifier.types";
+import { IdentifierDetails } from "../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../core/agent/agent.types";
 
 const identifierFix: IdentifierDetails[] = [
   {

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -105,6 +105,7 @@ const connectionStateChangedHandler = async (
     );
     dispatch(setToastMsg(ToastMsgType.CONNECTION_REQUEST_PENDING));
   } else {
+    // @TODO - foconnor: Should be able to just update Redux without fetching from DB.
     const connectionRecordId = event.payload.connectionId!;
     const connectionDetails =
       await Agent.agent.connections.getConnectionShortDetailById(

--- a/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.tsx
+++ b/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.tsx
@@ -17,7 +17,7 @@ import { GroupMembers } from "./components/GroupMembers";
 import { SetupConnections } from "./components/SetupConnections";
 import { SetupThreshold } from "./components/SetupThreshold";
 import { Summary } from "./components/Summary";
-import { CreationStatus } from "../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../core/agent/agent.types";
 
 const stages = [SetupConnections, GroupMembers, SetupThreshold, Summary];
 

--- a/src/ui/components/CreateGroupIdentifier/components/GroupMembers.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/GroupMembers.test.tsx
@@ -10,7 +10,7 @@ import { connectionsFix } from "../../../__fixtures__/connectionsFix";
 import { GroupMembers } from "./GroupMembers";
 import { IdentifierColor } from "../../CreateIdentifier/components/IdentifierColorSelector";
 import { Stage } from "../CreateGroupIdentifier.types";
-import { CreationStatus } from "../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../core/agent/agent.types";
 
 setupIonicReact();
 mockIonicReact();

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnectionBodyInit.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnectionBodyInit.tsx
@@ -2,7 +2,7 @@ import { IonButton, IonIcon } from "@ionic/react";
 import { copyOutline, scanOutline } from "ionicons/icons";
 import { useEffect, useState } from "react";
 import { QRCode } from "react-qrcode-logo";
-import { CreationStatus } from "../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../core/agent/agent.types";
 import { i18n } from "../../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../../store/hooks";
 import { getIdentifiersCache } from "../../../../store/reducers/identifiersCache";

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnectionBodyResume.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnectionBodyResume.tsx
@@ -15,7 +15,7 @@ import { SpinnerConverage } from "../../Spinner/Spinner.type";
 import { ScrollablePageLayout } from "../../layout/ScrollablePageLayout";
 import { IdentifierStage1BodyProps } from "../CreateGroupIdentifier.types";
 import { getIdentifiersCache } from "../../../../store/reducers/identifiersCache";
-import { CreationStatus } from "../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../core/agent/agent.types";
 
 const SetupConnectionBodyResume = ({
   componentId,

--- a/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupConnections.test.tsx
@@ -17,7 +17,7 @@ import { TabsRoutePath } from "../../navigation/TabsMenu";
 import { Stage } from "../CreateGroupIdentifier.types";
 import { SetupConnections } from "./SetupConnections";
 import { passcodeFiller } from "../../../utils/passcodeFiller";
-import { CreationStatus } from "../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../core/agent/agent.types";
 import { transformGroupIdentifier } from "../../../../utils/transformGroupIdentifier";
 import { identifierFix } from "../../../__fixtures__/identifierFix";
 

--- a/src/ui/components/CreateGroupIdentifier/components/SetupThreshold.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/SetupThreshold.test.tsx
@@ -10,7 +10,7 @@ import { connectionsFix } from "../../../__fixtures__/connectionsFix";
 import { SetupThreshold } from "./SetupThreshold";
 import { IdentifierColor } from "../../CreateIdentifier/components/IdentifierColorSelector";
 import { Stage } from "../CreateGroupIdentifier.types";
-import { CreationStatus } from "../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../core/agent/agent.types";
 
 setupIonicReact();
 mockIonicReact();

--- a/src/ui/components/CreateGroupIdentifier/components/Summary.test.tsx
+++ b/src/ui/components/CreateGroupIdentifier/components/Summary.test.tsx
@@ -12,7 +12,7 @@ import { ToastMsgType } from "../../../globals/types";
 import { IdentifierColor } from "../../CreateIdentifier/components/IdentifierColorSelector";
 import { Summary } from "./Summary";
 import { Stage } from "../CreateGroupIdentifier.types";
-import { CreationStatus } from "../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../core/agent/agent.types";
 
 const createGroupMock = jest.fn();
 

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.test.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { ConnectionDetails } from "../../../core/agent/agent.types";
+import { ConnectionDetails , CreationStatus } from "../../../core/agent/agent.types";
 import { IdentifierService } from "../../../core/agent/services";
 import EN_TRANSLATION from "../../../locales/en/en.json";
 import { setMultiSigGroupCache } from "../../../store/reducers/identifiersCache";
@@ -15,7 +15,6 @@ import { filteredIdentifierMapFix } from "../../__fixtures__/filteredIdentifierF
 import { CustomInputProps } from "../CustomInput/CustomInput.types";
 import { TabsRoutePath } from "../navigation/TabsMenu";
 import { CreateIdentifier } from "./CreateIdentifier";
-import { CreationStatus } from "../../../core/agent/services/identifier.types";
 
 setupIonicReact();
 mockIonicReact();

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.tsx
@@ -8,9 +8,9 @@ import { Agent } from "../../../core/agent/agent";
 import { IdentifierService } from "../../../core/agent/services";
 import {
   CreateIdentifierInputs,
-  CreationStatus,
   IdentifierShortDetails,
 } from "../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../core/agent/agent.types";
 import { i18n } from "../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
@@ -28,7 +28,7 @@ import { formatShortDate, formatTimeToSec } from "../../utils/formatters";
 import { passcodeFiller } from "../../utils/passcodeFiller";
 import { AccordionKey } from "./components/IdentifierAttributeDetailModal/IdentifierAttributeDetailModal.types";
 import { IdentifierDetailModule } from "./IdentifierDetailModule";
-import { CreationStatus } from "../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../core/agent/agent.types";
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
@@ -116,7 +116,7 @@ describe("ConnectionDetails Page", () => {
           label: "Cambridge University",
           createdAtUTC: "2017-08-14T19:23:24Z",
           logo: ".png",
-          status: ConnectionStatus.ACCEPTED,
+          status: ConnectionStatus.CONFIRMED,
           notes: [
             {
               id: "ebfeb1ebc6f1c276ef71212ec20",

--- a/src/ui/pages/Connections/Connections.tsx
+++ b/src/ui/pages/Connections/Connections.tsx
@@ -12,11 +12,8 @@ import { Agent } from "../../../core/agent/agent";
 import {
   ConnectionShortDetails,
   ConnectionStatus,
-} from "../../../core/agent/agent.types";
-import {
-  CreationStatus,
-  IdentifierShortDetails,
-} from "../../../core/agent/services/identifier.types";
+  CreationStatus } from "../../../core/agent/agent.types";
+import { IdentifierShortDetails } from "../../../core/agent/services/identifier.types";
 import { i18n } from "../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import {
@@ -101,7 +98,11 @@ const Connections = forwardRef<ConnectionsOptionRef, ConnectionsComponentProps>(
         if (openDetailId === undefined) return;
         const connection = connectionsCache[openDetailId];
         dispatch(setOpenConnectionId(undefined));
-        if (!connection || connection.status === ConnectionStatus.PENDING) {
+        if (
+          !connection ||
+          connection.status === ConnectionStatus.PENDING ||
+          connection.status === ConnectionStatus.FAILED
+        ) {
           return;
         } else {
           await getConnectionShortDetails(openDetailId);
@@ -197,7 +198,10 @@ const Connections = forwardRef<ConnectionsOptionRef, ConnectionsComponentProps>(
     };
 
     const handleShowConnectionDetails = (item: ConnectionShortDetails) => {
-      if (item.status === ConnectionStatus.PENDING) {
+      if (
+        item.status === ConnectionStatus.PENDING ||
+        item.status === ConnectionStatus.FAILED
+      ) {
         setDeletePendingItem(item);
         setOpenDeletePendingAlert(true);
         return;

--- a/src/ui/pages/Connections/components/AlphabeticList.tsx
+++ b/src/ui/pages/Connections/components/AlphabeticList.tsx
@@ -32,15 +32,16 @@ const AlphabeticList = ({
       onCardClick={handleShowConnectionDetails}
       data={displayConnection}
       onRenderEndSlot={(data) =>
-        data.status === ConnectionStatus.PENDING ? (
-          <IonChip>
-            <IonIcon
-              icon={hourglassOutline}
-              color="primary"
-            ></IonIcon>
-            <span>{data.status}</span>
-          </IonChip>
-        ) : null
+        data.status === ConnectionStatus.PENDING ||
+        data.status === ConnectionStatus.FAILED ? (
+            <IonChip>
+              <IonIcon
+                icon={hourglassOutline}
+                color="primary"
+              ></IonIcon>
+              <span>{ConnectionStatus.PENDING}</span>
+            </IonChip>
+          ) : null
       }
     />
   );

--- a/src/ui/pages/Connections/components/IdentifierSelectorModal/IdentifierSelectorModal.test.tsx
+++ b/src/ui/pages/Connections/components/IdentifierSelectorModal/IdentifierSelectorModal.test.tsx
@@ -7,7 +7,7 @@ import configureStore from "redux-mock-store";
 import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
 import { TabsRoutePath } from "../../../../../routes/paths";
 import { IdentifierSelectorModal } from "./IdentifierSelectorModal";
-import { CreationStatus } from "../../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../../core/agent/agent.types";
 
 setupIonicReact();
 mockIonicReact();

--- a/src/ui/pages/Connections/components/IdentifierSelectorModal/IdentifierSelectorModal.tsx
+++ b/src/ui/pages/Connections/components/IdentifierSelectorModal/IdentifierSelectorModal.tsx
@@ -1,9 +1,7 @@
 import { IonCheckbox, IonContent, IonModal } from "@ionic/react";
 import { useState } from "react";
-import {
-  CreationStatus,
-  IdentifierShortDetails,
-} from "../../../../../core/agent/services/identifier.types";
+import { IdentifierShortDetails } from "../../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../../core/agent/agent.types";
 import { useAppSelector } from "../../../../../store/hooks";
 import { getIdentifiersCache } from "../../../../../store/reducers/identifiersCache";
 import KeriLogo from "../../../../assets/images/KeriGeneric.jpg";

--- a/src/ui/pages/Identifiers/Identifiers.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.tsx
@@ -3,12 +3,9 @@ import { t } from "i18next";
 import { addOutline, peopleOutline } from "ionicons/icons";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Agent } from "../../../core/agent/agent";
-import { MiscRecordId } from "../../../core/agent/agent.types";
+import { MiscRecordId , CreationStatus } from "../../../core/agent/agent.types";
 import { BasicRecord } from "../../../core/agent/records/basicRecord";
-import {
-  CreationStatus,
-  IdentifierShortDetails,
-} from "../../../core/agent/services/identifier.types";
+import { IdentifierShortDetails } from "../../../core/agent/services/identifier.types";
 import { i18n } from "../../../i18n";
 import { TabsRoutePath } from "../../../routes/paths";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
@@ -254,8 +251,8 @@ const Identifiers = () => {
     navAnimation === "cards"
       ? "cards-identifier-nav"
       : navAnimation === "favourite"
-      ? "favorite-identifier-nav"
-      : ""
+        ? "favorite-identifier-nav"
+        : ""
   }`;
   const handleCloseCreateIdentifier = (identifier?: IdentifierShortDetails) => {
     if (identifier?.groupMetadata || identifier?.multisigManageAid) {
@@ -292,8 +289,8 @@ const Identifiers = () => {
         deletedPendingItem?.creationStatus === CreationStatus.FAILED
           ? "tabs.identifiers.detelepending.witnesserror"
           : deletedPendingItem?.groupMetadata?.groupId
-          ? "tabs.identifiers.detelepending.mutilsigdescription"
-          : "tabs.identifiers.detelepending.description"
+            ? "tabs.identifiers.detelepending.mutilsigdescription"
+            : "tabs.identifiers.detelepending.description"
       ),
       button: i18n.t("tabs.identifiers.detelepending.button"),
     }),
@@ -388,8 +385,8 @@ const Identifiers = () => {
                   selectedFilter === IdentifiersFilters.All
                     ? allIdentifiers
                     : selectedFilter === IdentifiersFilters.Individual
-                    ? individualIdentifiers
-                    : groupIdentifiers
+                      ? individualIdentifiers
+                      : groupIdentifiers
                 }
                 onShowCardDetails={() => handleShowNavAnimation("cards")}
                 title={`${i18n.t("tabs.identifiers.tab.allidentifiers")}`}

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -16,7 +16,7 @@ import { walletConnectionsFix } from "../../../../__fixtures__/walletConnections
 import { OperationType, ToastMsgType } from "../../../../globals/types";
 import { passcodeFiller } from "../../../../utils/passcodeFiller";
 import { ConnectWallet } from "./ConnectWallet";
-import { CreationStatus } from "../../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../../core/agent/agent.types";
 
 jest.mock("../../../../../core/agent/agent", () => ({
   Agent: {

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.test.tsx
@@ -13,7 +13,7 @@ import { multisignIdentifierFix } from "../../../../__fixtures__/filteredIdentif
 import { notificationsFix } from "../../../../__fixtures__/notificationsFix";
 import { ErrorPage } from "./ErrorPage";
 import { DISCORD_LINK } from "../../../../globals/constants";
-import { CreationStatus } from "../../../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../../../core/agent/agent.types";
 
 mockIonicReact();
 

--- a/src/ui/pages/WalletConnect/WalletConnect.test.tsx
+++ b/src/ui/pages/WalletConnect/WalletConnect.test.tsx
@@ -9,7 +9,7 @@ import { walletConnectionsFix } from "../../__fixtures__/walletConnectionsFix";
 import { WalletConnect } from "./WalletConnect";
 import { WalletConnectStageOne } from "./WalletConnectStageOne";
 import { WalletConnectStageTwo } from "./WalletConnectStageTwo";
-import { CreationStatus } from "../../../core/agent/services/identifier.types";
+import { CreationStatus } from "../../../core/agent/agent.types";
 
 const identifierCache = [
   {

--- a/src/utils/transformGroupIdentifier.test.ts
+++ b/src/utils/transformGroupIdentifier.test.ts
@@ -1,4 +1,4 @@
-import { CreationStatus } from "../core/agent/services/identifier.types";
+import { CreationStatus } from "../core/agent/agent.types";
 import { transformGroupIdentifier } from "./transformGroupIdentifier";
 
 describe("transformGroupIdentifier", () => {


### PR DESCRIPTION
## Description

There was a bug in KERIA where failed OOBI operations are returned with a `operation.failed` attribute instead of `operation.error`. So updating our fork (will commit back to KERIA soon).

So this change follows the identifier creation too (where e.g. witness receipts time out) to have a creation status of failed. This PR sets everything up for the UI but does not implement the design, if any. For now, it just considers failed as pending. It's not important for v1 as it's an edge case.

I wanted to cover this in the core however as before if we had a failed OOBI it was being assumed as complete by our wallet which is a big issue.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1766)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).
