### PR TITLE
fix(ui): should not be able to delete an identifier from a notification

### DIFF
--- a/src/ui/components/CredentialDetailModule/components/CredentialContent.test.tsx
+++ b/src/ui/components/CredentialDetailModule/components/CredentialContent.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
+import { act } from "react";
 import EN_TRANSLATIONS from "../../../../locales/en/en.json";
 import { store } from "../../../../store";
 import {
@@ -175,7 +176,7 @@ describe("Creds content", () => {
       dispatch: jest.fn(),
     };
 
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, queryByTestId } = render(
       <Provider store={storeMocked}>
         <CredentialContent
           cardData={credsFixAcdc[0]}
@@ -197,5 +198,24 @@ describe("Creds content", () => {
     await waitFor(() => {
       expect(getByTestId("credential-related-identifier-modal")).toBeVisible();
     });
+
+    await waitFor(() =>
+      expect(
+        getByTestId("identifier-card-template-default-index-0")
+      ).toBeInTheDocument()
+    );
+    expect(
+      queryByTestId("delete-button-credential-related-identifier")
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId("identifier-options-button"));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("share-identifier-option")).toBeInTheDocument();
+    });
+
+    expect(queryByTestId("delete-identifier-option")).not.toBeInTheDocument();
   });
 });

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModal.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModal.tsx
@@ -38,6 +38,7 @@ const IdentifierDetailModal = ({
         onClose={handleBack}
         hardwareBackButtonConfig={hardwareBackButtonConfig}
         navAnimation={false}
+        restrictedOptions={true}
       />
     </IonModal>
   );

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.test.tsx
@@ -579,6 +579,49 @@ describe("Individual Identifier details page", () => {
       );
     });
   });
+
+  test("Can restrict view to not be able to delete identifier", async () => {
+    verifySecretMock.mockResolvedValue(false);
+
+    const { getByTestId, unmount, queryByTestId } = render(
+      <Provider store={storeMockedAidKeri}>
+        <IdentifierDetailModule
+          identifierDetailId="ED4KeyyTKFj-72B008OTGgDCrFo6y7B2B73kfyzu5Inb"
+          onClose={jest.fn()}
+          pageId={pageId}
+          navAnimation
+          restrictedOptions={true}
+        />
+      </Provider>
+    );
+
+    // Wait until normal page is loaded
+    await waitFor(() =>
+      expect(
+        getByTestId("identifier-card-template-default-index-0")
+      ).toBeInTheDocument()
+    );
+
+    expect(
+      queryByTestId("delete-button-identifier-card-details")
+    ).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(getByTestId("identifier-options-button")).toBeInTheDocument()
+    );
+
+    act(() => {
+      fireEvent.click(getByTestId("identifier-options-button"));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("share-identifier-option")).toBeInTheDocument();
+    });
+
+    expect(queryByTestId("delete-identifier-option")).not.toBeInTheDocument();
+
+    unmount();
+  });
 });
 
 describe("Group Identifier details page", () => {

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.tsx
@@ -57,6 +57,7 @@ const IdentifierDetailModule = ({
   navAnimation,
   pageId,
   hardwareBackButtonConfig,
+  restrictedOptions,
 }: IdentifierDetailModuleProps) => {
   const history = useHistory();
   const dispatch = useAppDispatch();
@@ -354,13 +355,17 @@ const IdentifierDetailModule = ({
                   onRotateKey={openRotateModal}
                   cardData={cardData as IdentifierDetailsCore}
                 />
-                <PageFooter
-                  pageId={pageId}
-                  deleteButtonText={`${i18n.t(
-                    "tabs.identifiers.details.delete.button"
-                  )}`}
-                  deleteButtonAction={deleteButtonAction}
-                />
+                {restrictedOptions ? (
+                  <></>
+                ) : (
+                  <PageFooter
+                    pageId={pageId}
+                    deleteButtonText={`${i18n.t(
+                      "tabs.identifiers.details.delete.button"
+                    )}`}
+                    deleteButtonAction={deleteButtonAction}
+                  />
+                )}
               </div>
               <ShareConnection
                 isOpen={shareIsOpen}
@@ -375,6 +380,7 @@ const IdentifierDetailModule = ({
                 setCardData={setCardData}
                 oobi={oobi}
                 handleDeleteIdentifier={() => setAlertIsOpen(true)}
+                restrictedOptions={restrictedOptions}
               />
             </>
           )}

--- a/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.types.ts
+++ b/src/ui/components/IdentifierDetailModule/IdentifierDetailModule.types.ts
@@ -6,6 +6,7 @@ interface IdentifierDetailModuleProps {
   onClose?: (animation?: boolean) => void;
   navAnimation: boolean;
   hardwareBackButtonConfig?: HardwareBackButtonConfig;
+  restrictedOptions?: boolean;
 }
 
 interface IdentifierDetailModalProps

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.test.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.test.tsx
@@ -103,7 +103,35 @@ describe("Identifier Options modal", () => {
     );
     await waitForIonicReact();
 
-    await waitFor(() => expect(queryByTestId("rotate-keys-option")).toBe(null));
+    await waitFor(() =>
+      expect(queryByTestId("edit-identifier-option")).toBeInTheDocument()
+    );
+    expect(queryByTestId("rotate-keys-option")).not.toBeInTheDocument();
+  });
+
+  test("can exclude restricted options in certain flows", async () => {
+    const { queryByTestId } = render(
+      <Provider store={mockedStore}>
+        <IdentifierOptions
+          handleRotateKey={jest.fn()}
+          optionsIsOpen={true}
+          setOptionsIsOpen={jest.fn()}
+          cardData={identifierFix[2]}
+          oobi={oobi}
+          setCardData={jest.fn()}
+          handleDeleteIdentifier={async () => {
+            jest.fn();
+          }}
+          restrictedOptions={true}
+        />
+      </Provider>
+    );
+    await waitForIonicReact();
+
+    await waitFor(() =>
+      expect(queryByTestId("edit-identifier-option")).toBeInTheDocument()
+    );
+    expect(queryByTestId("delete-identifier-option")).not.toBeInTheDocument();
   });
 });
 

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.tsx
@@ -22,6 +22,7 @@ const IdentifierOptions = ({
   handleDeleteIdentifier,
   handleRotateKey,
   oobi,
+  restrictedOptions,
 }: IdentifierOptionsProps) => {
   const identifiersData = useAppSelector(getIdentifiersCache);
   const [editorOptionsIsOpen, setEditorIsOpen] = useState(false);
@@ -74,13 +75,16 @@ const IdentifierOptions = ({
       onClick: () => setShareIsOpen(true),
       testId: "share-identifier-option",
     },
-    {
+  ];
+
+  if (!restrictedOptions) {
+    optionsRotate.push({
       icon: trashOutline,
       label: i18n.t("tabs.identifiers.details.options.delete"),
       onClick: deleteIdentifier,
       testId: "delete-identifier-option",
-    },
-  ];
+    });
+  }
 
   const optionsNoRotate = optionsRotate.filter(
     (option) => option.testId !== "rotate-keys-option"

--- a/src/ui/components/IdentifierOptions/IdentifierOptions.types.ts
+++ b/src/ui/components/IdentifierOptions/IdentifierOptions.types.ts
@@ -8,6 +8,7 @@ interface IdentifierOptionsProps {
   handleDeleteIdentifier: () => void;
   handleRotateKey: () => void;
   oobi: string;
+  restrictedOptions?: boolean;
 }
 
 export type { IdentifierOptionsProps };

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.test.tsx
@@ -303,7 +303,7 @@ describe("Receive credential", () => {
     });
   });
 
-  test("Open indentifier detail", async () => {
+  test("Open identifier details", async () => {
     const initialState = {
       stateCache: {
         routes: [TabsRoutePath.NOTIFICATIONS],
@@ -360,6 +360,25 @@ describe("Receive credential", () => {
     await waitFor(() => {
       expect(getByTestId("identifier-detail-modal")).toBeVisible();
     });
+
+    await waitFor(() =>
+      expect(
+        getByTestId("identifier-card-template-default-index-0")
+      ).toBeInTheDocument()
+    );
+    expect(
+      queryByTestId("delete-button-identifier-detail")
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId("identifier-options-button"));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("share-identifier-option")).toBeInTheDocument();
+    });
+
+    expect(queryByTestId("delete-identifier-option")).not.toBeInTheDocument();
 
     fireEvent.click(getByText(EN_TRANSLATIONS.tabs.identifiers.details.done));
 


### PR DESCRIPTION
## Description

This restricts deletion of identifiers to within the normal identifier flow. Deleting an identifier as a `Related identifier` link within a notification is entirely problematic, and an unnecessary flow. So this blocks that, and for consistency from within the credential details view too.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2027)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Design Review

- [X] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [X] In case PR contains changes to the UI, add some screenshots to notice the differences

#### Before
<img src="https://github.com/user-attachments/assets/9bdf232d-2c58-4e63-931f-ddaf9d30f255" width="300">
<img src="https://github.com/user-attachments/assets/1411baf3-47a7-47cc-9d5b-aef749a4598d" width="300">


#### After
<img src="https://github.com/user-attachments/assets/8a61edec-524f-4deb-96e7-d6e7db22a370" width="300">
<img src="https://github.com/user-attachments/assets/21980c76-f691-4297-980a-c9c64e5787f1" width="300">