### PR TITLE
fix: credential request secondary cta has the old design

### DIFF
--- a/src/ui/components/PageFooter/PageFooter.tsx
+++ b/src/ui/components/PageFooter/PageFooter.tsx
@@ -22,6 +22,7 @@ const PageFooter = ({
   archiveButtonAction,
   archiveButtonDisabled,
   deleteButtonText,
+  deleteButtonIcon = true,
   deleteButtonAction,
   deleteButtonDisabled,
   children,
@@ -123,12 +124,15 @@ const PageFooter = ({
             onClick={deleteButtonAction}
             disabled={deleteButtonDisabled}
           >
-            <IonIcon
-              slot="icon-only"
-              size="small"
-              icon={trashOutline}
-              color="primary"
-            />
+            {deleteButtonIcon && (
+              <IonIcon
+                slot="icon-only"
+                size="small"
+                icon={trashOutline}
+                color="primary"
+              />
+            )}
+
             {deleteButtonText}
           </IonButton>
         )}

--- a/src/ui/components/PageFooter/PageFooter.types.ts
+++ b/src/ui/components/PageFooter/PageFooter.types.ts
@@ -19,6 +19,7 @@ interface PageFooterProps {
   archiveButtonAction?: () => void;
   archiveButtonDisabled?: boolean;
   deleteButtonText?: string;
+  deleteButtonIcon?: boolean;
   deleteButtonAction?: () => void;
   deleteButtonDisabled?: boolean;
   children?: ReactNode;

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.scss
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.scss
@@ -64,6 +64,15 @@
     padding: 1rem 0;
   }
 
+  .page-footer {
+    margin-bottom: 1rem;
+
+    .secondary-button::part(native) {
+      border: none;
+      color: var(--ion-color-error-800);
+    }
+  }
+
   @media screen and (min-width: 250px) and (max-width: 370px) {
     .credential-content {
       margin-top: 1rem;

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.scss
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.scss
@@ -67,6 +67,12 @@
   .page-footer {
     margin-bottom: 1rem;
 
+    .delete-button::part(native) {
+      border: none;
+      color: var(--ion-color-error-800);
+      background-color: transparent;
+    }
+
     .secondary-button::part(native) {
       border: none;
       color: var(--ion-color-error-800);

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.scss
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.scss
@@ -71,6 +71,7 @@
       border: none;
       color: var(--ion-color-error-800);
       background-color: transparent;
+      font-weight: 500;
     }
 
     .secondary-button::part(native) {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -536,9 +536,8 @@ describe("Credential request information: multisig", () => {
     expect(
       getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.accept)
     ).toBeVisible();
-    expect(
-      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.decline)
-    ).toBeVisible();
+
+    expect(getByTestId("delete-button-multi-sign")).toBeVisible();
 
     act(() => {
       fireEvent.click(getByTestId("primary-button-multi-sign"));

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -537,7 +537,7 @@ describe("Credential request information: multisig", () => {
       getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.accept)
     ).toBeVisible();
     expect(
-      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.reject)
+      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.decline)
     ).toBeVisible();
 
     act(() => {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.tsx
@@ -209,7 +209,7 @@ const CredentialRequestInformation = ({
       (!isGroupInitiator && !isGroupInitiatorJoined) ||
       isJoinGroup
       ? undefined
-      : `${i18n.t("tabs.notifications.details.buttons.reject")}`;
+      : `${i18n.t("tabs.notifications.details.buttons.decline")}`;
   }, [isGroupInitiator, isGroupInitiatorJoined, isJoinGroup]);
 
   const decline = () => setAlertDeclineIsOpen(true);
@@ -286,6 +286,7 @@ const CredentialRequestInformation = ({
             secondaryButtonAction={decline}
             deleteButtonAction={decline}
             deleteButtonText={deleteButtonText}
+            deleteButtonIcon={false}
           />
         }
       >


### PR DESCRIPTION
## Description

Fix credential request secondary decline button styles

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/jira/software/projects/DTIS/boards/36?assignee=631ed01829083bbe8cc2e570&selectedIssue=DTIS-2038)]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences

#### Browser
##### _Before_

<img width="336" alt="Screenshot 2025-03-24 at 16 41 47" src="https://github.com/user-attachments/assets/d8f065cd-f13a-4a14-851a-0f51bf84bee9" />

<img width="353" alt="Screenshot 2025-03-24 at 17 33 27" src="https://github.com/user-attachments/assets/7851e235-dde1-4086-a6b6-53db0dc8ed8c" />

##### _After_

<img width="339" alt="Screenshot 2025-03-24 at 16 41 26" src="https://github.com/user-attachments/assets/272ec572-2f21-4f9d-8c67-d669d14b7188" />

<img width="358" alt="Screenshot 2025-03-24 at 17 32 19" src="https://github.com/user-attachments/assets/7ff200b6-d155-48bf-9b05-824e41f45e52" />

