### PR TITLE
fix(core): group toad should match mhab toad

### DIFF
--- a/src/core/agent/services/multiSigService.test.ts
+++ b/src/core/agent/services/multiSigService.test.ts
@@ -352,7 +352,7 @@ describe("Creation of multi-sig", () => {
       mhab: getMemberIdentifierResponse,
       isith: 2,
       nsith: 2,
-      toad: 0,
+      toad: 3,
       wits: [],
       states: [
         getMemberIdentifierResponse.state,
@@ -778,7 +778,7 @@ describe("Creation of multi-sig", () => {
       mhab: getMemberIdentifierResponse,
       isith: 2,
       nsith: 2,
-      toad: 0,
+      toad: 3,
       wits: [],
       states: [
         resolvedOobiOpResponse.op.response,

--- a/src/core/agent/services/multiSigService.ts
+++ b/src/core/agent/services/multiSigService.ts
@@ -258,7 +258,7 @@ class MultiSigService extends AgentService {
         mhab: mHab,
         isith: threshold,
         nsith: threshold,
-        toad: mHab.state.b.length,
+        toad: Number(mHab.state.bt),
         wits: mHab.state.b,
         states: states,
         rstates: states,


### PR DESCRIPTION
## Description

Group toad should always match that of the mhab toad, and use a sensible threshold.

This was setting it to the max number, so I missed this when changing to the witness discovery mechanism.