### PR TITLE
feat(ui): Welcome back - Ive forgotten my passcode when recovery phrase is not yet set

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -167,8 +167,8 @@ const App = () => {
             <div className={showScan ? "ion-hide" : ""}>
               <Routes />
             </div>
+            <LockPage />
           </IonReactRouter>
-          <LockPage />
           <AppOffline />
         </>
       );

--- a/src/ui/pages/LockPage/LockPage.test.tsx
+++ b/src/ui/pages/LockPage/LockPage.test.tsx
@@ -264,7 +264,7 @@ describe("Lock Page", () => {
       },
     };
 
-    const { getByText, findByText, getByTestId } = render(
+    const { getByText } = render(
       <Provider store={storeMocked(initialState)}>
         <MemoryRouter initialEntries={[RoutePath.ROOT]}>
           <IonReactRouter>
@@ -279,14 +279,6 @@ describe("Lock Page", () => {
     );
 
     fireEvent.click(getByText(EN_TRANSLATIONS.lockpage.forgotten.button));
-
-    await waitFor(() => {
-      expect(
-        getByText(EN_TRANSLATIONS.lockpage.alert.button.verify)
-      ).toBeVisible();
-    });
-
-    fireEvent.click(getByText(EN_TRANSLATIONS.lockpage.alert.button.verify));
 
     await waitFor(() => {
       expect(deleteById).toBeCalled();

--- a/src/ui/pages/LockPage/LockPage.tsx
+++ b/src/ui/pages/LockPage/LockPage.tsx
@@ -148,37 +148,8 @@ const LockPageContainer = () => {
   };
 
   const resetPasscode = async () => {
-    if (authentication.seedPhraseIsSet) {
-      setOpenRecoveryAuth(true);
-      return;
-    }
-
-    try {
-      await Promise.all([
-        SecureStorage.delete(KeyStoreKeys.APP_PASSCODE),
-        SecureStorage.delete(KeyStoreKeys.APP_OP_PASSWORD),
-      ]);
-
-      await Promise.allSettled([
-        Agent.agent.basicStorage.deleteById(MiscRecordId.OP_PASS_HINT),
-        Agent.agent.basicStorage.deleteById(MiscRecordId.APP_PASSWORD_SKIPPED),
-        Agent.agent.basicStorage.deleteById(MiscRecordId.APP_ALREADY_INIT),
-      ]);
-
-      router.push(RoutePath.ROOT);
-
-      dispatch(
-        setAuthentication({
-          ...authentication,
-          passcodeIsSet: false,
-          passwordIsSet: false,
-          passwordIsSkipped: false,
-          loggedIn: true,
-        })
-      );
-    } catch (e) {
-      showError("Failed to clear app: ", e, dispatch);
-    }
+    setOpenRecoveryAuth(true);
+    return;
   };
 
   const error = useMemo(() => {
@@ -214,6 +185,40 @@ const LockPageContainer = () => {
         .catch((e) => showError("Unable to clear listener", e));
     };
   }, []);
+
+  const handleRecoveryButtonClick = async () => {
+    if (authentication.seedPhraseIsSet) {
+      setAlertIsOpen(true);
+      return;
+    }
+
+    try {
+      await Promise.all([
+        SecureStorage.delete(KeyStoreKeys.APP_PASSCODE),
+        SecureStorage.delete(KeyStoreKeys.APP_OP_PASSWORD),
+      ]);
+
+      await Promise.allSettled([
+        Agent.agent.basicStorage.deleteById(MiscRecordId.OP_PASS_HINT),
+        Agent.agent.basicStorage.deleteById(MiscRecordId.APP_PASSWORD_SKIPPED),
+        Agent.agent.basicStorage.deleteById(MiscRecordId.APP_ALREADY_INIT),
+      ]);
+
+      router.push(RoutePath.ROOT);
+
+      dispatch(
+        setAuthentication({
+          ...authentication,
+          passcodeIsSet: false,
+          passwordIsSet: false,
+          passwordIsSkipped: false,
+          loggedIn: true,
+        })
+      );
+    } catch (e) {
+      showError("Failed to clear app: ", e, dispatch);
+    }
+  };
 
   return (
     <ResponsivePageLayout
@@ -258,7 +263,7 @@ const LockPageContainer = () => {
       <PageFooter
         pageId={pageId}
         secondaryButtonText={`${i18n.t("lockpage.forgotten.button")}`}
-        secondaryButtonAction={() => setAlertIsOpen(true)}
+        secondaryButtonAction={handleRecoveryButtonClick}
       />
       <Alert
         isOpen={alertIsOpen}

--- a/src/ui/pages/LockPage/LockPage.tsx
+++ b/src/ui/pages/LockPage/LockPage.tsx
@@ -165,6 +165,8 @@ const LockPageContainer = () => {
         Agent.agent.basicStorage.deleteById(MiscRecordId.APP_ALREADY_INIT),
       ]);
 
+      router.push(RoutePath.ROOT);
+
       dispatch(
         setAuthentication({
           ...authentication,
@@ -174,7 +176,6 @@ const LockPageContainer = () => {
           loggedIn: true,
         })
       );
-      router.push(RoutePath.ROOT);
     } catch (e) {
       showError("Failed to clear app: ", e, dispatch);
     }


### PR DESCRIPTION
## Description

Bring back to create passcode screen and start onboarding journey from beginning when click on forgot password button before set up seed phrase

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-1967)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser

https://github.com/user-attachments/assets/0e6fe309-f0ad-4cd8-a9e4-b18554e580fd



