### PR TITLE
fix(ui): show input field errors after scanning

### DIFF
--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -265,11 +265,13 @@ const CreateSSIAgent = () => {
   const scanBootUrl = (event: ReactMouseEvent<HTMLElement, MouseEvent>) => {
     event.stopPropagation();
     dispatch(setCurrentOperation(OperationType.SCAN_SSI_BOOT_URL));
+    setTouchedBootUrlInput();
   };
 
   const scanConnectUrl = (event: ReactMouseEvent<HTMLElement, MouseEvent>) => {
     event.stopPropagation();
     dispatch(setCurrentOperation(OperationType.SCAN_SSI_CONNECT_URL));
+    setTouchedConnectUrlInput();
   };
 
   const removeLastSlash = (url: string) => {


### PR DESCRIPTION
## Description

We don't show the invalid URL error until the user had touched the input fields so they wouldn’t appear with errors on initial launch before doing anything.

But they could scan a QR code instead of using the input field, and this is probably more likely on mobile.

I’ve set it now that the error will show when you touch the input field OR you open the scanner for that field.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2058)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).