### PR TITLE
fix: consult inline schema oobi for apply notifications

### DIFF
--- a/src/core/agent/services/ipexCommunicationService.ts
+++ b/src/core/agent/services/ipexCommunicationService.ts
@@ -554,7 +554,8 @@ class IpexCommunicationService extends AgentService {
     }
 
     const schemaUrlBase =
-      message.exn.r === ExchangeRoute.IpexGrant
+      message.exn.r === ExchangeRoute.IpexGrant ||
+      message.exn.r === ExchangeRoute.IpexApply
         ? this.getInlineSchemaOobiBase(message) ??
           (await this.getSchemaUrl(
             connection.serviceEndpoints[0],


### PR DESCRIPTION
## Summary                                                                                                                                                           
  `createLinkedIpexMessageRecord` now consults `getInlineSchemaOobiBase`
  for `IpexApply` as well as `IpexGrant`.
                                                                                                                                                                       
  ## Bug
  Processing `/exn/ipex/apply` throws when the issuer's contact has no                                                                                                 
  resolved service endpoint:                                                                                                                                           
   
  ```
  TypeError: Cannot read properties of undefined (reading 'split')                                                                                                     
      at IpexCommunicationService.getSchemaUrl              
      at IpexCommunicationService.createLinkedIpexMessageRecord                                                                                                        
      at KeriaNotificationService.processExnIpexApplyNotification
   ```                                                                                                                                                            
  The grant branch avoids this by checking `exn.a.oobiUrl` first; the
  apply branch went straight to `getSchemaUrl(serviceEndpoints[0], …)`.                                                                                                
                                                                                                                                                                       
  ## Fix
  Extend the inline-OOBI-first ternary branch to also match                                                                                                            
  `ExchangeRoute.IpexApply`. Fallback to the existing `/indexer/<aid>`                                                                                                 
  lookup is preserved when no inline OOBI is present.