### PR TITLE
fix(ui): dont re-prompt biometrics after user fallback on iOS

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1862,7 +1862,7 @@
   "biometry": {
     "reason": "Please authenticate",
     "canceltitle": "Cancel",
-    "iosfallbacktitle": "Use passcode",
+    "iosfallbacktitle": "Enter Passcode",
     "androidtitle": "Authentication",
     "androidsubtitle": "Authentication using biometrics",
     "setupbiometryheader": "Do you want to allow “Veridian” to use biometrics?",

--- a/src/ui/components/MaxLoginAttemptAlert/hooks/loginAttemptHook.ts
+++ b/src/ui/components/MaxLoginAttemptAlert/hooks/loginAttemptHook.ts
@@ -9,13 +9,13 @@ import {
 } from "../../../../store/reducers/stateCache";
 import { showError } from "../../../utils/error";
 
-const MAX_LOGIN_ATTEMP = 5;
+const MAX_LOGIN_ATTEMPT = 5;
 
 const useLoginAttempt = () => {
   const dispatch = useAppDispatch();
   const loginAttempt = useAppSelector(getLoginAttempt);
 
-  const remainAttempt = MAX_LOGIN_ATTEMP - loginAttempt.attempts;
+  const remainAttempt = MAX_LOGIN_ATTEMPT - loginAttempt.attempts;
 
   const errorMessage = useMemo(() => {
     switch (remainAttempt) {

--- a/src/ui/pages/LockPage/LockPage.tsx
+++ b/src/ui/pages/LockPage/LockPage.tsx
@@ -103,6 +103,7 @@ const LockPageContainer = () => {
       await handleBiometrics();
     }
   };
+
   const handlePinChange = async (digit: number) => {
     const updatedPasscode = `${passcode}${digit}`;
 
@@ -139,7 +140,8 @@ const LockPageContainer = () => {
       authenResult = await handleBiometricAuth();
       preventBiometricOnEvent.current =
         (authenResult instanceof BiometryError &&
-          authenResult.code === BiometryErrorType.userCancel) ||
+          (authenResult.code === BiometryErrorType.userCancel ||
+            authenResult.code === BiometryErrorType.userFallback)) ||
         authenResult === true;
     } finally {
       await enablePrivacy();


### PR DESCRIPTION
## Description

We use the `appStateChanged` handler as a way to auto prompt biometrics if both the app and phone itself got locked, and we unlock the phone to immediately try biometrics.

We need this because we don't prompt for biometrics if the app locks itself, but the phone hasn't locked overall.

So this fix handles the case where we hit the user fallback in the native prompt (`Enter Passcode`) - we were only handling the case where the user selects `Cancel`.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2056)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).
