### PR TITLE
fix(ui): should only be able to delete connections from direct view and not linked views

### DIFF
--- a/src/ui/components/ConnectionOptions/ConnectionOptions.test.tsx
+++ b/src/ui/components/ConnectionOptions/ConnectionOptions.test.tsx
@@ -1,6 +1,6 @@
 import { waitForIonicReact } from "@ionic/react-test-utils";
 import { AnyAction, Store } from "@reduxjs/toolkit";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -74,5 +74,25 @@ describe("Connection Options modal", () => {
     expect(dispatchMock).toBeCalledWith(
       setCurrentOperation(OperationType.DELETE_CONNECTION)
     );
+  });
+
+  test("can exclude restricted options in certain flows", async () => {
+    const { queryByTestId } = render(
+      <Provider store={mockedStore}>
+        <ConnectionOptions
+          optionsIsOpen={true}
+          setOptionsIsOpen={jest.fn()}
+          handleDelete={jest.fn()}
+          handleEdit={jest.fn()}
+          restrictedOptions={true}
+        />
+      </Provider>
+    );
+    await waitForIonicReact();
+
+    await waitFor(() =>
+      expect(queryByTestId("connection-options-manage-button")).toBeInTheDocument()
+    );
+    expect(queryByTestId("delete-button-connection-options")).not.toBeInTheDocument();
   });
 });

--- a/src/ui/components/ConnectionOptions/ConnectionOptions.tsx
+++ b/src/ui/components/ConnectionOptions/ConnectionOptions.tsx
@@ -11,6 +11,7 @@ const ConnectionOptions = ({
   setOptionsIsOpen,
   handleEdit,
   handleDelete,
+  restrictedOptions,
 }: ConnectionOptionsProps) => {
   const dispatch = useAppDispatch();
 
@@ -24,7 +25,10 @@ const ConnectionOptions = ({
       },
       testId: "connection-options-manage-button",
     },
-    {
+  ];
+
+  if (!restrictedOptions) {
+    options.push({
       icon: trashOutline,
       label: i18n.t("connections.details.options.labels.delete"),
       onClick: () => {
@@ -32,8 +36,8 @@ const ConnectionOptions = ({
         dispatch(setCurrentOperation(OperationType.DELETE_CONNECTION));
       },
       testId: "delete-button-connection-options",
-    },
-  ];
+    });
+  }
 
   return (
     <OptionModal

--- a/src/ui/components/ConnectionOptions/ConnectionOptions.types.ts
+++ b/src/ui/components/ConnectionOptions/ConnectionOptions.types.ts
@@ -3,6 +3,7 @@ interface ConnectionOptionsProps {
   setOptionsIsOpen: (value: boolean) => void;
   handleEdit: (value: boolean) => void;
   handleDelete: () => void;
+  restrictedOptions?: boolean;
 }
 
 export type { ConnectionOptionsProps };

--- a/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
+++ b/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
@@ -234,9 +234,7 @@ describe("Cred Detail Module - current not archived credential", () => {
       queryAllByTestId,
       getByTestId,
       getAllByTestId,
-      queryByText,
       findByText,
-      unmount,
     } = render(
       <Provider store={storeMocked}>
         <CredentialDetailModule
@@ -502,6 +500,27 @@ describe("Cred Detail Module - current not archived credential", () => {
     });
 
     unmount();
+  });
+
+  test("View connection details", async () => {
+    // TODO complete
+    const { getByTestId } = render(
+      <Provider store={storeMocked}>
+        <CredentialDetailModule
+          pageId="credential-card-details"
+          id={credsFixAcdc[0].id}
+          onClose={jest.fn()}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("card-details-content")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("credential-card-details-fdooter")).toBeInTheDocument();
+    });
   });
 });
 

--- a/src/ui/components/CredentialDetailModule/CredentialDetailModule.tsx
+++ b/src/ui/components/CredentialDetailModule/CredentialDetailModule.tsx
@@ -421,6 +421,7 @@ const CredentialDetailModule = ({
     <ConnectionDetails
       connectionShortDetails={connectionShortDetails}
       handleCloseConnectionModal={() => setOpenConnectionlModal(false)}
+      restrictedOptions={true}
     />
   ) : (
     <>

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.test.tsx
@@ -357,6 +357,41 @@ describe("ConnectionDetails Page", () => {
       expect(getByTestId("connection-details-tab")).toBeVisible()
     );
   });
+
+  test("Can restrict view to not be able to delete connection", async () => {
+    const storeMocked = {
+      ...mockStore(initialStateFull),
+      dispatch: dispatchMock,
+    };
+
+    const handleCloseConnectionModal = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={storeMocked}>
+        <ConnectionDetails
+          connectionShortDetails={connectionsFix[0]}
+          handleCloseConnectionModal={handleCloseConnectionModal}
+          restrictedOptions={true}
+        />
+      </Provider>
+    );
+
+    // Wait until normal page is loaded
+    await waitFor(() =>
+      expect(getByTestId("action-button")).toBeInTheDocument()
+    );
+
+    expect(queryByTestId("delete-button-connection-details")).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId("action-button"));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("connection-options-manage-button")).toBeInTheDocument();
+    });
+
+    expect(queryByTestId("delete-button-connection-options")).not.toBeInTheDocument();
+  });
 });
 
 interface MockConnectionDetails {

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.tsx
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.tsx
@@ -45,6 +45,7 @@ import { ConnectionDetailsProps } from "./ConnectionDetails.types";
 const ConnectionDetails = ({
   connectionShortDetails,
   handleCloseConnectionModal,
+  restrictedOptions,
 }: ConnectionDetailsProps) => {
   const pageId = "connection-details";
   const dispatch = useAppDispatch();
@@ -284,12 +285,16 @@ const ConnectionDetails = ({
                     connectionDetails={connectionDetails}
                   />
                 </CardDetailsBlock>
-                <PageFooter
-                  pageId={pageId}
-                  deleteButtonText={`${i18n.t("connections.details.delete")}`}
-                  deleteButtonAction={() => deleteButtonAction()}
-                />
-              </div>
+                {restrictedOptions ? (
+                  <></>
+                ) : (
+                  <PageFooter
+                    pageId={pageId}
+                    deleteButtonText={`${i18n.t("connections.details.delete")}`}
+                    deleteButtonAction={() => deleteButtonAction()}
+                  />
+                )}
+                </div>
             ) : (
               <div
                 className="connection-notes-tab"
@@ -308,6 +313,7 @@ const ConnectionDetails = ({
             setOptionsIsOpen={setOptionsIsOpen}
             handleEdit={setModalIsOpen}
             handleDelete={handleDelete}
+            restrictedOptions={restrictedOptions}
           />
         </ScrollablePageLayout>
       )}

--- a/src/ui/pages/ConnectionDetails/ConnectionDetails.types.ts
+++ b/src/ui/pages/ConnectionDetails/ConnectionDetails.types.ts
@@ -3,6 +3,7 @@ import { ConnectionShortDetails } from "../../../core/agent/agent.types";
 interface ConnectionDetailsProps {
   connectionShortDetails: ConnectionShortDetails;
   handleCloseConnectionModal: () => void;
+  restrictedOptions?: boolean;
 }
 
 export type { ConnectionDetailsProps };


### PR DESCRIPTION
## Description

Similar to #1042. This restricts deletion of connections to within the normal connection flow. Deleting a connection as a issuer link within a credential or notification is problematic, and an unnecessary flow. So this blocks that.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2025)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Design Review

- [X] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [X] In case PR contains changes to the UI, add some screenshots to notice the differences

#### Before
<img src="https://github.com/user-attachments/assets/7e26797f-4ffc-45e6-8770-ed06bd706060" width="300">
<img src="https://github.com/user-attachments/assets/0f35ca80-dbff-47f6-aed2-d490d1078309" width="300">

#### After
<img src="https://github.com/user-attachments/assets/a0356a2a-bbb8-4acc-9fbb-9d31f6a58719" width="300">
<img src="https://github.com/user-attachments/assets/c3ad41bc-0a7c-4edf-99b1-eef5ca81fe07" width="300">
