### PR TITLE
fix(core): properly check linked contacts for group inception

### DIFF
--- a/src/core/__fixtures__/agent/multiSigFixtures.ts
+++ b/src/core/__fixtures__/agent/multiSigFixtures.ts
@@ -487,9 +487,9 @@ const resolvedOobiOpResponse = {
 };
 
 const initiatorConnectionShortDetails = {
-  id: "ENsj-3icUgAutHtrUHYnUPnP8RiafT5tOdVIZarFHuyP",
+  id: "EKlUo3CAqjPfFt0Wr2vvSc7MqT9WiL2EGadRsAP3V1IJ",
   label: "f4732f8a-1967-454a-8865-2bbf2377c26e",
-  oobi: "http://127.0.0.1:3902/oobi/ENsj-3icUgAutHtrUHYnUPnP8RiafT5tOdVIZarFHuyP/agent/EF_dfLFGvUh9kMsV2LIJQtrkuXWG_-wxWzC_XjCWjlkQ",
+  oobi: "http://127.0.0.1:3902/oobi/EKlUo3CAqjPfFt0Wr2vvSc7MqT9WiL2EGadRsAP3V1IJ/agent/EF_dfLFGvUh9kMsV2LIJQtrkuXWG_-wxWzC_XjCWjlkQ",
   status: ConnectionStatus.CONFIRMED,
   createdAtUTC: new Date().toISOString(),
 };
@@ -511,7 +511,7 @@ const getRequestMultisigIcp = {
     v: "KERI10JSON000735_",
     t: "exn",
     d: "EI8fS00-AxbbqXmwoivpw-0ui0qgZtGbh8Ue-ZVbxYS-",
-    i: "ELLb0OvktIxeHDeeOnRJ2pc9IkYJ38An4PXYigUQ_3AO",
+    i: "EKlUo3CAqjPfFt0Wr2vvSc7MqT9WiL2EGadRsAP3V1IJ",
     p: "",
     dt: "2024-08-19T10:20:54.591000+00:00",
     r: "/multisig/icp",

--- a/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.scss
+++ b/src/ui/pages/NotificationDetails/components/MultiSigRequest/ErrorPage.scss
@@ -48,6 +48,7 @@
     .content {
       .card-details-info-block-inner {
         padding: 1.25rem;
+        margin-top: 12px;
       }
 
       .instruction-list {


### PR DESCRIPTION
## Description

When creating groups, we use a `groupCreationId` or `groupId` that is a random salt as an indicator to other wallets that we are trying to set up a group, and not to treat OOBIs as normal connections but OOBIs of local group member identifiers.

There was naive check in place before when processing a group inception of `len(otherLinkedContacts) == len(smids) - 2` - so when we exclude ourselves, and the group initiator (sending of the message), we should have X linked contacts.

This doesn't work in 2 scenarios:
1. Everyone scans everyones QR code successfully, but the initiator decides to exclude someone when sending the inception event. Our UI supports this by unchecking people when initiating.
2. Bob might scan Carol's OOBI, but the initiator Alice never scanned or knew about Carol. And decided to continue setting up the group.

This PR iterates over each `smid` and does the correct checks.
 
## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2035)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).
