### PR TITLE
fix(ui): Blank verify screen and ProfileStateModal profile check

### DIFF
--- a/src/ui/components/ProfileStateModal/ProfileStateModal.test.tsx
+++ b/src/ui/components/ProfileStateModal/ProfileStateModal.test.tsx
@@ -31,6 +31,60 @@ jest.mock("../../../core/agent/agent", () => ({
 }));
 
 describe("ProfileStateModal - Show profile error states", () => {
+  test("Does not show profile state modal when verify seed phrase alert is active", async () => {
+    const initialStatePendingWithSeedPhraseAlert = {
+      stateCache: {
+        routes: [TabsRoutePath.CREDENTIALS],
+        authentication: {
+          loggedIn: true,
+          time: Date.now(),
+          passcodeIsSet: true,
+        },
+        isOnline: true,
+        showVerifySeedPhraseAlert: true,
+      },
+      seedPhraseCache: {},
+      profilesCache: {
+        ...profileCacheFixData,
+        defaultProfile: filteredIdentifierFix[2].id,
+      },
+      viewTypeCache: {
+        identifier: {
+          viewType: null,
+          favouriteIndex: 0,
+        },
+        credential: {
+          viewType: null,
+          favouriteIndex: 0,
+        },
+      },
+      biometricsCache: {
+        enabled: false,
+      },
+    };
+
+    const storeMocked = {
+      ...makeTestStore(initialStatePendingWithSeedPhraseAlert),
+    };
+
+    const history = createMemoryHistory();
+    history.push(TabsRoutePath.CREDENTIALS);
+
+    const { queryByText } = render(
+      <IonReactMemoryRouter history={history}>
+        <Provider store={storeMocked}>
+          <ProfileStateModal />
+        </Provider>
+      </IonReactMemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(
+        queryByText(EN_TRANSLATIONS.profiledetails.loadprofileerror.pending)
+      ).toBeNull();
+    });
+  });
+
   test("Show pending profile issue", async () => {
     const initialStatePendingEmpty = {
       stateCache: {

--- a/src/ui/components/ProfileStateModal/ProfileStateModal.tsx
+++ b/src/ui/components/ProfileStateModal/ProfileStateModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../../store/reducers/profileCache";
 import {
   getIsSyncingData,
+  getShowVerifySeedPhraseAlert,
   setSyncingData,
   setToastMsg,
 } from "../../../store/reducers/stateCache";
@@ -50,6 +51,9 @@ const ProfileStateModal = () => {
   const [isOpenProfiles, setOpenProfiles] = useState(false);
   const isOpen = useAppSelector(getShowProfileState);
   const isSyncing = useAppSelector(getIsSyncingData);
+  const showVerifySeedPhraseAlert = useAppSelector(
+    getShowVerifySeedPhraseAlert
+  );
   const history = useHistory();
   const checkedProfile = useRef<{
     id: string;
@@ -100,6 +104,12 @@ const ProfileStateModal = () => {
   ]);
 
   const checkProfileState = useCallback(() => {
+    // Avoid competing overlay modals during mandatory seed-phrase verification flow.
+    if (showVerifySeedPhraseAlert) {
+      setIsOpen(false);
+      return;
+    }
+
     const isProfileChecked =
       checkedProfile.current.id === currentProfile?.identity.id &&
       checkedProfile.current.status === currentProfile?.identity.creationStatus;
@@ -169,6 +179,7 @@ const ProfileStateModal = () => {
     setIsOpen,
     history.location.pathname,
     isSyncing,
+    showVerifySeedPhraseAlert,
     dispatch,
   ]);
 

--- a/src/ui/components/Settings/components/RecoverySeedPhrase/RecoverySeedPhrase.tsx
+++ b/src/ui/components/Settings/components/RecoverySeedPhrase/RecoverySeedPhrase.tsx
@@ -72,6 +72,7 @@ const RecoverySeedPhrase = ({
     <>
       <ScrollablePageLayout
         pageId="settings"
+        activeStatus={isEdit}
         header={
           <PageHeader
             title={title}


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

This PR is a fix for the blank screen when verifying the seed phrase after running out of time and creating too many profiles.

While working on this I also noticed another bug which happens when you launch the app, enter the passcode and just stay on the Verify Seed Phrase Alert for a few seconds. I found that `ProfileStateModal` performs an async profile check and opens the spinner modal shortly after mount.

I added a guard so `ProfileStateModal` does not open while seed-phrase verification alert flow is active.

Check ticket for video where you see both bugs. The one caused by `ProfileStateModal` is at the end of 0:11, before 0:12.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**VT20-2742**](https://cardanofoundation.atlassian.net/browse/VT20-2742)

### Testing & Validation

- [x] This PR has been tested/validated in iOS, Android and browser.
- [x] Added new unit tests, if relevant.

### Design Review

- [x] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.

### iOS

https://github.com/user-attachments/assets/8f9ce95e-6693-4669-a732-26cb724eed42



### Android

https://github.com/user-attachments/assets/ced12182-a4d8-40e1-bec2-ee320d6f2dff

