### PR TITLE
fix(ui): cardano connect scanner should only accept meerkat ids

### DIFF
--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -556,7 +556,7 @@ const Scanner = forwardRef(
     const processValue = async (content: string) => {
       await stopScan();
 
-      if (/^b[1-9A-HJ-NP-Za-km-z]{33}/.test(content)) {
+      if (currentOperation === OperationType.SCAN_WALLET_CONNECTION) {
         handleConnectWallet(content);
         isHandlingQR.current = false;
         return;


### PR DESCRIPTION
## Description

Only the main scanner and the connections page scanner should be versatile to accept different scans. The Cardano Connect scanner should only accept Meerkat/Peer IDs.

`handleConnectWallet` contains the validation too for meerkat ID formats, but it wasn't being hit before.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2013)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).
