### PR TITLE
fix(ui): android wrong navigation when create group identifier

### DIFF
--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -295,7 +295,7 @@ const Scanner = forwardRef(
 
     const handleAfterScanMultisig = () => {
       dispatch(setCurrentOperation(OperationType.OPEN_MULTISIG_IDENTIFIER));
-      handleReset?.();
+      handleReset?.(TabsRoutePath.IDENTIFIERS);
     };
 
     const handleDuplicateConnectionError = async (
@@ -398,6 +398,7 @@ const Scanner = forwardRef(
 
             if (scanMultiSigByTab) {
               handleAfterScanMultisig();
+              return;
             } else {
               handleReset?.();
             }

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -509,7 +509,7 @@ const Scanner = forwardRef(
     const processValue = async (content: string) => {
       await stopScan();
 
-      if (/^b[1-9A-HJ-NP-Za-km-z]{33}/.test(content)) {
+      if (currentOperation === OperationType.SCAN_WALLET_CONNECTION) {
         handleConnectWallet(content);
         isHandlingQR.current = false;
         return;


### PR DESCRIPTION
## Description

When scanning another group member's OOBI to finish setting up a group, we should be able to do this from the main scanner.

Also includes a fix to only allow meerkat IDs for the Cardano Connect scanner.

**Pending:** When scanning group OOBIs, either the initiator one, or other group members from the full page scanner (e.g. Connections page, as opened from any of the 3 locations), we should be able to continuing setting up the group correctly.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-1958)]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Android
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Browser
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)