### PR TITLE
fix: remove background from connectdapp scan

### DIFF
--- a/src/ui/components/ConnectdApp/ConnectdApp.scss
+++ b/src/ui/components/ConnectdApp/ConnectdApp.scss
@@ -14,7 +14,7 @@ body.scan-active {
       --background: transparent;
     }
 
-    .connect-dapp-scan.scrollable-page-layout {
+    .connect-dapp-scan {
       background: transparent;
     }
   }
@@ -40,7 +40,7 @@ body.scan-active {
 
   &.connect-dapp-scan {
     padding: 0;
-    background: transparent;
+    background: var(--ion-color-neutral-700);
 
     .scrollable-page-content {
       position: static;

--- a/src/ui/components/ConnectdApp/ConnectdApp.scss
+++ b/src/ui/components/ConnectdApp/ConnectdApp.scss
@@ -39,8 +39,8 @@ body.scan-active {
   }
 
   &.connect-dapp-scan {
-    background: var(--ion-color-neutral-700);
     padding: 0;
+    background: transparent;
 
     .scrollable-page-content {
       position: static;


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

When the user tries to scan something in order to use the Cardano connect feature, the scanning page doesn’t show the live stream from the camera and instead we see a gray background. 

It seems we added this background in [this PR](https://github.com/cardano-foundation/veridian-wallet/issues/1418) and looking at those videos in the PR the scan was working fine, not sure why we added that background as it seems unnecessary to me.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**VT20-2740**](https://cardanofoundation.atlassian.net/browse/VT20-2740)

### Testing & Validation

- [x] This PR has been tested/validated in iOS, Android and browser.
- [ ] Added new unit tests, if relevant.

### Design Review

- [x] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.


https://github.com/user-attachments/assets/ba1e4d3c-f28e-4949-b3c6-a56c75a68c96

