### PR TITLE
fix(ui): stop fetching credential request info after calling handleBack

### DIFF
--- a/src/core/agent/records/credentialStorage.test.ts
+++ b/src/core/agent/records/credentialStorage.test.ts
@@ -127,4 +127,9 @@ describe("Credential storage test", () => {
       CredentialMetadataRecord
     );
   });
+
+  test("Fetching credentials by empty ID array should skip the DB call", async () => {
+    expect(await credentialStorage.getCredentialMetadatasById([])).toEqual([]);
+    expect(storageService.findAllByQuery).not.toBeCalled();
+  });
 });

--- a/src/core/agent/records/credentialStorage.ts
+++ b/src/core/agent/records/credentialStorage.ts
@@ -68,7 +68,13 @@ class CredentialStorage {
   async getCredentialMetadatasById(
     ids: string[],
     query?: Query<CredentialMetadataRecord>
-  ) {
+  ): Promise<CredentialMetadataRecord[]> {
+    // @TODO - foconnor: If $or array is empty, SQL skips over condition, whereas IonicStorage returns nothing
+    // These should be consolidated. For now, this is the only occurance.
+    if (ids.length === 0) {
+      return [];
+    }
+
     return this.storageService.findAllByQuery(
       {
         $or: ids.map((id) => ({ id })),

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.tsx
@@ -103,7 +103,6 @@ const CredentialRequest = ({
     notificationDetails,
     identifiersData,
     getMultisigInfo,
-    handleBack,
     dispatch,
   ]);
 


### PR DESCRIPTION
## Description

`handleBack` was added to the dependency array of the `useCallback` as it's called in the catch block. However, it's also called after declining the request, which deletes the notification.

So after `handleBack` is called, we were trying to fetch the notification details again (which makes no sense in general), and in this case, the notification had been deleted already so you get a `Something went wrong` pop-up.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2049)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Design Review

- [X] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [X] In case PR contains changes to the UI, add some screenshots to notice the differences

#### Before
https://github.com/user-attachments/assets/328bac04-e8c5-4994-900d-5f4223b6c3f4

#### After
https://github.com/user-attachments/assets/6d4fcae6-7774-4a0e-ae7c-ea2d38f52ec7