### PR TITLE
fix: set accessibility in SecureStorage

### DIFF
--- a/src/core/storage/secureStorage/secureStorage.ts
+++ b/src/core/storage/secureStorage/secureStorage.ts
@@ -28,7 +28,11 @@ class SecureStorage {
   }
 
   static async set(key: string, value: string): Promise<void> {
-    await SecureStoragePlugin.set({ key, value });
+    await SecureStoragePlugin.set({
+      key,
+      value,
+      accessibility: "whenUnlockedThisDeviceOnly",
+    });
   }
 
   static async delete(key: string) {


### PR DESCRIPTION
## Description

Currently we have the flag `afterFirstUnlockThisDeviceOnly` to handle when the keychain can accesible. We change to `whenUnlockedThisDeviceOnly ` so Keychain item can be accessed just when the phone is unlocked.


#### Accessibility Flags in Keychain Swift library

**afterFirstUnlockThisDeviceOnly:** The data in the Keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
**whenUnlockedThisDeviceOnly:** The data in the Keychain can only be accessed when the device is unlocked. Only available if a passcode is set on the device.
Source: [library code](https://github.dev/auth0/SimpleKeychain/blob/8137acba43bb92f3212c7b7d229aa7b336c5adb2/SimpleKeychain/Accessibility.swift#L4)

Keychain and data protection:
https://support.apple.com/guide/security/keychain-data-protection-secb0694df1a/web
