### PR TITLE
fix(ui): Cant add contact if already exists in another profile

### DIFF
--- a/src/ui/components/Scan/hook/useScanHandle.ts
+++ b/src/ui/components/Scan/hook/useScanHandle.ts
@@ -114,19 +114,10 @@ const useScanHandle = () => {
           .pop()
           ?.split("/")[0];
 
-        // Detect duplicates locally first (current profile, any profile or
-        // legacy-root map) so the UI can open the existing connection without
-        // invoking the Agent when tests/fixtures already supply the data.
-        const existsInAnyProfile = Object.values(allProfiles || {}).some(
-          (p) =>
-            Array.isArray(p.connections) &&
-            p.connections.some((c) => c.id === connectionId)
-        );
-
+        // Detect duplicates locally first (current profile only)
+        // so the UI can open the existing connection without invoking the Agent
         const existsLocally =
-          !!connectionId &&
-          (connections.some((c) => c.id === connectionId) ||
-            existsInAnyProfile);
+          !!connectionId && connections.some((c) => c.id === connectionId);
 
         if (existsLocally) {
           // Duplicate detected: surface it to the UI the same way the Agent would.


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

The bug was in the duplicate detection logic in `useScanHandle.ts`. The code was checking for connections across all profiles instead of just the current profile. This prevented Profile 1 from adding a connection that already existed in Profile 2.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**VT20-2168**](https://cardanofoundation.atlassian.net/browse/VT20-2168)

### Testing & Validation

- [ ] This PR has been tested/validated in iOS, Android and browser.
- [ ] Added new unit tests, if relevant.

### Design Review

- [x] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.


https://github.com/user-attachments/assets/6c95b53b-10f8-440b-a07e-591b510d0551

