### PR TITLE
build(earthly): build old cred ui until new one is ready

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -159,7 +159,7 @@ cred-issuance-ui:
   LET DOCKER_IMAGE_NAME=${DOCKER_IMAGES_PREFIX}-${EARTHLY_TARGET_NAME}
 
   WAIT
-    FROM DOCKERFILE ./services/credential-server-ui
+    FROM DOCKERFILE ./services/credential-server-ui-old
   END
   WAIT
     DO functions+DOCKER_LABELS --LABELS="${DOCKER_IMAGES_LABELS}"


### PR DESCRIPTION
The directory names were updated, so pointing to the "old" UI until we've migrated.