### PR TITLE
build: fix android free rasp build

### DIFF
--- a/android/proguard-overwrites/README.md
+++ b/android/proguard-overwrites/README.md
@@ -1,0 +1,1 @@
+This is a temporary solution until freeRASP is patched to work properly with Gradle 8 and R8 - more info [here](https://github.com/talsec/Free-RASP-Capacitor/pull/29).

--- a/android/proguard-overwrites/proguard-rules.pro
+++ b/android/proguard-overwrites/proguard-rules.pro
@@ -1,0 +1,23 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+-dontwarn java.lang.invoke.StringConcatFactory

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -178,31 +178,31 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@jimcase/capacitor-exit-app"
 
 SPEC CHECKSUMS:
-  AparajitaCapacitorBiometricAuth: c058563fe00160e12b022341e11b3181357ea93a
-  Capacitor: de199cba6c8b20995428ad0b7cb0bc6ca625ffd4
-  CapacitorApp: 9cb31064a6c6bb2b1438583733a7bf45557fc1da
-  CapacitorBrowser: 55c21db47416dcc8fc3b623e18fd7d09acb26081
-  CapacitorClipboard: 007d79cd6c104002b274546d13873526ca20beb7
-  CapacitorCommunityPrivacyScreen: 682470c41cce325d7a85b95907887919d4694066
-  CapacitorCommunitySqlite: b11e556cf5d149f9e0b6fbbb47959a6cd718c3d0
-  CapacitorCommunityTapJacking: 96d1d28a7e2bd4c4d22eb0af0f1cd6eefa419a9f
+  AparajitaCapacitorBiometricAuth: 3057403ee3e9e390e57bfb92b576f439157951b8
+  Capacitor: 23fff43571a4d1e3ee7d67b5a3588c6e757c2913
+  CapacitorApp: 45cb7cbef4aa380b9236fd6980033eb5cde6fcd2
+  CapacitorBrowser: 352a66541b15ceadae1d703802b11979023705e3
+  CapacitorClipboard: 2afc5e21902233d7990978c8f41f023ddcee3e3d
+  CapacitorCommunityPrivacyScreen: 088ffe903fe97c6de54f31407d1bc72c2528a5fc
+  CapacitorCommunitySqlite: 6501e7349acf998346acf24ef757861bb3f6fc2b
+  CapacitorCommunityTapJacking: b055efdf44944def0eae0968c52fb5274a629212
   CapacitorCordova: 63d476958d5022d76f197031e8b7ea3519988c64
-  CapacitorDevice: 069faf433b3a99c3d5f0e500fbe634f60a8c6a84
-  CapacitorFreerasp: 4477326ed8cd7049ed556aa16aabf4fd400926d0
-  CapacitorKeyboard: 4db71e694e7afb5d7c0be09b05495c19f7d6c914
-  CapacitorMlkitBarcodeScanning: db64496b3e8f41be79e3ef81bfd1bb430adcb0ca
-  CapacitorNativeSettings: bef37b3c7e2184da7416a3f162c71de19fd27593
-  CapacitorScreenOrientation: 45e36e1121cdba1634eb12077c5e99391055116f
-  CapacitorShare: d94c53d7656f1ce8f6712ae8d19ab0c18a69259f
-  CapacitorSplashScreen: 7e7a0a1113833032f196b3af6fa437baccacf5bc
-  CapacitorStatusBar: a8c4c83ed2e973bdafb979e80e4b00d027832cb7
-  EvvaCapacitorSecureStoragePlugin: 43df44513abd5295a63f8e8813e9b5b7159dbfe0
+  CapacitorDevice: 62066b65e148a133df7b8c5bf972ba835b329748
+  CapacitorFreerasp: 5a31821fe4fc8036ed83b81a049d217098f0b799
+  CapacitorKeyboard: 2c26c6fccde35023c579fc37d4cae6326d5e6343
+  CapacitorMlkitBarcodeScanning: 06c21220bf207bdb146dddc2e8548f3f2686879f
+  CapacitorNativeSettings: 03d126571fc0e12f89ffeb1516788bf371b528bc
+  CapacitorScreenOrientation: 4b2778087f4b4b138705cdabe431de0829116974
+  CapacitorShare: 2fcf1758cd07e0558f6aed40d7437bf8a3a42297
+  CapacitorSplashScreen: f4e58cc02aafd91c7cbaf32a3d1b44d02a115125
+  CapacitorStatusBar: 438e90beeeefa8276b24e6c5991cb02dd13e51bf
+  EvvaCapacitorSecureStoragePlugin: 0d5ce72e8d8cc62255b7151733ed8c2e0fdc1eed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMLKit: eff9e23ec1d90ea4157a1ee2e32a4f610c5b3318
   GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  JimcaseCapacitorExitApp: 54f1ea5c2395417c5c875309f1bec789741b49a0
+  JimcaseCapacitorExitApp: 2dc3f9da1de471e4e5fa904d89870057152518df
   MLImage: 0ad1c5f50edd027672d8b26b0fee78a8b4a0fc56
   MLKitBarcodeScanning: 0a3064da0a7f49ac24ceb3cb46a5bc67496facd2
   MLKitCommon: 07c2c33ae5640e5380beaaa6e4b9c249a205542d
@@ -213,6 +213,6 @@ SPEC CHECKSUMS:
   SQLCipher: 77fbe633cd84db04b07876dd50766b4924b57d61
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: ce9a8454f89a663bc1ae704031f150763e9d05a4
+PODFILE CHECKSUM: 494975933aff2c288d2d7013782a5a70fa6e901e
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:cap": "npm run build && npx cap sync",
     "build:e2e": "npm run build:local && npx cap sync",
     "build:ios:flags": "find ios/xcconfig-overwrites -name '*.release.xcconfig' -exec sh -c 'cp \"$1\" \"ios/App/Pods/Target Support Files/$(basename $(dirname \"$1\"))/\"' _ {} \\;",
+    "build:android:proguard": "cp android/proguard-overwrites/proguard-rules.pro node_modules/capacitor-freerasp/android/proguard-rules.pro",
     "build:release": "cross-env ENVIRONMENT=prod webpack --config webpack.prod.cjs && npx cap sync",
     "prettier": "npx prettier --write './src/**/*.{ts,tsx,scss}' 'services/{credential-server,credential-server-ui}/src/**/*.{ts,tsx,scss}'",
     "eslint": "eslint 'src/**/*.{ts,tsx}'",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,9 @@ import { App } from "./ui/App";
 import reportWebVitals from "./reportWebVitals";
 import "./i18n";
 import { store } from "./store";
+import { ConfigurationService } from "./core/configuration";
 
+await new ConfigurationService().start();
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );

--- a/src/security/freerasp.ts
+++ b/src/security/freerasp.ts
@@ -41,7 +41,7 @@ export const freeRASPConfig = {
     appTeamId: process.env.APP_TEAM_ID || "",
   },
   watcherMail: process.env.WATCHER_MAIL || "",
-  isProd: ConfigurationService.env?.security.rasp.enabled ? true : false,
+  isProd: ConfigurationService.env.security.rasp.enabled,
 };
 
 const createThreatAction = (
@@ -49,8 +49,6 @@ const createThreatAction = (
   threatName: ThreatName,
   description: string
 ) => {
-  if (ConfigurationService.env.security.rasp.enabled) return;
-
   return () => {
     setThreatsDetected((currentState) => {
       const threatExists = currentState.some(

--- a/src/security/freerasp.ts
+++ b/src/security/freerasp.ts
@@ -31,18 +31,6 @@ export type FreeRASPInitResult =
   | { success: true }
   | { success: false; error: unknown };
 
-export const freeRASPConfig = {
-  androidConfig: {
-    packageName: "org.cardanofoundation.idw",
-    certificateHashes: [process.env.APP_CERT_HASH || ""],
-  },
-  iosConfig: {
-    appBundleId: "org.cardanofoundation.idw",
-    appTeamId: process.env.APP_TEAM_ID || "",
-  },
-  watcherMail: process.env.WATCHER_MAIL || "",
-  isProd: ConfigurationService.env.security.rasp.enabled,
-};
 
 const createThreatAction = (
   setThreatsDetected: React.Dispatch<React.SetStateAction<ThreatCheck[]>>,
@@ -138,6 +126,19 @@ export const initializeFreeRASP = async (
       ThreatName.DEVICE_ID,
       i18n.t("systemthreats.rules.deviceid")
     ),
+  };
+  
+  const freeRASPConfig = {
+    androidConfig: {
+      packageName: "org.cardanofoundation.idw",
+      certificateHashes: [process.env.APP_CERT_HASH || ""],
+    },
+    iosConfig: {
+      appBundleId: "org.cardanofoundation.idw",
+      appTeamId: process.env.APP_TEAM_ID || "",
+    },
+    watcherMail: process.env.WATCHER_MAIL || "",
+    isProd: ConfigurationService.env.security.rasp.enabled,
   };
 
   try {

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -122,6 +122,18 @@ jest.mock("../core/agent/agent", () => ({
   },
 }));
 
+jest.mock("../core/configuration/configurationService", () => ({
+  ConfigurationService: {
+    env: {
+      security: {
+        rasp: {
+          enabled: true
+        }
+      }
+    }
+  }
+}));
+
 const getDeviceInfo = jest.fn();
 
 jest.mock("@capacitor/device", () => ({

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -70,16 +70,19 @@ const App = () => {
     if (!Capacitor.isNativePlatform()) return;
 
     const initConfiguration = async () => {
-      await new ConfigurationService().start();
-      initializeFreeRASP(setThreatsDetected).then((response) => {
+      if (ConfigurationService.env.security.rasp.enabled) {
+        const result = await initializeFreeRASP(setThreatsDetected);
         setIsFreeRASPInitialized(true);
         setFreeRASPInitResult({
-          success: response.success,
-          error: response.success
+          success: result.success,
+          error: result.success
             ? ""
-            : (response.error as string) || "Unknown error",
+            : (result.error as string) || "Unknown error",
         });
-      });
+      } else {
+        setIsFreeRASPInitialized(true);
+        setFreeRASPInitResult({ success: true, error: "" });
+      }
     };
 
     initConfiguration();

--- a/src/ui/components/AppWrapper/AppWrapper.tsx
+++ b/src/ui/components/AppWrapper/AppWrapper.tsx
@@ -13,7 +13,6 @@ import {
   PeerConnectionBrokenEvent,
   PeerDisconnectedEvent,
 } from "../../../core/cardano/walletConnect/peerConnection.types";
-import { ConfigurationService } from "../../../core/configuration";
 import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
 import { i18n } from "../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";


### PR DESCRIPTION
## Description

The freeRASP production build wasn't working as there was a conflict with the R8 minification. See comments in https://github.com/talsec/Free-RASP-Capacitor/pull/29. The proguard file is part of that PR but is missing in the node_modules, so this is a temporary fix to stage them for the release build.

Also, I have set it so that freeRASP is not initialised at all unless we are in prod, because otherwise Android will complain about the cert signing hash.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: No

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).