### PR TITLE
fix(ui): correct cta btn for threshold reached presentation when not accepted

### DIFF
--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.types.ts
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.types.ts
@@ -24,7 +24,7 @@ interface CredentialRequestProps {
   userAID?: string | null;
   onAccept: () => void;
   onBack: () => void;
-  onReloadData?: () => void;
+  onReloadData?: () => Promise<void>;
 }
 
 interface ChooseCredentialProps {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -129,7 +129,7 @@ describe("Credential request information: multisig", () => {
       current: "",
       previous: undefined,
     },
-    threshold: "5",
+    threshold: "2",
     members: ["member-1", "member-2"],
     othersJoined: [],
     memberInfos: [
@@ -146,7 +146,7 @@ describe("Credential request information: multisig", () => {
     ],
   };
 
-  test("Initiator open cred", async () => {
+  test("Initiator open request before proposing", async () => {
     const storeMocked = {
       ...mockStore(initialState),
       dispatch: dispatchMock,
@@ -228,16 +228,16 @@ describe("Credential request information: multisig", () => {
     expect(accept).toBeCalled();
   });
 
-  test("Initiator chosen cred", async () => {
+  test("Initiator opens request after proposing and before threshold is met", async () => {
     const linkedGroup = {
       linkedRequest: {
         accepted: true,
         current: "cred-id",
         previous: undefined,
       },
-      threshold: "5",
+      threshold: "2",
       members: ["member-1", "member-2"],
-      othersJoined: ["member-1"],
+      othersJoined: [],
       memberInfos: [
         {
           aid: "member-1",
@@ -331,14 +331,117 @@ describe("Credential request information: multisig", () => {
     expect(back).toBeCalled();
   });
 
-  test("Member open cred", async () => {
+  test("Initiator opens request after proposing and after threshold is met", async () => {
+    const linkedGroup = {
+      linkedRequest: {
+        accepted: true,
+        current: "cred-id",
+        previous: undefined,
+      },
+      threshold: "2",
+      members: ["member-1", "member-2"],
+      othersJoined: ["member-2"],
+      memberInfos: [
+        {
+          aid: "member-1",
+          name: "Member 1",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: true,
+        },
+      ],
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const back = jest.fn();
+
+    const { getByText, getByTestId, queryByText } = render(
+      <Provider store={storeMocked}>
+        <CredentialRequestInformation
+          pageId="multi-sign"
+          activeStatus
+          onBack={back}
+          onAccept={jest.fn()}
+          userAID="member-1"
+          notificationDetails={notificationsFix[4]}
+          credentialRequest={credRequestFix}
+          linkedGroup={linkedGroup}
+          onReloadData={jest.fn()}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.title
+        )
+      ).toBeVisible();
+    });
+
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.reachthreshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.threshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.groupmember
+      )
+    ).toBeVisible();
+    expect(
+      queryByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposalfrom
+      )
+    ).toBeNull();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposedcred
+      )
+    ).toBeVisible();
+    expect(
+      queryByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.accept)
+    ).toBeNull();
+    expect(
+      queryByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.reject)
+    ).toBeNull();
+    expect(
+      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.ok)
+    ).toBeVisible();
+
+    act(() => {
+      fireEvent.click(getByTestId("primary-button-multi-sign"));
+    });
+
+    expect(back).toBeCalled();
+  });
+
+  test("Member opens request that does not yet have a proposal", async () => {
     const linkedGroup = {
       linkedRequest: {
         accepted: false,
         current: "cred-id",
         previous: undefined,
       },
-      threshold: "5",
+      threshold: "2",
       members: ["member-1", "member-2"],
       othersJoined: [],
       memberInfos: [
@@ -434,14 +537,14 @@ describe("Credential request information: multisig", () => {
     expect(back).toBeCalled();
   });
 
-  test("Member open cred after initiator chosen cred", async () => {
+  test("Member open request and accepts proposal from initiator", async () => {
     const linkedGroup = {
       linkedRequest: {
-        accepted: true,
+        accepted: false,
         current: "cred-id",
         previous: undefined,
       },
-      threshold: "5",
+      threshold: "2",
       members: ["member-1", "member-2"],
       othersJoined: ["member-1"],
       memberInfos: [
@@ -547,7 +650,7 @@ describe("Credential request information: multisig", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    await passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193515");
 
     await waitFor(() => {
       expect(joinMultisigOfferMock).toBeCalled();
@@ -584,6 +687,372 @@ describe("Credential request information: multisig", () => {
     await waitFor(() => {
       expect(deleteNotificationMock).toBeCalled();
     });
+
+    unmount();
+    document.getElementsByTagName("body")[0].innerHTML = "";
+  });
+
+  test("Member opens request after already accepting but before reaching threshold", async () => {
+    const linkedGroup = {
+      linkedRequest: {
+        accepted: true,
+        current: "cred-id",
+        previous: undefined,
+      },
+      threshold: "3",
+      members: ["member-1", "member-2", "member-3"],
+      othersJoined: ["member-1"],
+      memberInfos: [
+        {
+          aid: "member-1",
+          name: "Member 1",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: false,
+        },
+      ],
+    };
+
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.NOTIFICATIONS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+        },
+        isOnline: true,
+      },
+      connectionsCache: {
+        connections: connectionsForNotifications,
+      },
+      notificationsCache: {
+        notifications: notificationsFix,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const back = jest.fn();
+
+    const { getByText, getAllByText, getByTestId, queryByTestId, unmount } =
+      render(
+        <Provider store={storeMocked}>
+          <CredentialRequestInformation
+            pageId="multi-sign"
+            activeStatus
+            onBack={back}
+            onAccept={jest.fn()}
+            userAID="member-2"
+            notificationDetails={notificationsFix[4]}
+            credentialRequest={credRequestFix}
+            linkedGroup={linkedGroup}
+            onReloadData={jest.fn()}
+          />
+        </Provider>
+      );
+
+    await waitFor(() => {
+      expect(
+        getAllByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.proposedcred
+        ).length
+      ).toBeGreaterThan(1);
+    });
+
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.memberjoined
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.threshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.groupmember
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposalfrom
+      )
+    ).toBeVisible();
+    expect(
+      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.ok)
+    ).toBeVisible();
+
+    expect(
+      queryByTestId("secondary-button-multi-sign")
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId("primary-button-multi-sign"));
+    });
+
+    expect(back).toBeCalled();
+
+    unmount();
+    document.getElementsByTagName("body")[0].innerHTML = "";
+  });
+
+  test("Member opens request after already accepting and reaching threshold", async () => {
+    const linkedGroup = {
+      linkedRequest: {
+        accepted: true,
+        current: "cred-id",
+        previous: undefined,
+      },
+      threshold: "2",
+      members: ["member-1", "member-2", "member-3"],
+      othersJoined: ["member-1"],
+      memberInfos: [
+        {
+          aid: "member-1",
+          name: "Member 1",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: false,
+        },
+      ],
+    };
+
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.NOTIFICATIONS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+        },
+        isOnline: true,
+      },
+      connectionsCache: {
+        connections: connectionsForNotifications,
+      },
+      notificationsCache: {
+        notifications: notificationsFix,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const back = jest.fn();
+
+    const { getByText, getAllByText, getByTestId, queryByTestId, unmount } =
+      render(
+        <Provider store={storeMocked}>
+          <CredentialRequestInformation
+            pageId="multi-sign"
+            activeStatus
+            onBack={back}
+            onAccept={jest.fn()}
+            userAID="member-2"
+            notificationDetails={notificationsFix[4]}
+            credentialRequest={credRequestFix}
+            linkedGroup={linkedGroup}
+            onReloadData={jest.fn()}
+          />
+        </Provider>
+      );
+
+    await waitFor(() => {
+      expect(
+        getAllByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.proposedcred
+        ).length
+      ).toBeGreaterThan(1);
+    });
+
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.reachthreshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.threshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.groupmember
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposalfrom
+      )
+    ).toBeVisible();
+    expect(
+      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.ok)
+    ).toBeVisible();
+
+    expect(
+      queryByTestId("secondary-button-multi-sign")
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId("primary-button-multi-sign"));
+    });
+
+    expect(back).toBeCalled();
+
+    unmount();
+    document.getElementsByTagName("body")[0].innerHTML = "";
+  });
+
+  test("Member opens request after before accepting but threshold has already been reached", async () => {
+    const linkedGroup = {
+      linkedRequest: {
+        accepted: false,
+        current: "cred-id",
+        previous: undefined,
+      },
+      threshold: "2",
+      members: ["member-1", "member-2", "member-3"],
+      othersJoined: ["member-1", "member-3"],
+      memberInfos: [
+        {
+          aid: "member-1",
+          name: "Member 1",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: false,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: true,
+        },
+      ],
+    };
+
+    const initialState = {
+      stateCache: {
+        routes: [TabsRoutePath.NOTIFICATIONS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+        },
+        isOnline: true,
+      },
+      connectionsCache: {
+        connections: connectionsForNotifications,
+      },
+      notificationsCache: {
+        notifications: notificationsFix,
+      },
+    };
+
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const back = jest.fn();
+
+    const { getByText, getAllByText, getByTestId, queryByTestId, unmount } =
+      render(
+        <Provider store={storeMocked}>
+          <CredentialRequestInformation
+            pageId="multi-sign"
+            activeStatus
+            onBack={back}
+            onAccept={jest.fn()}
+            userAID="member-2"
+            notificationDetails={notificationsFix[4]}
+            credentialRequest={credRequestFix}
+            linkedGroup={linkedGroup}
+            onReloadData={jest.fn()}
+          />
+        </Provider>
+      );
+
+    await waitFor(() => {
+      expect(
+        getAllByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.proposedcred
+        ).length
+      ).toBeGreaterThan(1);
+    });
+
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.reachthreshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.threshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.groupmember
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposalfrom
+      )
+    ).toBeVisible();
+    expect(
+      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.ok)
+    ).toBeVisible();
+
+    expect(
+      queryByTestId("secondary-button-multi-sign")
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId("primary-button-multi-sign"));
+    });
+
+    expect(back).toBeCalled();
 
     unmount();
     document.getElementsByTagName("body")[0].innerHTML = "";


### PR DESCRIPTION
## Description

Whenever the threshold has been met for a presentation request, we should just show the `OK` button. This works correctly when we accept before reaching the threshold - this bug only applies when you have not accepted it but the threshold has been met already.

The CTA action when clicked was correct, but the text was `Accept`, and the `Decline` button was also showing.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2048)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Design Review

- [X] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [X] In case PR contains changes to the UI, add some screenshots to notice the differences

#### Before
<img src="https://github.com/user-attachments/assets/7dbbb4db-1523-48fc-834d-a829b15fde42" width="350px" />

#### After
<img src="https://github.com/user-attachments/assets/30a450d5-816d-4295-a492-88f019654a7a" width="350px" />