### PR TITLE
chore: new keria with no setuptools

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -15,7 +15,7 @@ ARG --global PUSH=false
 ARG --global KERIA_DOCKER_IMAGE_REPO=weboftrust/keria
 ARG --global KERIA_DOCKER_IMAGE_TAG=0.2.0-rc1
 ARG --global KERIA_GIT_REPO_URL="https://github.com/cardano-foundation/keria.git"
-ARG --global KERIA_GIT_REF="fbc61f360667d295cf067640062f0cc91fc81e3d"
+ARG --global KERIA_GIT_REF="c00de7a92c75d5ca62a5743bd71aafba37bdd4c3"
 
 ARG --global KERI_DOCKER_IMAGE_REPO=weboftrust/keri
 ARG --global KERI_DOCKER_IMAGE_TAG=1.1.26


### PR DESCRIPTION
Agreed with kent that setuptools isn't necessarily. So removing as it keeps breaking our build.