### PR TITLE
fix(ui): Accept credential animation not vertically centered

### DIFF
--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -215,8 +215,7 @@ const ReceiveCredential = ({
 
     const combinedHeight = 28.5 + iconRow.getBoundingClientRect().height;
     const headerHeight = (header as HTMLDivElement).offsetHeight;
-    const currentViewportHeight =
-      window.visualViewport?.height ?? window.innerHeight;
+    const currentViewportHeight = window.innerHeight;
 
     const opticalCenter = currentViewportHeight * 0.5;
 

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -1,6 +1,4 @@
-import { Capacitor } from "@capacitor/core";
 import { IonButton, IonCol, IonIcon } from "@ionic/react";
-import { SafeArea } from "capacitor-plugin-safe-area";
 import {
   alertCircleOutline,
   checkmark,
@@ -9,7 +7,7 @@ import {
   personCircleOutline,
   swapHorizontalOutline,
 } from "ionicons/icons";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Agent } from "../../../../../core/agent/agent";
 import {
   ACDCDetails,
@@ -86,22 +84,6 @@ const ReceiveCredential = ({
   const isMultisig = credDetail?.identifierType === IdentifierType.Group;
   const [isRevoked, setIsRevoked] = useState(false);
   const [openIdentifierDetail, setOpenIdentifierDetail] = useState(false);
-  const [viewportHeight, setViewportHeight] = useState(
-    window.visualViewport?.height || window.innerHeight
-  );
-
-  useEffect(() => {
-    if (Capacitor.isNativePlatform() && Capacitor.getPlatform() === "android") {
-      SafeArea.getSafeAreaInsets().then((insets) => {
-        setViewportHeight(
-          (window.visualViewport?.height || window.innerHeight) -
-            insets.insets.bottom -
-            insets.insets.top
-        );
-      });
-    }
-  }, []);
-
   const connection = connectionsCache?.find(
     (c) => c.id === notificationDetails.connectionId
   )?.label;
@@ -233,8 +215,10 @@ const ReceiveCredential = ({
 
     const combinedHeight = 28.5 + iconRow.getBoundingClientRect().height;
     const headerHeight = (header as HTMLDivElement).offsetHeight;
+    const currentViewportHeight =
+      window.visualViewport?.height ?? window.innerHeight;
 
-    const opticalCenter = viewportHeight * 0.5;
+    const opticalCenter = currentViewportHeight * 0.5;
 
     const translateY = opticalCenter - headerHeight - combinedHeight / 2;
 

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -1,4 +1,6 @@
+import { Capacitor } from "@capacitor/core";
 import { IonButton, IonCol, IonIcon } from "@ionic/react";
+import { SafeArea } from "capacitor-plugin-safe-area";
 import {
   alertCircleOutline,
   checkmark,
@@ -7,7 +9,7 @@ import {
   personCircleOutline,
   swapHorizontalOutline,
 } from "ionicons/icons";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Agent } from "../../../../../core/agent/agent";
 import {
   ACDCDetails,
@@ -50,8 +52,6 @@ import { NotificationDetailsProps } from "../../NotificationDetails.types";
 import "./ReceiveCredential.scss";
 
 const ANIMATION_DELAY = 2600;
-// Cache viewport height on initial load to prevent issues with mobile browsers resizing the viewport when showing/hiding the keyboard, which can cause unwanted jumps in the animation.
-const INITIAL_VIEWPORT_HEIGHT = window.innerHeight;
 
 const ReceiveCredential = ({
   pageId,
@@ -86,6 +86,21 @@ const ReceiveCredential = ({
   const isMultisig = credDetail?.identifierType === IdentifierType.Group;
   const [isRevoked, setIsRevoked] = useState(false);
   const [openIdentifierDetail, setOpenIdentifierDetail] = useState(false);
+  const [viewportHeight, setViewportHeight] = useState(
+    window.visualViewport?.height || window.innerHeight
+  );
+
+  useEffect(() => {
+    if (Capacitor.isNativePlatform() && Capacitor.getPlatform() === "android") {
+      SafeArea.getSafeAreaInsets().then((insets) => {
+        setViewportHeight(
+          (window.visualViewport?.height || window.innerHeight) -
+            insets.insets.bottom -
+            insets.insets.top
+        );
+      });
+    }
+  }, []);
 
   const connection = connectionsCache?.find(
     (c) => c.id === notificationDetails.connectionId
@@ -218,7 +233,6 @@ const ReceiveCredential = ({
 
     const combinedHeight = 28.5 + iconRow.getBoundingClientRect().height;
     const headerHeight = (header as HTMLDivElement).offsetHeight;
-    const viewportHeight = INITIAL_VIEWPORT_HEIGHT;
 
     const opticalCenter = viewportHeight * 0.5;
 


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

This update uses safe-area insets to derive a more accurate usable viewport height, ensuring the animation starts from the correct position across devices.

Key changes:
- Replace reliance on window.innerHeight with safe-area–adjusted viewport height
- Recalculate slide-down offset based on actual usable screen space
- Improve consistency of vertical centering and animation behavior on Android

This approach reduces layout discrepancies caused by device-specific UI elements (e.g. system bars, gesture areas) and ensures smoother, more predictable animations.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**VT20-2671**](https://cardanofoundation.atlassian.net/browse/VT20-2671)

### Testing & Validation

- [x] This PR has been tested/validated in iOS, Android and browser.
- [x] Added new unit tests, if relevant.

### Design Review

- [x] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.

### IOS

https://github.com/user-attachments/assets/aa8b0c9d-b552-46de-801a-109358dc3946

### Android

https://github.com/user-attachments/assets/f133f431-02f3-4b40-a39b-17da040648de

