### PR TITLE
fix(ui): only show biometrics setting if strong biometrics available

### DIFF
--- a/src/ui/pages/Menu/components/Settings/Settings.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.test.tsx
@@ -276,7 +276,7 @@ describe("Settings page", () => {
     });
   });
 
-  test("Open setting page when biometrics not enroll", async () => {
+  test("Open setting page when biometrics not available", async () => {
     const mockStore = configureStore();
     const dispatchMock = jest.fn();
     const initialState = {
@@ -316,41 +316,17 @@ describe("Settings page", () => {
       };
     });
 
-    const { getByText, getByTestId } = render(
+    const { queryByText } = render(
       <Provider store={storeMocked}>
         <Settings />
       </Provider>
     );
 
     expect(
-      getByText(
+      queryByText(
         EN_TRANSLATIONS.tabs.menu.tab.settings.sections.security.biometry
       )
-    ).toBeInTheDocument();
-
-    act(() => {
-      fireEvent.click(getByTestId("settings-item-0"));
-    });
-
-    await waitFor(() => {
-      expect(
-        getByText(
-          EN_TRANSLATIONS.tabs.menu.tab.settings.sections.security
-            .biometricsalert.message
-        )
-      );
-    });
-
-    fireEvent.click(
-      getByText(
-        EN_TRANSLATIONS.tabs.menu.tab.settings.sections.security.biometricsalert
-          .ok
-      )
-    );
-
-    await waitFor(() => {
-      expect(openSettingMock).toBeCalledTimes(1);
-    });
+    ).not.toBeInTheDocument();
   });
 
   test("Open documentation link", async () => {

--- a/src/ui/pages/Menu/components/Settings/Settings.tsx
+++ b/src/ui/pages/Menu/components/Settings/Settings.tsx
@@ -86,7 +86,11 @@ const Settings = ({ switchView, handleClose }: SettingsProps) => {
     },
   ];
 
-  if (biometricsCache.enabled !== undefined) {
+  if (
+    biometricsCache.enabled !== undefined &&
+    biometricInfo?.strongBiometryIsAvailable &&
+    biometricInfo?.isAvailable
+  ) {
     securityItems.unshift({
       index: OptionIndex.BiometricUpdate,
       icon: fingerPrintOutline,


### PR DESCRIPTION
## Description

We only allow "strong" biometrics, as determined by the OS for safety reasons. We already handle this on onboarding, and the lockpage, where we only show biometric options if strong biometrics are available.

However, we never correctly blocked the setting in the settings menu.

After this PR, the setting won't appear in dev mode (browser), emulators, or device's with weak or no biometrics. So this PR requires a real device to verify there's no regression.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2066)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).