### PR TITLE
fix: exclude minification of all SQLCipher classes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,6 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -50,3 +50,7 @@
 -keep class * {
     @androidx.annotation.Keep *;
 }
+
+# This will exclude minification of all SQLCipher classes and class-members so Capacitor Community SQLite does not error on minified function names
+-keep class net.sqlcipher.** { *; }
+-keepclassmembers class net.sqlcipher.** { *; }


### PR DESCRIPTION
## Description

When build the app through command line in Android Emulator - the app keep crashing.

Adding the flags from the doc above fixes the issue. Then,
`npm run build:cap && cd android && ./gradlew assembleRelease`

Source: [link](https://github.com/capacitor-community/sqlite/blob/master/docs/AndroidMinify.md)

## Checklist before requesting a review

### Issue ticket number and [link](https://cardanofoundation.atlassian.net/browse/DTIS-1948)

- [x] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated
