### PR TITLE
fix(ui): deleted proposed credential msg for proposer (group ipex)

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1223,7 +1223,8 @@
               "memberwaitingproposal": "The group initiator will propose a credential to present. Once chosen, the you and the rest of the group will be notified and asked to approve or decline the selection.",
               "memberjoined": "Your response has been recorded. Please check back for updates.",
               "providecredential": "Provided credential",
-              "missingproposedcredential": "The proposed credential has either not yet been accepted in your wallet or you have since deleted it."
+              "missingproposedcredential": "The proposed credential has either not yet been accepted in your wallet or you have since deleted it.",
+              "initiatordeletedproposedcredential": "You have deleted this credential from your wallet since proposing this."
             },
             "choosecredential": {
               "description": "Below is a list of all '{{requestCred}}' credentials, ordered by the name of the issuer",

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.test.tsx
@@ -441,6 +441,234 @@ describe("Credential request information: multisig", () => {
     expect(back).toBeCalled();
   });
 
+  test("Initiator opens request after proposing and before threshold is met, but has deleted the proposed credential", async () => {
+    const linkedGroup = {
+      linkedRequest: {
+        accepted: true,
+        current: "cred-id",
+        previous: undefined,
+      },
+      threshold: "2",
+      members: ["member-1", "member-2"],
+      othersJoined: [],
+      memberInfos: [
+        {
+          aid: "member-1",
+          name: "Member 1",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: false,
+        },
+      ],
+    };
+
+    const storeMocked = {
+      ...mockStore({
+        ...initialState,
+        credsCache: {
+          creds: [],
+        }
+      }),
+      dispatch: dispatchMock,
+    };
+
+    const back = jest.fn();
+
+    const { getByText, getByTestId, queryByText } = render(
+      <Provider store={storeMocked}>
+        <CredentialRequestInformation
+          pageId="multi-sign"
+          activeStatus
+          onBack={back}
+          onAccept={jest.fn()}
+          userAID="member-1"
+          notificationDetails={notificationsFix[4]}
+          credentialRequest={credRequestFix}
+          linkedGroup={linkedGroup}
+          onReloadData={jest.fn()}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.title
+        )
+      ).toBeVisible();
+    });
+
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.initiatorselectedcred
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.threshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.groupmember
+      )
+    ).toBeVisible();
+    expect(
+      queryByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposalfrom
+      )
+    ).toBeNull();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposedcred
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.initiatordeletedproposedcredential
+      )
+    ).toBeVisible();
+    expect(
+      queryByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.accept)
+    ).toBeNull();
+    expect(
+      queryByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.reject)
+    ).toBeNull();
+    expect(
+      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.ok)
+    ).toBeVisible();
+
+    act(() => {
+      fireEvent.click(getByTestId("primary-button-multi-sign"));
+    });
+
+    expect(back).toBeCalled();
+  });
+
+  test("Initiator opens request after proposing and after threshold is met", async () => {
+    const linkedGroup = {
+      linkedRequest: {
+        accepted: true,
+        current: "cred-id",
+        previous: undefined,
+      },
+      threshold: "2",
+      members: ["member-1", "member-2"],
+      othersJoined: ["member-2"],
+      memberInfos: [
+        {
+          aid: "member-1",
+          name: "Member 1",
+          joined: true,
+        },
+        {
+          aid: "member-2",
+          name: "Member 2",
+          joined: true,
+        },
+      ],
+    };
+
+    const storeMocked = {
+      ...mockStore({
+        ...initialState,
+        credsCache: {
+          creds: [],
+        }
+      }),
+      dispatch: dispatchMock,
+    };
+
+    const back = jest.fn();
+
+    const { getByText, getByTestId, queryByText } = render(
+      <Provider store={storeMocked}>
+        <CredentialRequestInformation
+          pageId="multi-sign"
+          activeStatus
+          onBack={back}
+          onAccept={jest.fn()}
+          userAID="member-1"
+          notificationDetails={notificationsFix[4]}
+          credentialRequest={credRequestFix}
+          linkedGroup={linkedGroup}
+          onReloadData={jest.fn()}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(
+        getByText(
+          EN_TRANSLATIONS.tabs.notifications.details.credential.request
+            .information.title
+        )
+      ).toBeVisible();
+    });
+
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.reachthreshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.threshold
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.groupmember
+      )
+    ).toBeVisible();
+    expect(
+      queryByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposalfrom
+      )
+    ).toBeNull();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.proposedcred
+      )
+    ).toBeVisible();
+    expect(
+      getByText(
+        EN_TRANSLATIONS.tabs.notifications.details.credential.request
+          .information.initiatordeletedproposedcredential
+      )
+    ).toBeVisible();
+    expect(
+      queryByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.accept)
+    ).toBeNull();
+    expect(
+      queryByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.reject)
+    ).toBeNull();
+    expect(
+      getByText(EN_TRANSLATIONS.tabs.notifications.details.buttons.ok)
+    ).toBeVisible();
+
+    act(() => {
+      fireEvent.click(getByTestId("primary-button-multi-sign"));
+    });
+
+    expect(back).toBeCalled();
+  });
+
   test("Member opens request that does not yet have a proposal", async () => {
     const linkedGroup = {
       linkedRequest: {

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.tsx
@@ -386,6 +386,8 @@ const CredentialRequestInformation = ({
               {missingProposedCred ? (
                 <InfoCard
                   content={i18n.t(
+                    isGroupInitiator ?
+                    "tabs.notifications.details.credential.request.information.initiatordeletedproposedcredential" :
                     "tabs.notifications.details.credential.request.information.missingproposedcredential"
                   )}
                   className="missing-proposed-cred-info"


### PR DESCRIPTION
## Description

Continuation of #1057 but provides a more accurate message for the initiator who proposed the credential, in case they delete it themself.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2047)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).

### Design Review

- [X] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [X] In case PR contains changes to the UI, add some screenshots to notice the differences

#### Before
<img src="https://github.com/user-attachments/assets/4395e839-b5ff-4353-9f15-c607a43cf879" width="350px" />

#### After
<img src="https://github.com/user-attachments/assets/b5c8100b-b532-4845-a318-bfd46195f1f3" width="350px" />