### PR TITLE
docs(readme): remove changelog.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Thank you for contributing!
 ## Additional Documents
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security](SECURITY.md)
-- [Changelog](CHANGELOG.md)
 
 
 # Troubleshooting


### PR DESCRIPTION
## Description

Removed link in the README.md file pointing to a CHANGELOG.md file that never existed.