### PR TITLE
build: only copy files for build:cap

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "webpack serve --config webpack.dev.cjs --host 0.0.0.0 --port 3003",
     "build": "cross-env ENVIRONMENT=remote webpack --config webpack.prod.cjs",
     "build:local": "cross-env ENVIRONMENT=local-direct webpack --config webpack.prod.cjs",
-    "build:cap": "npm run build && npx cap sync",
+    "build:cap": "npm run build && npx cap copy",
     "build:e2e": "npm run build:local && npx cap sync",
     "prettier": "npx prettier --write './src/**/*.{ts,tsx,scss}' 'services/{credential-server,credential-server-ui}/src/**/*.{ts,tsx,scss}'",
     "eslint": "eslint 'src/**/*.{ts,tsx}'",


### PR DESCRIPTION
## Description

We only need to call `npx cap sync` when adding new Capacitor dependencies. `npx cap copy` should be enough to copy the web files after we've made changes.

The main issue right now with `npx cap sync` is we merged #988 which contains some custom iOS build flags for security reasons, and `npx cap sync` will overwrite the changes.