### PR TITLE
fix(ui): reset biometrics preference when resetting onboarding passcode

### DIFF
--- a/src/store/reducers/stateCache/stateCache.ts
+++ b/src/store/reducers/stateCache/stateCache.ts
@@ -76,10 +76,8 @@ const stateCacheSlice = createSlice({
         (route) => route.path !== action.payload
       );
     },
-    removeSetPasscodeRoute: (state) => {
-      state.routes = state.routes.filter(
-        (route) => route.path !== RoutePath.SET_PASSCODE
-      );
+    resetAllRoutes: (state) => {
+      state.routes = [];
     },
     setLoginAttempt: (state, action: PayloadAction<LoginAttempts>) => {
       state.authentication.loginAttempt = { ...action.payload };
@@ -195,8 +193,8 @@ const {
   setRecoveryCompleteNoInterruption,
   setCurrentRoute,
   removeCurrentRoute,
-  removeSetPasscodeRoute,
   removeRoute,
+  resetAllRoutes,
   login,
   logout,
   setAuthentication,
@@ -284,7 +282,7 @@ export {
   logout,
   removeCurrentRoute,
   removeRoute,
-  removeSetPasscodeRoute,
+  resetAllRoutes,
   removeToastMessage,
   setAuthentication,
   setCameraDirection,

--- a/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.tsx
+++ b/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.tsx
@@ -56,7 +56,6 @@ const CreatePasscodeModule = forwardRef<
     const [originalPassCode, setOriginalPassCode] = useState("");
     const { enablePrivacy, disablePrivacy } = usePrivacyScreen();
     const { handleBiometricAuth, biometricInfo } = useBiometricAuth();
-    const isAndroidDevice = getPlatforms().includes("android");
 
     const setupBiometricsHeaderText = i18n.t("biometry.setupbiometryheader");
 

--- a/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.test.tsx
+++ b/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.test.tsx
@@ -206,16 +206,6 @@ describe("Forgot Passcode Page", () => {
     await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
-      expect(
-        queryByText(EN_TRANSLATIONS.biometry.setupbiometryheader)
-      ).toBeInTheDocument();
-    });
-
-    await act(async () => {
-      fireEvent.click(getByTestId("alert-setup-biometry-confirm-button"));
-    });
-
-    await waitFor(() => {
       expect(onCloseMock).toHaveBeenCalled();
     });
   });

--- a/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.tsx
+++ b/src/ui/components/ForgotAuthInfo/ForgotAuthInfo.tsx
@@ -122,6 +122,7 @@ const ForgotAuthInfo = ({
             }}
             onCreateSuccess={handleClose}
             overrideAlertZIndex={overrideAlertZIndex}
+            changePasscodeMode
           />
         ) : (
           <PasswordModule

--- a/src/ui/pages/CreatePassword/CreatePassword.tsx
+++ b/src/ui/pages/CreatePassword/CreatePassword.tsx
@@ -28,7 +28,7 @@ const CreatePassword = ({
   const stateCache = useAppSelector(getStateCache);
   const ionRouter = useAppIonRouter();
   const passwordModuleRef = useRef<PasswordModuleRef>(null);
-  const isOnboarding = stateCache.routes[0].path === RoutePath.CREATE_PASSWORD;
+  const isOnboarding = stateCache.routes[0]?.path === RoutePath.CREATE_PASSWORD;
 
   const handleContinue = async (skipped: boolean) => {
     if (!isOnboarding) {

--- a/src/ui/pages/LockPage/LockPage.test.tsx
+++ b/src/ui/pages/LockPage/LockPage.test.tsx
@@ -22,6 +22,7 @@ import { passcodeFiller } from "../../utils/passcodeFiller";
 import { SetPasscode } from "../SetPasscode";
 import { LockPage } from "./LockPage";
 import { KeyStoreKeys } from "../../../core/storage";
+import { MiscRecordId } from "../../../core/agent/agent.types";
 
 const deleteSecureStorageMock = jest.fn();
 jest.mock("../../../core/storage", () => ({
@@ -281,8 +282,14 @@ describe("Lock Page", () => {
     fireEvent.click(getByText(EN_TRANSLATIONS.lockpage.forgotten.button));
 
     await waitFor(() => {
-      expect(deleteById).toBeCalled();
-      expect(deleteSecureStorageMock).toBeCalled();
+      expect(deleteSecureStorageMock).toBeCalledWith(KeyStoreKeys.APP_PASSCODE);
+      expect(deleteSecureStorageMock).toBeCalledWith(
+        KeyStoreKeys.APP_OP_PASSWORD
+      );
+      expect(deleteById).toBeCalledWith(MiscRecordId.OP_PASS_HINT);
+      expect(deleteById).toBeCalledWith(MiscRecordId.APP_PASSWORD_SKIPPED);
+      expect(deleteById).toBeCalledWith(MiscRecordId.APP_ALREADY_INIT);
+      expect(deleteById).toBeCalledWith(MiscRecordId.APP_BIOMETRY);
     });
   });
 

--- a/src/ui/pages/LockPage/LockPage.tsx
+++ b/src/ui/pages/LockPage/LockPage.tsx
@@ -14,7 +14,10 @@ import { KeyStoreKeys, SecureStorage } from "../../../core/storage";
 import { i18n } from "../../../i18n";
 import { PublicRoutes, RoutePath } from "../../../routes/paths";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
-import { getBiometricsCacheCache } from "../../../store/reducers/biometricsCache";
+import {
+  getBiometricsCacheCache,
+  setEnableBiometricsCache,
+} from "../../../store/reducers/biometricsCache";
 import {
   getAuthentication,
   getCurrentRoute,
@@ -206,9 +209,8 @@ const LockPageContainer = () => {
         Agent.agent.basicStorage.deleteById(MiscRecordId.OP_PASS_HINT),
         Agent.agent.basicStorage.deleteById(MiscRecordId.APP_PASSWORD_SKIPPED),
         Agent.agent.basicStorage.deleteById(MiscRecordId.APP_ALREADY_INIT),
+        Agent.agent.basicStorage.deleteById(MiscRecordId.APP_BIOMETRY),
       ]);
-
-      router.push(RoutePath.ROOT);
 
       dispatch(
         setAuthentication({
@@ -219,6 +221,9 @@ const LockPageContainer = () => {
           loggedIn: true,
         })
       );
+      dispatch(setEnableBiometricsCache(false));
+
+      router.push(RoutePath.ROOT);
     } catch (e) {
       showError("Failed to clear app: ", e, dispatch);
     }

--- a/src/ui/pages/LockPage/LockPage.tsx
+++ b/src/ui/pages/LockPage/LockPage.tsx
@@ -23,6 +23,7 @@ import {
   getCurrentRoute,
   getFirstAppLaunch,
   login,
+  resetAllRoutes,
   setAuthentication,
   setFirstAppLaunchComplete,
 } from "../../../store/reducers/stateCache";
@@ -218,9 +219,10 @@ const LockPageContainer = () => {
           passcodeIsSet: false,
           passwordIsSet: false,
           passwordIsSkipped: false,
-          loggedIn: true,
+          loggedIn: false,
         })
       );
+      dispatch(resetAllRoutes());
       dispatch(setEnableBiometricsCache(false));
 
       router.push(RoutePath.ROOT);


### PR DESCRIPTION
## Description

During the onboarding, after setting the pincode and biometrics, if we re-launch the app we land on the lock page.
If we click `I've forgotten my passcode`, it gets reset.

At this point:
1. If you relaunch the app, you'll get a biometrics prompt on the welcome screen that does nothing.
2. When setting the new passcode, you will be prompted to set it up again, even though it's already set.
  a. If you cancel the setup, you'll get a prompt saying you can set it up later, despite already being set. 

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2061)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).