### PR TITLE
feat(core): integrate freerasp

### DIFF
--- a/src/ui/pages/SystemThreatAlert/SystemThreatAlert.scss
+++ b/src/ui/pages/SystemThreatAlert/SystemThreatAlert.scss
@@ -1,0 +1,157 @@
+.system-threat-alert-page {
+  .alert-container {
+    text-align: center;
+    min-height: 95vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+  }
+
+  .title {
+    color: var(--ion-color-neutral-800);
+    margin-top: 1.5rem;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+
+  .description {
+    color: var(--ion-color-neutral-700);
+    margin-top: 1rem;
+    font-size: 1rem;
+  }
+
+  .system-threats {
+    width: 100%;
+    margin-top: 1.5rem;
+  }
+
+  .warning-icon {
+    font-size: 3.25rem;
+    color: var(--ion-color-danger);
+  }
+
+  .init-error {
+    text-align: left;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    color: var(--color-neutral-700);
+    font-weight: 400;
+  }
+
+  .accordion-group {
+    --ion-background-color: var(--ion-color-neutral-100);
+    margin-bottom: 0;
+
+    .accordion {
+      border-radius: 1rem;
+      padding: 0.75rem 0;
+
+      ion-item {
+        &.threat-header {
+          font-weight: 500;
+          --ripple-color: transparent;
+          --background-activated: transparent;
+          --background-activated-opacity: 0;
+          --background-focused: transparent;
+          --background-focused-opacity: 0;
+          --background-hover: transparent;
+          --background-hover-opacity: 0;
+          --color: var(--ion-color-neutral-700);
+          --color-activated: var(--ion-color-neutral-700);
+          --color-focused: var(--ion-color-neutral-700);
+
+          ion-icon {
+            margin: 0 0 0 1rem;
+            width: 1rem;
+            height: 1rem;
+            color: var(--color-neutral-400) !important;
+          }
+
+          .threat-header-content {
+            display: flex;
+            align-items: center;
+            width: 100%;
+          }
+
+          .threat-name {
+            color: var(--ion-color-neutral-700);
+            font-weight: 500;
+            font-size: 1rem;
+          }
+
+          &:active {
+            --background: transparent;
+            --color: var(--ion-color-neutral-700);
+          }
+        }
+      }
+
+      .threat-content {
+        text-align: left;
+        padding: 0 1rem;
+      }
+
+      .threat-description {
+        font-size: 1rem;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 1.5rem;
+      }
+    }
+  }
+
+  .info-card {
+    background-color: rgba(var(--ion-color-warning-800-rgb), 0.1);
+    margin: 1.5rem 0;
+
+    p {
+      text-align: left;
+    }
+
+    ion-icon {
+      color: var(--ion-color-warning-800);
+    }
+  }
+
+  .help-button {
+    margin-top: 1.5rem;
+    width: 100%;
+    height: 3.5rem;
+    border-radius: 1rem;
+    padding: 1rem 1.5rem 1rem 1.25rem;
+    background: linear-gradient(
+        0deg,
+        var(--color-primary-700, #0056b3),
+        var(--color-primary-700, #0056b3)
+      ),
+      radial-gradient(
+        1.86% 150% at 50% 50%,
+        rgba(0, 86, 179, 0.2) 50%,
+        rgba(0, 86, 179, 0.2) 50%
+      );
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    letter-spacing: 0%;
+    text-align: center;
+    color: var(--color-neutral-100, #f9fafb);
+
+    .help-icon {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+
+    span {
+      font-size: 1rem;
+      font-style: normal;
+      font-weight: 500;
+      line-height: 1.5rem;
+    }
+  }
+}

--- a/src/ui/pages/SystemThreatAlert/SystemThreatAlert.test.tsx
+++ b/src/ui/pages/SystemThreatAlert/SystemThreatAlert.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render } from "@testing-library/react";
+import TRANSLATE from "../../../locales/en/en.json";
+import SystemThreatAlert, { SUPPORT_LINK } from "./SystemThreatAlert";
+
+const browserMock = jest.fn(({ link }: { link: string }) =>
+  Promise.resolve(link)
+);
+
+jest.mock("@capacitor/browser", () => ({
+  ...jest.requireActual("@capacitor/browser"),
+  Browser: {
+    open: (params: never) => browserMock(params),
+  },
+}));
+
+describe("System Threat Alert", () => {
+  test("Render", async () => {
+    const { getByText } = render(
+      <SystemThreatAlert error="Debug threat error" />
+    );
+
+    expect(getByText(TRANSLATE.systemthreats.title)).toBeVisible();
+    expect(getByText(TRANSLATE.systemthreats.description)).toBeVisible();
+    expect(getByText(TRANSLATE.systemthreats.help)).toBeVisible();
+    expect(getByText(TRANSLATE.systemthreats.initerror)).toBeVisible();
+  });
+
+  test("Click on Help button", async () => {
+    const { getByText } = render(
+      <SystemThreatAlert error="Debug threat error" />
+    );
+
+    fireEvent.click(getByText(TRANSLATE.systemthreats.help));
+
+    expect(browserMock).toBeCalledWith({
+      url: SUPPORT_LINK,
+    });
+  });
+});

--- a/src/ui/pages/SystemThreatAlert/SystemThreatAlert.tsx
+++ b/src/ui/pages/SystemThreatAlert/SystemThreatAlert.tsx
@@ -1,0 +1,70 @@
+import { Browser } from "@capacitor/browser";
+import { IonIcon } from "@ionic/react";
+import {
+  alertCircleOutline,
+  helpCircleOutline,
+  warningOutline,
+} from "ionicons/icons";
+import React from "react";
+import { i18n } from "../../../i18n";
+import { CardDetailsBlock } from "../../components/CardDetails";
+import { InfoCard } from "../../components/InfoCard";
+import { ScrollablePageLayout } from "../../components/layout/ScrollablePageLayout";
+import { PageFooter } from "../../components/PageFooter";
+import "./SystemThreatAlert.scss";
+import { SystemThreatAlertProps } from "./SystemThreatAlert.types";
+
+export const SUPPORT_LINK =
+  "https://cardanofoundation.atlassian.net/servicedesk/customer/portal/14";
+
+const SystemThreatAlert: React.FC<SystemThreatAlertProps> = ({ error }) => {
+  const handleHelpButtonClick = () => {
+    Browser.open({
+      url: SUPPORT_LINK,
+    });
+  };
+
+  const pageId = "system-threat-alert-page";
+  return (
+    <ScrollablePageLayout
+      activeStatus
+      pageId={pageId}
+    >
+      <div className="alert-container">
+        <IonIcon
+          icon={alertCircleOutline}
+          className="warning-icon"
+        />
+        <h2 className="title">
+          {i18n.t("systemthreats.title", {
+            defaultValue: "Threats Detected",
+          })}
+        </h2>
+        <p className="description">
+          {i18n.t("systemthreats.description", {
+            defaultValue:
+              "The following security threats have been detected on your device:",
+          })}
+        </p>
+        <CardDetailsBlock className="system-threats">
+          <p className="init-error">
+            {i18n.t("systemthreats.initerror", {
+              defaultValue: error,
+            })}
+          </p>
+        </CardDetailsBlock>
+        <InfoCard
+          content={i18n.t("systemthreats.alert")}
+          icon={warningOutline}
+        />
+        <PageFooter
+          primaryButtonText={`${i18n.t("systemthreats.help")}`}
+          primaryButtonIcon={helpCircleOutline}
+          primaryButtonAction={handleHelpButtonClick}
+        />
+      </div>
+    </ScrollablePageLayout>
+  );
+};
+
+export default SystemThreatAlert;

--- a/src/ui/pages/SystemThreatAlert/SystemThreatAlert.types.ts
+++ b/src/ui/pages/SystemThreatAlert/SystemThreatAlert.types.ts
@@ -1,0 +1,3 @@
+export interface SystemThreatAlertProps {
+  error?: string;
+}


### PR DESCRIPTION
### Description

Integration of freeRASP for Security Threat Detection in the application.

This change introduces the integration of the `capacitor-freerasp` library to enhance application security by detecting critical and non-critical runtime threats. A new utility file `freerasp.ts` is added to initialize and configure freeRASP, a rules file `freeraspRules.ts` is created to define threats and their properties, and `App.tsx` is updated to leverage these tools, automatically closing the app if a critical threat is detected.

#### Key Changes
1. **New File: `utils/freerasp.ts`**
   - Defines a `ThreatName` enum listing potential threats freeRASP can detect, such as privileged access, debug mode, app integrity, etc.
   - Introduces a `ThreatCheck` interface to track the security status (`isSecure`) of each threat.
   - Configures `freeRASPConfig` with Android-specific details (`packageName`, `certificateHashes`) and iOS-specific details (`appBundleId`, `appTeamId`), along with a notification email and a production flag based on `DEV_MODE`.
   - Establishes initial check lists: `commonChecks` for shared threats, `androidChecks` for Android-specific threats, and `iosChecks` for iOS-specific threats, all defaulting to `isSecure: true`.
   - Implements `createThreatAction`, a factory function to update threat states when detected, and `initializeFreeRASP`, which sets up and starts freeRASP with corresponding actions.

2. **New File: `utils/freeraspRules.ts`**
   - Defines `freeraspRules`, an object mapping each `ThreatName` to:
     - A `name` matching the enum.
     - A `critical` flag (true for severe threats like root access or compromised integrity).
     - A detailed `description` of each threat’s purpose and risk.
   - Includes platform-specific threats (e.g., `obfuscation_issues` for Android, `device_id` for iOS) and adjusts criticality for some (e.g., `developer_mode`, `adb_enabled`) based on the environment (`DEV_MODE`).

3. **Update in `App.tsx`**
   - Imports and uses `initializeFreeRASP` to start freeRASP on component mount, updating the `appChecks` state with detection results.
   - Adds a `useEffect` hook that continuously checks `appChecks` against `freeraspRules`. If a critical threat (`critical: true`) has `isSecure: false`, it calls `CapacitorApp.exitApp()` to close the app on native platforms.

#### How to replicate and show the SystemThreatAlert page
Just set `DEV_MODE` to false in .env.

#### Notes for Reviewers
- Ensure environment variables (`REACT_APP_CERT_HASH`, `DEV_MODE`) are properly set in the CI/CD pipeline.
- Review the rules and descriptions in `freeraspRules.ts`.
- When a threat is raised and catched we show the SystemThreatAlert page blocking the app and wiping the seed phrase in redux. The user has to close and open the app manually to try again.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/jira/software/projects/DTIS/boards/36?assignee=631ed01829083bbe8cc2e570&selectedIssue=DTIS-1946)]

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences

Threat Alert Screen:
#### IOS
<img width="364" alt="Screenshot 2025-03-17 at 11 26 34" src="https://github.com/user-attachments/assets/921706f2-a461-4984-ae37-4def629f4194" />

#### Android
![Screenshot_20250317_113511](https://github.com/user-attachments/assets/a96b2a8d-54b1-49a7-8e01-456b1ad59474)

