### PR TITLE
feat(ui): Fix flakeys test

### DIFF
--- a/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
@@ -107,7 +107,7 @@ describe("Manage password", () => {
   });
 
   test("Cancel alert", async () => {
-    const { queryByTestId, getByTestId, unmount } = render(
+    const { queryByTestId, getByTestId, queryByText } = render(
       <Provider store={storeMocked}>
         <ManagePassword />
       </Provider>
@@ -128,6 +128,15 @@ describe("Manage password", () => {
 
     await waitFor(() => {
       expect(
+        queryByText(
+          TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
+            .page.alert.enablemessage
+        )
+      ).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(
         getByTestId("alert-cancel-enable-password").getAttribute("is-open")
       ).toBe("true");
       expect(
@@ -143,13 +152,20 @@ describe("Manage password", () => {
 
     await waitFor(() => {
       expect(
+        queryByText(
+          TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
+            .page.alert.enablemessage
+        )
+      ).toBeNull();
+    });
+
+    await waitFor(() => {
+      expect(
         getByTestId("alert-cancel-enable-password").getAttribute("is-open")
       ).toBe("false");
 
       expect(queryByTestId("create-password-modal")).toBe(null);
     });
-
-    unmount();
   });
 
   test("Password not set", async () => {
@@ -157,8 +173,8 @@ describe("Manage password", () => {
       queryByTestId,
       getByTestId,
       getByText,
-      findByText,
       getAllByTestId,
+      queryByText,
     } = render(
       <Provider store={storeMocked}>
         <ManagePassword />
@@ -174,21 +190,28 @@ describe("Manage password", () => {
       fireEvent.click(getByTestId("settings-item-toggle-password"));
     });
 
-    const text = await waitFor(async () => {
-      return await findByText(
-        TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
-          .page.alert.enablemessage
-      );
-    });
-
     await waitFor(() => {
-      expect(text).toBeVisible();
+      expect(
+        getByText(
+          TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
+            .page.alert.enablemessage
+        )
+      ).toBeVisible();
     });
 
     act(() => {
       fireEvent.click(
-        getAllByTestId("alert-cancel-enable-password-confirm-button")[0]
+        getByTestId("alert-cancel-enable-password-confirm-button")
       );
+    });
+
+    await waitFor(() => {
+      expect(
+        queryByText(
+          TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
+            .page.alert.enablemessage
+        )
+      ).toBeNull();
     });
 
     await waitFor(() => {
@@ -233,7 +256,7 @@ describe("Manage password", () => {
       dispatch: dispatchMock,
     };
 
-    const { queryByTestId, getByTestId, findByText } = render(
+    const { queryByTestId, getByTestId, findByText, queryByText } = render(
       <Provider store={storeMocked}>
         <ManagePassword />
       </Provider>
@@ -259,6 +282,15 @@ describe("Manage password", () => {
 
     act(() => {
       fireEvent.click(getByTestId("alert-cancel-confirm-button"));
+    });
+
+    await waitFor(() => {
+      expect(
+        queryByText(
+          TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
+            .page.alert.disablemessage
+        )
+      ).toBeNull();
     });
 
     await waitFor(() => {

--- a/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/components/ManagePassword/ManagePassword.test.tsx
@@ -166,16 +166,12 @@ describe("Manage password", () => {
 
       expect(queryByTestId("create-password-modal")).toBe(null);
     });
+
+    document.getElementsByTagName("html")[0].innerHTML = "";
   });
 
   test("Password not set", async () => {
-    const {
-      queryByTestId,
-      getByTestId,
-      getByText,
-      getAllByTestId,
-      queryByText,
-    } = render(
+    const { queryByTestId, getByTestId, getByText, queryByText } = render(
       <Provider store={storeMocked}>
         <ManagePassword />
       </Provider>
@@ -223,6 +219,8 @@ describe("Manage password", () => {
     await waitFor(() => {
       expect(getByTestId("create-password-modal")).toBeVisible();
     });
+
+    document.getElementsByTagName("html")[0].innerHTML = "";
   });
 
   test("Disable password option", async () => {
@@ -256,7 +254,7 @@ describe("Manage password", () => {
       dispatch: dispatchMock,
     };
 
-    const { queryByTestId, getByTestId, findByText, queryByText } = render(
+    const { queryByTestId, getByTestId, queryByText, getByText } = render(
       <Provider store={storeMocked}>
         <ManagePassword />
       </Provider>
@@ -271,13 +269,13 @@ describe("Manage password", () => {
       fireEvent.click(getByTestId("settings-item-toggle-password"));
     });
 
-    const text = await findByText(
-      TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword.page
-        .alert.disablemessage
-    );
-
     await waitFor(() => {
-      expect(text).toBeVisible();
+      expect(
+        getByText(
+          TRANSLATIONS.tabs.menu.tab.settings.sections.security.managepassword
+            .page.alert.disablemessage
+        )
+      ).toBeVisible();
     });
 
     act(() => {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -63,7 +63,7 @@ describe("Credential request information", () => {
       ...mockStore(initialState),
       dispatch: dispatchMock,
     };
-    const { getByText, getByTestId, queryByText } = render(
+    const { getByText, getByTestId, queryByText, unmount } = render(
       <Provider store={storeMocked}>
         <CredentialRequestInformation
           pageId="multi-sign"
@@ -105,7 +105,6 @@ describe("Credential request information", () => {
     );
 
     await waitFor(() => {
-      expect(deleteNotificationMock).toBeCalled();
       expect(
         queryByText(
           EN_TRANSLATIONS.tabs.notifications.details.credential.request
@@ -113,6 +112,13 @@ describe("Credential request information", () => {
         )
       ).toBeNull();
     });
+
+    await waitFor(() => {
+      expect(deleteNotificationMock).toBeCalled();
+    });
+
+    unmount();
+    document.getElementsByTagName("body")[0].innerHTML = "";
   });
 });
 
@@ -477,21 +483,22 @@ describe("Credential request information: multisig", () => {
 
     const back = jest.fn();
 
-    const { getByText, getByTestId, getAllByText, queryByText } = render(
-      <Provider store={storeMocked}>
-        <CredentialRequestInformation
-          pageId="multi-sign"
-          activeStatus
-          onBack={back}
-          onAccept={jest.fn()}
-          userAID="member-2"
-          notificationDetails={notificationsFix[4]}
-          credentialRequest={credRequestFix}
-          linkedGroup={linkedGroup}
-          onReloadData={jest.fn()}
-        />
-      </Provider>
-    );
+    const { getByText, getByTestId, getAllByText, queryByText, unmount } =
+      render(
+        <Provider store={storeMocked}>
+          <CredentialRequestInformation
+            pageId="multi-sign"
+            activeStatus
+            onBack={back}
+            onAccept={jest.fn()}
+            userAID="member-2"
+            notificationDetails={notificationsFix[4]}
+            credentialRequest={credRequestFix}
+            linkedGroup={linkedGroup}
+            onReloadData={jest.fn()}
+          />
+        </Provider>
+      );
 
     await waitFor(() => {
       expect(
@@ -578,5 +585,8 @@ describe("Credential request information: multisig", () => {
     await waitFor(() => {
       expect(deleteNotificationMock).toBeCalled();
     });
+
+    unmount();
+    document.getElementsByTagName("body")[0].innerHTML = "";
   });
 });

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -477,7 +477,7 @@ describe("Credential request information: multisig", () => {
 
     const back = jest.fn();
 
-    const { getByText, getByTestId, getAllByText, getAllByTestId } = render(
+    const { getByText, getByTestId, getAllByText, queryByText } = render(
       <Provider store={storeMocked}>
         <CredentialRequestInformation
           pageId="multi-sign"
@@ -553,17 +553,26 @@ describe("Credential request information: multisig", () => {
 
     await waitFor(() => {
       expect(
-        getAllByTestId("multisig-request-alert-decline")[0]
-      ).toHaveTextContent(
-        EN_TRANSLATIONS.tabs.notifications.details.credential.request
-          .information.alert.textdecline
-      );
+        getByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.alert.textdecline
+        )
+      ).toBeVisible();
     });
 
     act(() => {
       fireEvent.click(
-        getAllByTestId("multisig-request-alert-decline-confirm-button")[0]
+        getByTestId("multisig-request-alert-decline-confirm-button")
       );
+    });
+
+    await waitFor(() => {
+      expect(
+        queryByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.alert.textdecline
+        )
+      ).toBeNull();
     });
 
     await waitFor(() => {


### PR DESCRIPTION
## Description

It seem Jest doesn't cleanup JSDOM after each test (maybe only for alert) (https://github.com/jestjs/jest/issues/1224), it make alert 's JSDOM of previous test still exist on current test and jest find duplicate text. Therefore, I was cleaned up JSDOM after the test that use `Alert` component.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1915)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---