### PR TITLE
fix(ui): Back button hidden after closing searched connection

### DIFF
--- a/src/ui/pages/Connections/Connections.tsx
+++ b/src/ui/pages/Connections/Connections.tsx
@@ -12,7 +12,8 @@ import { Agent } from "../../../core/agent/agent";
 import {
   ConnectionShortDetails,
   ConnectionStatus,
-  CreationStatus } from "../../../core/agent/agent.types";
+  CreationStatus,
+} from "../../../core/agent/agent.types";
 import { IdentifierShortDetails } from "../../../core/agent/services/identifier.types";
 import { i18n } from "../../../i18n";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
@@ -88,6 +89,7 @@ const Connections = forwardRef<ConnectionsOptionRef, ConnectionsComponentProps>(
     const [oobi, setOobi] = useState("");
     const [hideHeader, setHideHeader] = useState(false);
     const [openConnectionlModal, setOpenConnectionlModal] = useState(false);
+    const [search, setSearch] = useState("");
 
     useEffect(() => {
       setShowPlaceholder(Object.keys(connectionsCache).length === 0);
@@ -318,6 +320,8 @@ const Connections = forwardRef<ConnectionsOptionRef, ConnectionsComponentProps>(
               onSearchFocus={setHideHeader}
               mappedConnections={mappedConnections}
               handleShowConnectionDetails={handleShowConnectionDetails}
+              search={search}
+              setSearch={setSearch}
             />
           )}
         </ScrollablePageLayout>

--- a/src/ui/pages/Connections/components/ConnectionsBody/ConnectionsBody.tsx
+++ b/src/ui/pages/Connections/components/ConnectionsBody/ConnectionsBody.tsx
@@ -64,8 +64,9 @@ const ConnectionsBody = ({
   mappedConnections,
   handleShowConnectionDetails,
   onSearchFocus,
+  search,
+  setSearch,
 }: ConnectionsBodyProps) => {
-  const [search, setSearch] = useState("");
   const [keyboardIsOpen, setKeyboardIsOpen] = useState(false);
   const container = useRef<HTMLDivElement>(null);
 

--- a/src/ui/pages/Connections/components/ConnectionsBody/ConnectionsBody.types.ts
+++ b/src/ui/pages/Connections/components/ConnectionsBody/ConnectionsBody.types.ts
@@ -11,6 +11,8 @@ interface ConnectionsBodyProps {
   onSearchFocus?: (value: boolean) => void;
   mappedConnections: MappedConnections[];
   handleShowConnectionDetails: (item: ConnectionShortDetails) => void;
+  search: string;
+  setSearch: (value: string) => void;
 }
 
 interface SearchConnectionListProps {


### PR DESCRIPTION
## Description

Fix back button hidden after closing searched connection

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-2024)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

https://github.com/user-attachments/assets/e84fd60e-2034-4e6e-9755-99f45774a5f9
