### PR TITLE
fix: disable freerasp threat ADB_ENABLED

### DIFF
--- a/src/security/freerasp.ts
+++ b/src/security/freerasp.ts
@@ -31,7 +31,6 @@ export type FreeRASPInitResult =
   | { success: true }
   | { success: false; error: unknown };
 
-
 const createThreatAction = (
   setThreatsDetected: React.Dispatch<React.SetStateAction<ThreatCheck[]>>,
   threatName: ThreatName,
@@ -116,18 +115,15 @@ export const initializeFreeRASP = async (
     ),
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     devMode: () => {},
-    adbEnabled: createThreatAction(
-      setThreatsDetected,
-      ThreatName.ADB_ENABLED,
-      i18n.t("systemthreats.rules.adbenabled")
-    ),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    adbEnabled: () => {},
     deviceID: createThreatAction(
       setThreatsDetected,
       ThreatName.DEVICE_ID,
       i18n.t("systemthreats.rules.deviceid")
     ),
   };
-  
+
   const freeRASPConfig = {
     androidConfig: {
       packageName: "org.cardanofoundation.idw",


### PR DESCRIPTION
## Description

DEVELOPER_MODE and ADB_ENABLED should behave the same/similar, and we have DEVELOPER_MODE disabled so we need to disabled also this common config in android devices ADB_ENABLED.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
