### PR TITLE
fix(ui): remove trailing slash when scan and boot url

### DIFF
--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.tsx
@@ -208,9 +208,13 @@ const CreateSSIAgent = () => {
         throw new Error(SEED_PHRASE_EMPTY);
       }
 
+      const connectUrl = removeLastSlash(ssiAgent.connectUrl.trim());
+
+      dispatch(setConnectUrl(connectUrl));
+
       await Agent.agent.recoverKeriaAgent(
         seedPhraseCache.seedPhrase.split(" "),
-        ssiAgent.connectUrl
+        connectUrl
       );
 
       dispatch(setRecoveryCompleteNoInterruption());
@@ -258,9 +262,15 @@ const CreateSSIAgent = () => {
         throw new Error(SSI_URLS_EMPTY);
       }
 
+      const bootUrl = removeLastSlash(ssiAgent.bootUrl.trim());
+      const connectUrl = removeLastSlash(ssiAgent.connectUrl.trim());
+
+      dispatch(setBootUrl(bootUrl));
+      dispatch(setConnectUrl(connectUrl));
+
       await Agent.agent.bootAndConnect({
-        bootUrl: ssiAgent.bootUrl,
-        url: ssiAgent.connectUrl,
+        bootUrl: bootUrl,
+        url: connectUrl,
       });
 
       await updateFirstInstallValue(true);


### PR DESCRIPTION
## Description

Remove trailing slash after scan boot and connect ur

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/issues/DTIS-2192)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Android

https://github.com/user-attachments/assets/0d313094-c3b9-406b-a470-c2e7939b5bc4


