### PR TITLE
Feature/vt20 1911 delete related connections when deleting an account identifier

### DIFF
--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -359,8 +359,13 @@ class IdentifierService extends AgentService {
     const metadata = await this.identifierStorage.getIdentifierMetadata(
       identifier
     );
+    if (!metadata) {
+      return;
+    }
     if (metadata.groupMetadata) {
       await this.deleteGroupLinkedConnections(metadata.groupMetadata.groupId);
+    } else {
+      await this.connections.deleteAllConnectionsForIdentifier(identifier);
     }
 
     if (metadata.groupMemberPre) {


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

Currently when we delete an identifier, all related notifications are deleted because this was leading to a lot of bad edge cases. The related connections are persisted, but in the new account based flow we will no longer be able to access them, so we may as well delete them.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [VT20-1911](https://cardanofoundation.atlassian.net/jira/software/c/projects/VT20/boards/116?assignee=631ed01829083bbe8cc2e570&selectedIssue=VT20-1911)

### Testing & Validation

- [ ] This PR has been tested/validated in iOS, Android and browser.
- [ ] Added new unit tests, if relevant.

### Design Review

- [ ] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.



[VT20-1911]: https://cardanofoundation.atlassian.net/browse/VT20-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ