### PR TITLE
fix(ui): Remove watch the video from profile under wallet menu

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1402,8 +1402,7 @@
             "actionedit": "Edit",
             "actionconfirm": "Confirm",
             "actioncancel": "Cancel",
-            "name": "Name",
-            "watchvideo": "Watch the video"
+            "name": "Name"
           },
           "connections": {
             "title": "Connections",

--- a/src/ui/globals/constants.ts
+++ b/src/ui/globals/constants.ts
@@ -6,7 +6,6 @@ const DOUBLE_TAP_DELAY = 300;
 // Links
 const DISCORD_LINK = "https://discord.com/invite/9yNneV8Ktv";
 const DOCUMENTATION_LINK = "https://docs.idw.cardanofoundation.org/";
-const PROFILE_LINK = "https://youtu.be/82oJLhwWFk8";
 const ONBOARDING_DOCUMENTATION_LINK =
   "https://docs.idw.cardanofoundation.org/ballot/onboarding";
 const RECOVERY_DOCUMENTATION_LINK =
@@ -23,7 +22,6 @@ export {
   DOUBLE_TAP_DELAY,
   DISCORD_LINK,
   DOCUMENTATION_LINK,
-  PROFILE_LINK,
   ONBOARDING_DOCUMENTATION_LINK,
   RECOVERY_DOCUMENTATION_LINK,
   ANDROID_MIN_VERSION,

--- a/src/ui/pages/Menu/components/Profile/Profile.test.tsx
+++ b/src/ui/pages/Menu/components/Profile/Profile.test.tsx
@@ -3,12 +3,11 @@ import { ionFireEvent } from "@ionic/react-test-utils";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
+import { configureStore } from "@reduxjs/toolkit";
 import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
 import { TabsRoutePath } from "../../../../../routes/paths";
 import { setAuthentication } from "../../../../../store/reducers/stateCache";
 import { CustomInputProps } from "../../../../components/CustomInput/CustomInput.types";
-import { PROFILE_LINK } from "../../../../globals/constants";
 import { Menu } from "../../Menu";
 import { SubMenuKey } from "../../Menu.types";
 
@@ -79,7 +78,9 @@ jest.mock("@capacitor/browser", () => ({
   },
 }));
 
-const mockStore = configureStore();
+const mockStore = configureStore({
+  reducer: (state = initialState, action) => state,
+});
 const dispatchMock = jest.fn();
 
 const initialState = {
@@ -109,7 +110,7 @@ const initialState = {
 };
 
 const storeMocked = {
-  ...mockStore(initialState),
+  ...mockStore,
   dispatch: dispatchMock,
 };
 
@@ -280,36 +281,6 @@ describe("Profile page", () => {
 
     await waitFor(() => {
       expect(getByText(EN_TRANSLATIONS.nameerror.hasspecialchar)).toBeVisible();
-    });
-  });
-
-  test("Open Profile link", async () => {
-    const { getByTestId, getByText } = render(
-      <Provider store={storeMocked}>
-        <Menu />
-      </Provider>
-    );
-
-    expect(getByTestId("menu-tab")).toBeInTheDocument();
-    expect(
-      getByText(EN_TRANSLATIONS.tabs.menu.tab.items.profile.title)
-    ).toBeInTheDocument();
-    const profileButton = getByTestId(`menu-input-item-${SubMenuKey.Profile}`);
-
-    act(() => {
-      fireEvent.click(profileButton);
-    });
-
-    const profileLink = getByTestId("profile-item-profile-link");
-
-    act(() => {
-      fireEvent.click(profileLink);
-    });
-
-    await waitFor(() => {
-      expect(browserMock).toBeCalledWith({
-        url: PROFILE_LINK,
-      });
     });
   });
 });

--- a/src/ui/pages/Menu/components/Profile/Profile.test.tsx
+++ b/src/ui/pages/Menu/components/Profile/Profile.test.tsx
@@ -78,11 +78,6 @@ jest.mock("@capacitor/browser", () => ({
   },
 }));
 
-const mockStore = configureStore({
-  reducer: (state = initialState, action) => state,
-});
-const dispatchMock = jest.fn();
-
 const initialState = {
   stateCache: {
     routes: ["/"],
@@ -108,6 +103,11 @@ const initialState = {
     showConnectWallet: false,
   },
 };
+
+const mockStore = configureStore({
+  reducer: (state = initialState, action) => state,
+});
+const dispatchMock = jest.fn();
 
 const storeMocked = {
   ...mockStore,

--- a/src/ui/pages/Menu/components/Profile/Profile.tsx
+++ b/src/ui/pages/Menu/components/Profile/Profile.tsx
@@ -1,7 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
-import { IonCard, IonIcon, IonItem } from "@ionic/react";
-import { chevronForward } from "ionicons/icons";
-import { Browser } from "@capacitor/browser";
+import { IonCard, IonItem } from "@ionic/react";
 import { ProfileOptionRef, ProfileProps } from "./Profile.types";
 import "./Profile.scss";
 import { i18n } from "../../../../../i18n";
@@ -14,7 +12,6 @@ import {
   setAuthentication,
 } from "../../../../../store/reducers/stateCache";
 import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
-import { PROFILE_LINK } from "../../../../globals/constants";
 import { showError } from "../../../../utils/error";
 import { nameChecker } from "../../../../utils/nameChecker";
 import { ErrorMessage } from "../../../../components/ErrorMessage";
@@ -88,23 +85,6 @@ const Profile = forwardRef<ProfileOptionRef, ProfileProps>(
                 >
                   <span>{i18n.t("tabs.menu.tab.items.profile.name")}</span>
                   <span>{userName}</span>
-                </div>
-              </IonItem>
-            </IonCard>
-            <IonCard>
-              <IonItem onClick={() => Browser.open({ url: PROFILE_LINK })}>
-                <div
-                  className="profile-item"
-                  data-testid="profile-item-profile-link"
-                >
-                  <span>
-                    {i18n.t("tabs.menu.tab.items.profile.watchvideo")}
-                  </span>
-                  <IonIcon
-                    aria-hidden="true"
-                    icon={chevronForward}
-                    slot="end"
-                  />
                 </div>
               </IonItem>
             </IonCard>


### PR DESCRIPTION
## Description

Removing the link to watch the video in the Profile menu.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [**DTIS-1981**](https://cardanofoundation.atlassian.net/issues/DTIS-1981)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---

![12032025133704](https://github.com/user-attachments/assets/08ab9194-8ccb-4e9b-88b4-e2a9db1e30f5)

